### PR TITLE
Zombies cant strip things

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -129,6 +129,9 @@
 	if(!is_incorporeal(user))
 		return FALSE
 
+	if(!user.dextrous)
+		return
+
 	var/obj/item/item = get_item(source)
 	if(isnull(item))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Zombies cant strip things

## Why It's Good For The Game

They aren't dexterous enough to do that, and they have no use for this except grief

## Changelog
:cl:
fix: Zombies cant strip things anymore
/:cl:
