### PR TITLE
fixes certain ex-hive rulers losing ruler/leader abilities

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -77,16 +77,16 @@
 	if(lead && !(locate(/datum/action/ability/xeno_action/set_xeno_lead) in xeno_caste.actions))
 		lead.remove_action(src)
 	var/datum/action/ability/xeno_action/blessing_menu/bless = actions_by_path[/datum/action/ability/xeno_action/blessing_menu]
-	if(bless !(locate(/datum/action/ability/xeno_action/blessing_menu) in xeno_caste.actions))
+	if(bless && !(locate(/datum/action/ability/xeno_action/blessing_menu) in xeno_caste.actions))
 		bless.remove_action(src)
 	var/datum/action/ability/xeno_action/hive_message/message = actions_by_path[/datum/action/ability/xeno_action/hive_message]
-	if(message !(locate(/datum/action/ability/xeno_action/hive_message) in xeno_caste.actions))
+	if(message && !(locate(/datum/action/ability/xeno_action/hive_message) in xeno_caste.actions))
 		message.remove_action(src)
 	var/datum/action/ability/xeno_action/rally_hive/hive = actions_by_path[/datum/action/ability/xeno_action/rally_hive]
-	if(hive !(locate(/datum/action/ability/xeno_action/rally_hive) in xeno_caste.actions))
+	if(hive && !(locate(/datum/action/ability/xeno_action/rally_hive) in xeno_caste.actions))
 		hive.remove_action(src)
 	var/datum/action/ability/xeno_action/rally_minion/minion = actions_by_path[/datum/action/ability/xeno_action/rally_minion]
-	if(minion !(locate(/datum/action/ability/xeno_action/rally_minion) in xeno_caste.actions))
+	if(minion && !(locate(/datum/action/ability/xeno_action/rally_minion) in xeno_caste.actions))
 		minion.remove_action(src)
 
 


### PR DESCRIPTION

## About The Pull Request
Losing Hive Ruler status no longer removes ruler/leader abilities if your caste has the said ruler/leader abilities by default.
## Why It's Good For The Game
Losing Hive Ruler status caused certain castes (mainly Shrike) to lose their leader/ruler abilities like Hive Blessing. These caste start with the abilities by default and it shouldn't be removed just because they gained (results in no given abilities) and then lost Hive Ruler (results in losing the mentioned abilities). Bugfix. 

## Changelog
:cl:
fix: Losing Hive Ruler status no longer removes leader/ruler abilities if your caste has the abilities by default.
/:cl:
