### PR TITLE
NPC's melee while retreating

### DIFF
--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -508,9 +508,12 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	var/dir_to_target = angle2dir(Get_Angle(get_turf(mob_parent), get_turf(atom_to_walk_to)))
 	var/list/dir_options = list()
 
-	if((dist_to_target >= min_range) && (dist_to_target <= max_range)) //in optimal range
+	var/in_optimal = (dist_to_target >= min_range) && (dist_to_target <= max_range)
+	if(in_optimal || (current_action == MOVING_TO_SAFETY && (dist_to_target >= lower_engage_dist) && (dist_to_target <= upper_engage_dist)))
+	//in optimal range or the specific scenario of running away from something we can still hurt
 		if((SEND_SIGNAL(mob_parent, COMSIG_STATE_MAINTAINED_DISTANCE) & COMSIG_MAINTAIN_POSITION))
 			return
+	if(in_optimal)
 		if(!get_dir(mob_parent, atom_to_walk_to)) //We're right on top, move out of it
 			return CARDINAL_ALL_DIRS
 		if(prob(atom_to_walk_to == escorted_atom ? 80 : 50)) //If we're holding around an escort target, we don't move too much

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -268,7 +268,7 @@
 	return list(0, 1)
 
 /obj/item/weapon/twohanded/spear/get_ai_combat_range()
-	return 2
+	return list(0, 2)
 
 /obj/item/weapon/gun/get_ai_combat_range()
 	if((gun_features_flags & GUN_IFF) || (ammo_datum_type::ammo_behavior_flags & AMMO_IFF))

--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -49,6 +49,12 @@
 	QDEL_NULL(mob_inventory)
 	return ..()
 
+/datum/ai_behavior/human/register_action_signals(action_type)
+	. = ..()
+	switch(action_type)
+		if(MOVING_TO_SAFETY)
+			RegisterSignal(mob_parent, COMSIG_STATE_MAINTAINED_DISTANCE, PROC_REF(melee_interact))
+
 /datum/ai_behavior/human/start_ai()
 	. = ..()
 	RegisterSignal(mob_parent, COMSIG_HUMAN_DAMAGE_TAKEN, PROC_REF(on_take_damage))

--- a/code/modules/ai/ai_behaviors/human_mobs/weapon_module.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/weapon_module.dm
@@ -18,7 +18,13 @@
 	var/list/dead_target_chat = list("Target down.", "Hostile down.", "Scratch one.", "I got one!", "Down for the count.", "Kill confirmed.")
 
 /datum/ai_behavior/human/melee_interact(datum/source, atom/interactee, melee_tool = melee_weapon) //specifies the arg value
-	return ..()
+	var/toggle_intent = FALSE
+	if(!melee_tool && current_action == MOVING_TO_SAFETY) //this exists so npcs will melee on retreat, even if unarmed
+		toggle_intent = TRUE
+		mob_parent.a_intent = INTENT_HARM
+	. = ..()
+	if(toggle_intent)
+		mob_parent.a_intent = INTENT_HELP
 
 ///Weapon stuff that happens during process
 /datum/ai_behavior/human/proc/weapon_process()


### PR DESCRIPTION

## About The Pull Request
NPC's will now try melee their combat target even while retreating.
## Why It's Good For The Game
Currently NPC's will never try melee when retreating, even if they're literally trapped in a corner.
Now they wil run but still try and hit their opponent if they get too close.
## Changelog
:cl:
fix: NPC's will try melee attack even when retreating
/:cl:
