### PR TITLE
acidded sandbags drop 0 sandbags

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -145,12 +145,9 @@
 	if(disassembled && is_wired)
 		new /obj/item/stack/barbed_wire(loc)
 	if(stack_type)
-		var/stack_amt
-		if(!disassembled && !isnull(destroyed_stack_amount))
-			stack_amt = destroyed_stack_amount
-		else
+		var/stack_amt = destroyed_stack_amount
+		if(disassembled)
 			stack_amt = round(stack_amount * (obj_integrity/max_integrity)) //Get an amount of sheets back equivalent to remaining health. Obviously, fully destroyed means 0
-
 		if(stack_amt)
 			new stack_type (loc, stack_amt)
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Sandbags that are not carefully disassembled do not drop any sandbags.

## Why It's Good For The Game
Sandbags have this unique issue where it can be deconstructed through some means (e.g. acid) and drop up to 5 sandbags as it drops sandbags based on its health no matter what happens. This mainly happens when sandbags are fully acidded and drops 5 sandbags (instead of 0) because it was on full health. This doesn't happen with metal or plasteel cades, so it is just weird and inconsistent.

## Changelog
:cl:
balance: Sandbags that are not carefully disassembled (e.g. acid) no longer drop any sandbags.
/:cl:
