### PR TITLE
Changes a respawn error message to something clearer

### DIFF
--- a/code/datums/actions/observer_action.dm
+++ b/code/datums/actions/observer_action.dm
@@ -89,7 +89,7 @@
 		return
 
 	if((!(owner.client?.prefs?.be_special & BE_SSD_RANDOM_NAME)) && (CONFIG_GET(flag/prevent_dupe_names) && GLOB.real_names_joined.Find(owner.client.prefs.real_name)))
-		to_chat(usr, span_warning("Someone has already joined the round with this character name. Please pick another."))
+		to_chat(usr, span_warning("Someone has already joined the round with this character name. Go to 'Game Preferences' under the Preferences tab, and change your character/name."))
 		return
 
 	message_admins(span_adminnotice("[owner.key] took control of [new_mob.name] as [new_mob.p_they()] was ssd."))


### PR DESCRIPTION
## About The Pull Request

Changes the error message "Someone has already joined the round with this character name. Please pick another." to "Someone has already joined the round with this character name. Go to 'Game Preferences' under the Preferences tab, and change your character/name." when you try to take an SSD mob without changing your name.

## Why It's Good For The Game

<img width="563" height="198" alt="image" src="https://github.com/user-attachments/assets/61112b29-6855-45be-948b-64354c56194e" />

## Changelog
:cl: Joe13413
fix: Clarified an error message that pops up when you try to take an SSD mob.
/:cl:
