### PR TITLE
Adds ERP (and more) to EORD

### DIFF
--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -171,7 +171,7 @@
 		/datum/job/pmc,
 		/datum/job/special_forces,
 		/datum/job/icc,
-		/datum/job/vsd
+		/datum/job/vsd,
 	)
 
 	// List of HvH factions - these are handled differently, using the quick loadout outfits.


### PR DESCRIPTION

## About The Pull Request
ERP sadly goes unused, VSD is campaign only, and vets never show up anymore. I wanna still play with their crap so I'm adding them to EORD.
## Why It's Good For The Game
People get to play with fun toys in the toy room called EORD.
## Changelog

:cl:
add: Added ERP to EORD
add: Added VSD to EORD
add: Added vets to EORD
/:cl:
