### PR TITLE
Cade Capsule can fit in engi storage module

### DIFF
--- a/code/datums/storage/subtypes/internal.dm
+++ b/code/datums/storage/subtypes/internal.dm
@@ -317,6 +317,7 @@
 		/obj/item/circuitboard,
 		/obj/item/lightreplacer,
 		/obj/item/minerupgrade,
+		/obj/item/deploy_capsule/barricade,
 	))
 
 /datum/storage/internal/medical


### PR DESCRIPTION

## About The Pull Request

## Why It's Good For The Game

## Changelog
:cl: Atropos
balance: Cade capsule fits in engi storage module
/:cl:
