### PR TITLE
Add loadout vendors to spec rooms in Arachne

### DIFF
--- a/_maps/map_files/Arachne/TGS_Arachne.dmm
+++ b/_maps/map_files/Arachne/TGS_Arachne.dmm
@@ -39136,7 +39136,7 @@ eQh
 aXQ
 slK
 oaU
-vza
+dHS
 nlJ
 gng
 xfX


### PR DESCRIPTION

## About The Pull Request

Add loadout vendors to spec rooms in Arachne, replacing tables
Before:
<img width="908" height="424" alt="image" src="https://github.com/user-attachments/assets/c98b8d2c-0752-4db7-9dbd-5901d8240673" />

After:
<img width="911" height="432" alt="image" src="https://github.com/user-attachments/assets/343828a4-65c5-49fa-a19c-a0d0a2454b8d" />


## Why It's Good For The Game

- Reduce specialist spillover into the common area, specialists can take spare resources from others more easily
- Less risk of roombas eating important items
- You dont have to walk back out of the specialist room to get your loadout

## Changelog
:cl:
add: Added loadout vendors to spec rooms in Arachne
/:cl:
