### PR TITLE
Less special zombies in zombie crash

### DIFF
--- a/code/modules/ai/spawners/zombie.dm
+++ b/code/modules/ai/spawners/zombie.dm
@@ -7,12 +7,12 @@
 	resistance_flags = UNACIDABLE|PLASMACUTTER_IMMUNE|PROJECTILE_IMMUNE
 	spawntypes = list(
 		/mob/living/carbon/human/species/zombie/ai/patrol = 100,
-		/mob/living/carbon/human/species/zombie/ai/fast/patrol = 20,
+		/mob/living/carbon/human/species/zombie/ai/fast/patrol = 15,
 		/mob/living/carbon/human/species/zombie/ai/tank/patrol = 4,
-		/mob/living/carbon/human/species/zombie/ai/smoker/patrol = 4,
-		/mob/living/carbon/human/species/zombie/ai/hunter/patrol = 4,
-		/mob/living/carbon/human/species/zombie/ai/boomer/patrol = 4,
-		/mob/living/carbon/human/species/zombie/ai/strong/patrol = 4,
+		/mob/living/carbon/human/species/zombie/ai/smoker/patrol = 2,
+		/mob/living/carbon/human/species/zombie/ai/hunter/patrol = 2,
+		/mob/living/carbon/human/species/zombie/ai/boomer/patrol = 2,
+		/mob/living/carbon/human/species/zombie/ai/strong/patrol = 2,
 	)
 	spawnamount = 2
 	spawndelay = 15 SECONDS


### PR DESCRIPTION

## About The Pull Request
Significantly lowered the ratio of special zombies to normal zombies.

This should mean that less than 10% of zombies are special zombies (instead of around 20%).
The number of fast zombies will be higher however.

Also removed the station zombie spawns from zombie tunnels.
## Why It's Good For The Game
There is just a LOT of special zombies atm, mainly due to simply adding more types, and pick weights not being properly updated.

Zombie mode should mainly be about fighting a horde of vanilla zombies, not a rainbow of constant special zombie types.

Removed the station zombies from tunnels because they have proper defender spawn waves now, and player zombies already have a huge advantage with leading large hordes, they don't need this as well.
## Changelog
:cl:
balance: Special zombies types now spawn much less often from zombie tunnels
/:cl:
