### PR TITLE
no removing shrapnel while busy

### DIFF
--- a/code/datums/elements/shrapnel_removal.dm
+++ b/code/datums/elements/shrapnel_removal.dm
@@ -25,6 +25,8 @@
 	return COMPONENT_ITEM_NO_ATTACK
 
 /datum/element/shrapnel_removal/proc/attempt_remove(obj/item/removaltool, mob/living/M, mob/living/user)
+	if(user.do_actions)
+		return
 	if(!ishuman(M))
 		M.balloon_alert(user, "that's not a human!")
 		REMOVE_TRAIT(user, TRAIT_IS_SHRAP_REMOVING, REF(removaltool))
@@ -37,8 +39,6 @@
 	if(!has_shrapnel(targetlimb))
 		M.balloon_alert(user, "nothing in that limb!")
 		REMOVE_TRAIT(user, TRAIT_IS_SHRAP_REMOVING, REF(removaltool))
-		return
-	if(user.do_actions)
 		return
 	var/skill = user.skills.getRating(SKILL_MEDICAL)
 	if(skill < SKILL_MEDICAL_PRACTICED)


### PR DESCRIPTION

## About The Pull Request
You can no longer perform shrapnel removal while doing actions already. This means you cannot stack/queue shrapnel removal actions.

## Why It's Good For The Game
It is odd that you can stack actions while using regular tweezer to effectively replicate the upgraded version, making the reason to buy it moot. Arguably a bug, but given that people use it like the upgraded version with this method, it goes to balance.
 
## Changelog
:cl:
balance: You no longer can remove shrapnel if you're already doing an action.
/:cl:
