### PR TITLE
evolution no longer resets sunder

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -180,6 +180,8 @@
 	new_xeno.hive?.update_ruler() // Since ruler wasn't set during initialization, update ruler now.
 	transfer_observers_to(new_xeno)
 
+	new_xeno.sunder = sunder
+
 	if(new_xeno.health - getBruteLoss(src) - getFireLoss(src) > 0) //Cmon, don't kill the new one! Shouldnt be possible though
 		new_xeno.bruteloss = bruteloss //Transfers the damage over.
 		new_xeno.fireloss = fireloss //Transfers the damage over.


### PR DESCRIPTION

## About The Pull Request
Evolving (e.g caste swap, strain swap, evolve, de-evolve) no longer resets your sunder to 0 and instead will transfer all of your sunder over to your new caste.

## Why It's Good For The Game
Attrition from sunder can be easily bypassed and thus becomes irrelevant when you realize you can reset your sunder to maximum upon caste swap (to the same exact caste by the way), strain swap, or evolution/devolution. This makes acid pool an unneeded structure as resetting sunder via evolution is much more convenient and means you don't have to spend the points on it. Though, only T4s (excluding Shrike as they can evolve up & down) have to really care about sunder since they can't use this trick.

It is arguably a bug that should be fixed, but has balance implications because it buffs the use of sunder and may lead to xenos dying more due to them having too much attrition.

## Changelog
:cl:
balance: Sunder now carries over through evolutions.
/:cl:
