### PR TITLE
Raises metnal minimum pop to be able to be voted to 55 players

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -111,7 +111,7 @@ map bluesummers
 endmap
 
 map metnal
-	minplayers 45
+	minplayers 55
   endmap
 
 


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

Soul war has made this map that was already intentionally xeno sided MUCH worse, i haven't even seen them reach the worst part (caves) yet, map is just too big and needs more players on the marine side mostly.

## Changelog
:cl:
config: Rises metnal minumum pop to 55
/:cl:
