### PR TITLE
Hivelord's Healing Infusion Round Statistic

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -445,6 +445,10 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 		parts += "[GLOB.round_statistics.drone_essence_link] health points restored through Drone's Essence Link."
 	if(GLOB.round_statistics.drone_essence_link_sunder)
 		parts += "[GLOB.round_statistics.drone_essence_link_sunder] sunder removed through Drone's Essence Link."
+	if(GLOB.round_statistics.hivelord_healing_infusion)
+		parts += "[GLOB.round_statistics.hivelord_healing_infusion] health points restored through Hivelord's Healing Infusion."
+	if(GLOB.round_statistics.hivelord_healing_infusion_sunder)
+		parts += "[GLOB.round_statistics.hivelord_healing_infusion_sunder] sunder removed through Hivelord's Healing Infusion."
 	if(GLOB.round_statistics.sentinel_drain_stings)
 		parts += "[GLOB.round_statistics.sentinel_drain_stings] number of times Sentinel drain sting was used."
 	if(GLOB.round_statistics.defender_charge_victims)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -108,6 +108,10 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/drone_essence_link = 0
 	/// The amount of sunder removed via Essence Link status effect and Salve Regen status effect.
 	var/drone_essence_link_sunder = 0
+	/// The amount of health points restored via Healing Infusion status effect.
+	var/hivelord_healing_infusion = 0
+	/// The amount of sunder removed via Healing Infusion status effect.
+	var/hivelord_healing_infusion_sunder = 0
 	var/warrior_flings = 0
 	var/warrior_punches = 0
 	var/warrior_lunges = 0

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -741,19 +741,9 @@
 	if(patient.recovery_aura)
 		total_heal_amount *= (1 + patient.recovery_aura * 0.05) //Recovery aura multiplier; 5% bonus per full level
 
-	//Healing pool has been calculated; now to decrement it
-	var/brute_amount = min(patient.bruteloss, total_heal_amount)
-	if(brute_amount)
-		patient.adjustBruteLoss(-brute_amount, updating_health = TRUE)
-		total_heal_amount = max(0, total_heal_amount - brute_amount) //Decrement from our heal pool the amount of brute healed
-
-	if(!total_heal_amount) //no healing left, no need to continue
-		return
-
-	var/burn_amount = min(patient.fireloss, total_heal_amount)
-	if(burn_amount)
-		patient.adjustFireLoss(-burn_amount, updating_health = TRUE)
-
+	var/leftover_healing = total_heal_amount
+	HEAL_XENO_DAMAGE(patient, leftover_healing, FALSE)
+	GLOB.round_statistics.hivelord_healing_infusion += (total_heal_amount - leftover_healing)
 
 ///Called when the target xeno regains Sunder via heal_wounds in life.dm
 /datum/status_effect/healing_infusion/proc/healing_infusion_sunder_regeneration(mob/living/carbon/xenomorph/patient, seconds_per_tick)
@@ -770,7 +760,8 @@
 
 	new /obj/effect/temp_visual/telekinesis(get_turf(patient)) //Visual confirmation
 
-	patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD) //5% bonus per rank of our recovery aura
+	var/restored_sunder = patient.adjust_sunder(-1.5 * (1 + patient.recovery_aura * 0.05) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD) //5% bonus per rank of our recovery aura
+	GLOB.round_statistics.hivelord_healing_infusion_sunder += -restored_sunder
 
 /atom/movable/screen/alert/status_effect/healing_infusion
 	name = "Healing Infusion"


### PR DESCRIPTION

## About The Pull Request
The amount of health and sunder restored via Hivelord's Healing Infusion is now recorded in the round statistics.
<img width="476" height="214" alt="image" src="https://github.com/user-attachments/assets/a4226c3f-7988-4731-b252-df5d11e70fe0" />

## Why It's Good For The Game
More information is nice. I'd would like to see how impactful Hivelord's Healing Infusion is.

## Changelog
:cl:
add: The amount of health and sunder restored via Hivelord's Healing Infusion is now recorded in the round statistics.
/:cl:
