### PR TITLE
Maw and Jaw can only fire at targets outside of caves

### DIFF
--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -350,7 +350,7 @@
 	var/turf/clicked_turf = locate(polled_coords[1], polled_coords[2], z)
 	var/area/clicked_area = clicked_turf.loc
 	if(clicked_area.ceiling >= CEILING_UNDERGROUND)
-		balloon_alert(xeno_shooter, "underground!")
+		balloon_alert(xeno_shooter, "Underground!")
 		return FALSE
 	addtimer(CALLBACK(src, PROC_REF(maw_impact_start), ammo, clicked_turf, xeno_shooter), ammo.impact_time-2 SECONDS)
 	notify_ghosts("<b>[xeno_shooter]</b> has just fired \the <b>[src]</b> !", source = clicked_turf, action = NOTIFY_JUMP)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin, mainly applies to jaw since maw is ded.
## Why It's Good For The Game
Jaw already has to be PLACED outside of caves, and shooting into caves where xenos are already at their strongest is a bit too much, especially in the sovl era where marines get quite stretched by the time they have to fight in caves any way.
## Changelog
:cl:
balance: Jaws (and maw) cannot fire into caves
/:cl:
