### PR TITLE
Disables King Summon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -61,7 +61,7 @@
 		/datum/action/ability/xeno_action/petrify,
 		/datum/action/ability/activable/xeno/off_guard,
 		/datum/action/ability/activable/xeno/shattering_roar,
-		/datum/action/ability/xeno_action/psychic_summon,
+		// datum/action/ability/xeno_action/psychic_summon, -- Disabled for Sovl war balance reasons.
 		/datum/action/ability/xeno_action/pheromones,
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,
@@ -101,7 +101,7 @@
 		/datum/action/ability/activable/xeno/off_guard,
 		/datum/action/ability/activable/xeno/shattering_roar,
 		/datum/action/ability/xeno_action/zero_form_beam,
-		/datum/action/ability/xeno_action/psychic_summon,
+		// datum/action/ability/xeno_action/psychic_summon, -- Disabled for Sovl war balance reasons.
 		/datum/action/ability/xeno_action/pheromones,
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,


### PR DESCRIPTION

## About The Pull Request

Disables the king summon ability for testing without it.
Not intended to be merged in its current state.

## Why It's Good For The Game

In the current Sovl war, the ability to summon the entire hive to a single location is incredibly overpowered.
Marines are far, far more limited in their ability to traverse the map so responding to a summon is nearly impossible before a marine position has been overrun.

## Changelog

:cl:
balance: Disables king hive summon.
/:cl:
