### PR TITLE
weeds grow much faster

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -256,7 +256,7 @@
 	/// list of all potential turfs that we can expand to
 	var/node_turfs = list()
 	/// How far this node can spread weeds
-	var/node_range = 4
+	var/node_range = 2
 	/// What type of weeds this node spreads
 	var/obj/alien/weeds/weed_type = /obj/alien/weeds
 	///The plasma cost multiplier for this node


### PR DESCRIPTION
## About The Pull Request
Substantially decreases the amount of time that the SSweeds needs to wait before it re-activates & decreases the amount of time before weeds are created.

Also changes the attempts to be dynamic: (2 * node's maximum range) + 1.
This keeps it as 5 still, but would increase it to 9 if the weed range is 4.

**GRAPHICS TO COMPARE BELOW:**

The speed in which **current** weeds (with the [testmerge](https://github.com/tgstation/TerraGov-Marine-Corps/pull/18452)) can grow at. I did not record the whole thing because it would of taken 1-2 minutes to fully fill out (note: it wouldn't of anyways because it used all 9 expansion attempts/loops).

5 SECONDS wait with 0.1 SECONDS - 3 SECONDS of randomized weed spawn time.
![wait50-30timer](https://github.com/user-attachments/assets/a39c14bb-e353-4fc9-8d28-f9a1f9fff7c3)

The speed in which **new** weeds (with the [testmerge](https://github.com/tgstation/TerraGov-Marine-Corps/pull/18452)) can grow at.

2 SECONDS wait with 0.1 SECONDS - 0.3 SECONDS of randomized weed spawn time.
![wait20-03timer](https://github.com/user-attachments/assets/32a1cd03-a55b-49df-931f-d6e6abe055d3)
## Why It's Good For The Game
With https://github.com/tgstation/TerraGov-Marine-Corps/pull/18452, weeding is incredibly slow especially shipside where you have to watch your weeds grow toward a direction you want it to grow which can be a random time between 0.1 second to 8 seconds.

## Changelog
:cl:
balance: Substantially speeds up in which weeds grow/spawn from a resin node.
/:cl:
