### PR TITLE
Fixes booleans showing up in PatientChemicals

### DIFF
--- a/tgui/packages/tgui/interfaces/MedScanner/PatientChemicals.tsx
+++ b/tgui/packages/tgui/interfaces/MedScanner/PatientChemicals.tsx
@@ -149,8 +149,9 @@ export function PatientChemicals() {
                         ? 'Harmful chemical. Purge immediately.'
                         : `Purge below ${chemical.od_threshold}u to stabilize.
                         ${
-                          !!(chemical.amount > chemical.crit_od_threshold) &&
-                          `This is a critical OD. Its effects are worse than normal. `
+                          chemical.amount > chemical.crit_od_threshold
+                            ? `This is a critical OD. Its effects are worse than normal. `
+                            : ``
                         }${Math.trunc(
                           (chemical.amount - chemical.od_threshold) /
                             chemical.metabolism_factor,
@@ -165,7 +166,7 @@ export function PatientChemicals() {
                       ml={SPACING_PIXELS}
                     >
                       {chemical.od
-                        ? `OD${!!(chemical.amount > chemical.crit_od_threshold) && ', CRIT'}`
+                        ? `OD${chemical.amount > chemical.crit_od_threshold ? ', CRIT' : ''}`
                         : 'HARMFUL'}
                     </MedBoxedTag>
                   </Tooltip>


### PR DESCRIPTION

## About The Pull Request
The OD tag showed up as **ODfalse** if a chemical wasn't critically ODing.

Double negations are being strange as fuck here, so let's just do a ternary with an empty string as the false outcome.
## Why It's Good For The Game
This is bad.
<img width="315" height="70" alt="image" src="https://github.com/user-attachments/assets/ad5b5409-ceca-4e37-8946-482cd82a02f1" />
## Changelog
:cl:
fix: Health scans will not show "ODfalse" if a chemical is ODing but not critically ODing.
/:cl:
