### PR TITLE
Humans count as having no brain when they have no head/decapitated zombies dont revive

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -183,7 +183,7 @@
 
 /mob/living/carbon/human/has_brain()
 	var/datum/internal_organ/brain = get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(!brain || !istype(brain))
+	if(!istype(brain))
 		return FALSE
 	var/datum/limb/braincase = get_limb(brain.parent_limb)
 	if(braincase.limb_status & LIMB_DESTROYED)


### PR DESCRIPTION

## About The Pull Request

Decapped zombies dont revive, fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/18453

## Why It's Good For The Game
fix

## Changelog
:cl:
fix: Decapped zombies dont revive
/:cl:
