### PR TITLE
Zombies are damaged by wired barricades

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -27,7 +27,7 @@
 	var/is_open = FALSE
 	///Can this barricade type be wired
 	var/can_wire = FALSE
-	///is this barriade wired?
+	///Is this barricade wired?
 	var/is_wired = FALSE
 
 /obj/structure/barricade/Initialize(mapload, mob/user)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -135,6 +135,7 @@
 	reagents.add_reagent(/datum/reagent/zombium, claw.zombium_per_hit)
 
 /obj/structure/barricade/attack_zombie(mob/living/carbon/human/zombie, obj/item/weapon/zombie_claw/claw, params, rightclick)
-	if(is_wired)
-		balloon_alert(zombie, "barbed wire slices into you!")
-		zombie.apply_damage(40, blocked = MELEE , sharp = TRUE, updating_health = TRUE)//Higher damage since zombies have high healing rate, and theyre using their hands
+	if(!is_wired)
+		return
+	balloon_alert(zombie, "barbed wire slices into you!")
+	zombie.apply_damage(40, blocked = MELEE , sharp = TRUE, updating_health = TRUE)//Higher damage since zombies have high healing rate, and theyre using their hands


### PR DESCRIPTION
## About The Pull Request

Zombies are damaged by wired barricades

## Why It's Good For The Game

It is expected behavior

## Changelog
:cl:
add: Zombies can now be damaged by wired barricades
/:cl:
