### PR TITLE
sentries immediately stop shooting if target dies

### DIFF
--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -418,6 +418,14 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	var/obj/item/weapon/gun/internal_gun = get_internal_item()
 	if(!internal_gun)
 		return
+	if(QDELETED(gun_target)) // Maybe they just got gibbed or deleted.
+		sentry_stop_fire()
+		return
+	if(isliving(gun_target))
+		var/mob/living/living_target = gun_target
+		if(living_target.stat == DEAD)
+			sentry_stop_fire()
+			return
 	if(CHECK_BITFIELD(internal_gun.reciever_flags, AMMO_RECIEVER_REQUIRES_UNIQUE_ACTION) && length(internal_gun.chamber_items))
 		INVOKE_ASYNC(internal_gun, TYPE_PROC_REF(/obj/item/weapon/gun, do_unique_action))
 	if(!CHECK_BITFIELD(internal_gun.item_flags, IS_DEPLOYED) || get_dist(src, gun_target) > range || (!CHECK_BITFIELD(get_dir(src, gun_target), dir) && !CHECK_BITFIELD(internal_gun.turret_flags, TURRET_RADIAL)) || !check_target_path(gun_target))


### PR DESCRIPTION

## About The Pull Request
Sentries now immediately stops shoot when their target dies.

Practically: Makes the longevity of turrets in Zombie Crash in particular much long since they don't need to dump an additional 6 or 7 bullets into a body that is already dead.

## Why It's Good For The Game
No need to shoot more bullets once the target is dead. Makes defending the ship in Zombie Crash less painful.

## Changelog
:cl:
balance: Sentries now immediately stops shoot when their target dies.
/:cl:
