### PR TITLE
abilities that weaken fire now actually do that

### DIFF
--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -208,7 +208,7 @@
 /obj/fire/flamer/reduce_fire(amount = 1)
 	if(!..())
 		return
-	burn_level -= amount * 2
+	burn_level -= amount * 2 // 2 because that is the same as value from process().
 	if(burn_ticks > 0)
 		update_appearance(UPDATE_ICON)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
The abilities mentioned in https://github.com/tgstation/TerraGov-Marine-Corps/pull/17832 now actually "weaken[s]" the fire instead of reducing the duration / the time it takes to "extinguish" it. This weakening only allows to marine-fire (like flamer fire) and not xeno-fire (like melting acid).

It also now accounts for fire_decay so melting fire and its variants disproportionately favored when it comes to extinguishing fire.

## Why It's Good For The Game
The original PR said it weakened fire. Not exactly true, it just made faster to extinguish. So theoretically you could step in a fire that looks like it is about to burn out, but take massive damage if it was a raging fire. Plus, it makes extinguishing fire with abilities more appealing.

## Changelog
:cl:
balance: Abilities that reduce fire's duration now scale with the rate in which that particular fire delays at & may also reduce the fire's strength.
/:cl:
