### PR TITLE
Reduce zombie wired barricade damage

### DIFF
--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -138,4 +138,4 @@
 	if(!is_wired)
 		return
 	balloon_alert(zombie, "barbed wire slices into you!")
-	zombie.apply_damage(40, blocked = MELEE , sharp = TRUE, updating_health = TRUE)//Higher damage since zombies have high healing rate, and theyre using their hands
+	zombie.apply_damage(20, blocked = MELEE , sharp = TRUE, updating_health = TRUE)//Higher damage since zombies have high healing rate, and theyre using their hands


### PR DESCRIPTION

## About The Pull Request

Reduce zombie barricade damage

## Why It's Good For The Game

It's too much, a single horde isn't close to getting through a single metal ballistic cade line

## Changelog
:cl:
balance: Reduce wired barricade damage to zombies
/:cl:
