### PR TITLE
No more huggers in Zombie Crash

### DIFF
--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_EMPTY(map_items)
 GLOBAL_LIST_EMPTY(fog_blocker_locations)		//list of turfs marked by /obj/effect/landmark/lv624/fog_blocker
 GLOBAL_LIST_EMPTY(xeno_spawn_protection_locations)
 GLOBAL_LIST_EMPTY(fog_blockers)
+GLOBAL_LIST_EMPTY(tank_hugger_structures)		// List of all [/obj/structure/xenoautopsy/tank/hugger] to be qdel'd during [/datum/game_mode/infestation/crash/zombie/post_setup()].
 
 GLOBAL_LIST_EMPTY(huntergames_primary_spawns)
 GLOBAL_LIST_EMPTY(huntergames_secondary_spawns)

--- a/code/datums/gamemodes/zombie_crash.dm
+++ b/code/datums/gamemodes/zombie_crash.dm
@@ -40,6 +40,8 @@
 	. = ..()
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_zombie()
+	for(var/obj/structure/xenoautopsy/tank/hugger/tank_with_hugger AS in GLOB.tank_hugger_structures)
+		qdel(tank_with_hugger)
 
 	for(var/i in GLOB.xeno_resin_silo_turfs)
 		new /obj/effect/ai_node/spawner/zombie(i)

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -188,6 +188,14 @@
 	desc = "There is something spider-like inside..."
 	occupant = /obj/item/clothing/mask/facehugger
 
+/obj/structure/xenoautopsy/tank/hugger/Initialize(mapload)
+	. = ..()
+	GLOB.tank_hugger_structures += src
+
+/obj/structure/xenoautopsy/tank/hugger/Destroy()
+	GLOB.tank_hugger_structures -= src
+	return ..()
+
 /obj/structure/xenoautopsy/tank/hugger/release_occupant()
 	var/obj/item/clothing/mask/facehugger/hugger = new occupant(loc)
 	hugger.go_active()


### PR DESCRIPTION

## About The Pull Request
Tanks with huggers in them are qdel'd when Zombie Crash is started.

Tested:
<img width="386" height="751" alt="image" src="https://github.com/user-attachments/assets/4ea6448f-53ce-4a43-aff4-26896f59c16e" />

## Why It's Good For The Game
Xenomorphs shouldn't exist in Zombie Crash.

## Changelog
:cl:
del: Tanks with huggers inside of them no longer exist in Zombie Crash.
/:cl:
