### PR TITLE
fix freelancer and spec op suit sprites

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -423,6 +423,7 @@
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	soft_armor = list(MELEE = 50, BULLET = 65, LASER = 65, ENERGY = 55, BOMB = 60, BIO = 55, FIRE = 55, ACID = 55)
 	armor_features_flags = ARMOR_LAMP_OVERLAY
+	item_map_variant_flags = NONE
 	attachments_by_slot = list(
 		ATTACHMENT_SLOT_STORAGE,
 		ATTACHMENT_SLOT_MODULE,
@@ -810,6 +811,7 @@
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 	armor_protection_flags = CHEST|GROIN
 	armor_features_flags = NONE
+	item_map_variant_flags = NONE
 
 /obj/item/clothing/suit/storage/marine/specops/support
 	name = "Ballistic vest"


### PR DESCRIPTION

## About The Pull Request
Fixes freelancer and spec ops suits having error sprites.

If you are adding child types from marine armour, its expecting map variants by default.
## Why It's Good For The Game
Stealth armour bad.
## Changelog
:cl:
fix: fixed freelancer and spec op ERTs having invisible armour sprites
/:cl:
