### PR TITLE
Zombies cant rip out other zombies' hearts

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -398,6 +398,9 @@ Contains most of the procs that are called when a mob is attacked by something
 /mob/living/carbon/human/attackby(obj/item/I, mob/living/user, params)
 	if(stat != DEAD || I.sharp < IS_SHARP_ITEM_ACCURATE || user.a_intent != INTENT_HARM)
 		return ..()
+	if(iszombie(user))
+		to_chat(user, span_warning("You shouldn't rip out another zombie's heart."))
+		return
 	if(!get_organ_slot(ORGAN_SLOT_HEART))
 		to_chat(user, span_notice("[src] no longer has a heart."))
 		return


### PR DESCRIPTION

## About The Pull Request

Zombies cant rip out other zombies' hearts

## Why It's Good For The Game

Less grief

## Changelog
:cl:
fix: Zombies cant rip out other zombies' hearts
/:cl:
