### PR TITLE
round start c4 for crash

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -431,6 +431,7 @@
 			/obj/item/toy/deck/kotahi = -1,
 			/obj/item/toy/deck = -1,
 			/obj/item/deployable_floodlight = 5,
+			/obj/item/explosive/plastique = 12,
 		),
 	)
 


### PR DESCRIPTION

## About The Pull Request
Crash weapon vendors start with 12 C4.
## Why It's Good For The Game
Zombie crash kinda needs it if its low pop and you don't have certain roles.
## Changelog
:cl:
qol: Crash weapon vendors start with 12 C4 charges
/:cl:
