### PR TITLE
resin jelly prevents additional melting stacks

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -806,9 +806,6 @@
 	playsound(debuff_owner.loc, "sound/bullets/acid_impact1.ogg", 4)
 	particle_holder.particles.spawning = 1 + round(stacks / 2)
 
-	if(debuff_owner.has_status_effect(STATUS_EFFECT_RESIN_JELLY_COATING))
-		return
-
 	debuff_owner.apply_damage(STATUS_EFFECT_MELTING_DAMAGE, BURN, null, FIRE)
 
 	if(!isxeno(debuff_owner))


### PR DESCRIPTION

## About The Pull Request
Having the Resin Jelly status effect now prevents you from getting more Melting stacks.

## Why It's Good For The Game
Resin Jelly apparently only stopped you from getting the Melting status effect itself. So you could get more stacks even if you had the jelly applied to you & had at least 1 stack. That is inconsistent and a bug, I think.
## Changelog


:cl:
fix: Having the Resin Jelly status effect now prevents you from getting more Melting stacks.
/:cl:
