### PR TITLE
Field utility pouch inventory menu on left click (instead of quickdraw)

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -792,7 +792,6 @@
 	storage_datum.storage_slots = 5
 	storage_datum.max_w_class = WEIGHT_CLASS_NORMAL
 	storage_datum.sprite_slots = 4
-	storage_datum.draw_mode = TRUE
 	storage_datum.set_holdable(can_hold_list = list(
 		/obj/item/attachable/motiondetector,
 		/obj/item/radio,


### PR DESCRIPTION

## About The Pull Request
This PR removes the draw_mode = TRUE property from the field utility pouch, meaning clicking it opens the storage UI instead of drawing the rightmost item.
## Why It's Good For The Game
The field utility pouch, a multi-slot pouch designed to hold a varied amount of items, quickdraws on click like a pistol pouch or boot knife unless you use the Switch Storage Drawing verb.

I don't really know why it does this, and the only other person I could find that uses this pouch (Marcelline) says she clicks it with her gun to get around the quickdraw. Huh.
## Changelog
:cl:
qol: Field utility pouch now opens its inventory on left click instead of drawing the rightmost item.
/:cl:
