### PR TITLE
Primo Locked King Summon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -60,7 +60,6 @@
 		/datum/action/ability/xeno_action/petrify,
 		/datum/action/ability/activable/xeno/off_guard,
 		/datum/action/ability/activable/xeno/shattering_roar,
-		/datum/action/ability/xeno_action/psychic_summon,
 		/datum/action/ability/xeno_action/pheromones,
 		/datum/action/ability/xeno_action/pheromones/emit_recovery,
 		/datum/action/ability/xeno_action/pheromones/emit_warding,


### PR DESCRIPTION

## About The Pull Request

Locks king summon to Primordial King only. Does this by removing summon from basic king.
Alternative to #18454

## Why It's Good For The Game

Increases the investment required to acquire the very powerful king summon ability instead of complete removal.

## Changelog


:cl:
balance: King summon is primordial only.
/:cl:
