### PR TITLE
MG-27 can aimmode when deployed

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -467,7 +467,19 @@
 	damage_falloff_mult = 0.25
 	undeploy_time = 0.5 SECONDS
 	max_integrity = 200
+	actions_types = list(/datum/action/item_action/aim_mode)
 
+/obj/item/weapon/gun/standard_mmg/toggle_auto_aim_mode(mob/living/carbon/human/user) //somewhat redundant, but just for clarity to the user
+	if(!(item_flags & IS_DEPLOYED))
+		user.balloon_alert(user, "Not deployed")
+		return
+	return ..()
+
+/obj/item/weapon/gun/standard_mmg/toggle_aim_mode(mob/living/carbon/human/user)
+	if(!HAS_TRAIT(src, TRAIT_GUN_IS_AIMING) && !(item_flags & IS_DEPLOYED))
+		user.balloon_alert(user, "Not deployed")
+		return
+	return ..()
 
 /obj/item/weapon/gun/standard_mmg/machinegunner
 	starting_attachment_types = list(/obj/item/attachable/stock/t27, /obj/item/attachable/scope/unremovable/mmg)


### PR DESCRIPTION

## About The Pull Request
MMG has aimmode, but only when deployed.
## Why It's Good For The Game
Since its a deployed weapon, it is largely static so best suited for defence.
Marines need a bit better defensive options, so in this goes.
## Changelog
:cl:
balance: MG-27 has aimmode, but only when deployed
/:cl:
