### PR TITLE
Firesupport bino fix

### DIFF
--- a/code/game/objects/items/firesupport_binoculars.dm
+++ b/code/game/objects/items/firesupport_binoculars.dm
@@ -174,7 +174,7 @@
 		return FALSE
 	if(target.z != user.z)
 		return FALSE
-	if(!(user in viewers(zoom_tile_offset + zoom_viewsize + 3, target)))
+	if(!line_of_sight(user, target, 30, TRUE))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fire support use actual LOS.
## Why It's Good For The Game
Cursed byond LOS is... exceptionally cursed and just goes through shit, uses xray vision etc.
## Changelog
:cl:
fix: Firesupport binos use true LOS instead of viewers()
/:cl:
