### PR TITLE
Readds siloless collapse, now only happens with no silos and decorrupted gens

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -34,6 +34,8 @@
 
 #define COMSIG_GLOB_SHIP_SELF_DESTRUCT_ACTIVATED "!ship_self_destruct_activated"
 
+#define COMSIG_GLOB_SILOLESS_COLLAPSE "!siloless_collapse"
+
 /// from /obj/machinery/setAnchored(): (machine, anchoredstate)
 #define COMSIG_GLOB_MACHINERY_ANCHORED_CHANGE "!machinery_anchored_change"
 /// called after a successful var edit somewhere in the world: (list/args)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -548,6 +548,7 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define XENO_ACID_WELL_MAX_CHARGES 5 //Maximum number of charges for the acid well
 
 #define HIVE_CAN_HIJACK (1<<0)
+#define HIVE_CAN_COLLAPSE_FROM_SILO (1<<1)
 
 #define XENO_PULL_CHARGE_TIME 2 SECONDS
 #define XENO_SLOWDOWN_REGEN 0.4

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -121,6 +121,7 @@
 
 //Nuclear war mode collapse duration
 #define NUCLEAR_WAR_ORPHAN_HIVEMIND 5 MINUTES
+#define NUCLEAR_WAR_SILO_COLLAPSE 5 MINUTES
 
 #define SHUTTLE_HIJACK_LOCK 30 MINUTES
 

--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -366,6 +366,15 @@ GLOBAL_LIST_INIT(bioscan_locations, list(
 /datum/game_mode/proc/get_hivemind_collapse_countdown()
 	return
 
+/datum/game_mode/proc/siloless_hive_collapse()
+	return
+
+/datum/game_mode/proc/update_silo_death_timer(datum/hive_status/silo_owner)
+	return
+
+/datum/game_mode/proc/get_siloless_collapse_countdown()
+	return
+
 ///Provides the amount of time left before the game ends, used for the stat panel
 /datum/game_mode/proc/game_end_countdown()
 	return

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -39,6 +39,8 @@
 		/datum/xeno_caste/queen = 8,
 	)
 
+	var/siloless_hive_timer
+
 /datum/game_mode/infestation/nuclear_war/post_setup()
 	var/client_count = length(GLOB.clients)
 	if(client_count >= NUCLEAR_WAR_MECH_MINIMUM_POP_REQUIRED)
@@ -71,10 +73,53 @@
 	if(round_stage == INFESTATION_MARINE_CRASHING)
 		round_finished = MODE_INFESTATION_M_MINOR
 		return
-	round_finished = MODE_INFESTATION_M_MAJOR
 
 /datum/game_mode/infestation/nuclear_war/get_hivemind_collapse_countdown()
 	var/eta = timeleft(orphan_hive_timer) MILLISECONDS
+	return !isnull(eta) ? round(eta) : 0
+
+/// Checks if the conditions for silo collapse have been met and starts/stops the countdown timer accordingly
+/datum/game_mode/infestation/nuclear_war/update_silo_death_timer(datum/hive_status/silo_owner)
+	if(!(silo_owner.hive_flags & HIVE_CAN_COLLAPSE_FROM_SILO))
+		return
+
+	//handle potential stopping
+	if(round_stage != INFESTATION_MARINE_DEPLOYMENT)
+		if(siloless_hive_timer)
+			deltimer(siloless_hive_timer)
+			siloless_hive_timer = null
+		return
+	if(length(GLOB.xeno_resin_silos_by_hive[XENO_HIVE_NORMAL]))
+		if(siloless_hive_timer)
+			deltimer(siloless_hive_timer)
+			siloless_hive_timer = null
+		return
+	if(GLOB.corrupted_generators)
+		if(siloless_hive_timer)
+			deltimer(siloless_hive_timer)
+			siloless_hive_timer = null
+		return
+	//handle starting
+	if(siloless_hive_timer)
+		return
+
+	silo_owner.xeno_message("We don't have any silos or corrupted generators! The hive will collapse if nothing is done.", "xenoannounce", 6, TRUE)
+	siloless_hive_timer = addtimer(CALLBACK(src, PROC_REF(siloless_hive_collapse)), NUCLEAR_WAR_SILO_COLLAPSE, TIMER_STOPPABLE)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SILOLESS_COLLAPSE)
+
+///called by [/proc/update_silo_death_timer] after [NUCLEAR_WAR_SILO_COLLAPSE] elapses to end the round
+/datum/game_mode/infestation/nuclear_war/siloless_hive_collapse()
+	if(!(round_type_flags & MODE_INFESTATION))
+		return
+	if(round_finished)
+		return
+	if(round_stage == INFESTATION_MARINE_CRASHING)
+		return
+	round_finished = MODE_INFESTATION_M_MAJOR
+
+/// Returns the time left before the hive collapses due to lack of silos or corrupted generators
+/datum/game_mode/infestation/nuclear_war/get_siloless_collapse_countdown()
+	var/eta = timeleft(siloless_hive_timer) MILLISECONDS
 	return !isnull(eta) ? round(eta) : 0
 
 /datum/game_mode/infestation/nuclear_war/check_finished()

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -4,6 +4,7 @@
 #define GEOTHERMAL_HEAVY_DAMAGE 3
 
 GLOBAL_VAR_INIT(generators_on_ground, 0)
+GLOBAL_VAR_INIT(corrupted_generators, 0)
 
 /obj/machinery/power/geothermal
 	name = "\improper G-11 geothermal generator"
@@ -42,6 +43,9 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 /obj/machinery/power/geothermal/Destroy() //just in case
 	if(is_ground_level(z))
 		GLOB.generators_on_ground -= 1
+	if(corrupted && is_ground_level(z))
+		GLOB.corrupted_generators -= 1
+		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[corrupted])
 	return ..()
 
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
@@ -258,6 +262,9 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 		if(!I.use_tool(src, user, 20 SECONDS - clamp((user.skills.getRating(SKILL_ENGINEER) - SKILL_ENGINEER_ENGI) * 5, 0, 20), 2, 25, null, BUSY_ICON_BUILD))
 			return FALSE
 
+		if(is_ground_level(z))
+			GLOB.corrupted_generators -= 1
+			SSticker.mode?.update_silo_death_timer(GLOB.hive_datums[corrupted])
 		corrupted = 0
 		stop_processing()
 		update_icon()
@@ -333,6 +340,10 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 /obj/machinery/power/geothermal/proc/corrupt(hivenumber)
 	corrupted = hivenumber
 	is_on = FALSE
+	if(is_ground_level(z))
+		GLOB.corrupted_generators += 1
+	if(SSticker.mode)
+		SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
 	power_gen_percent = 0
 	cur_tick = 0
 	icon_state = "off"

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -48,6 +48,7 @@
 		RegisterSignals(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), PROC_REF(is_burrowed_larva_host))
 		if(length(GLOB.xeno_resin_silos_by_hive[hivenumber]) == 1)
 			GLOB.hive_datums[hivenumber].give_larva_to_next_in_queue()
+	SSticker.mode.update_silo_death_timer(GLOB.hive_datums[hivenumber])
 	var/turf/tunnel_turf = get_step(src, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/xeno/tunnel/newt = new(tunnel_turf, hivenumber)
@@ -58,6 +59,7 @@
 	if(GLOB.hive_datums[hivenumber])
 		UnregisterSignal(GLOB.hive_datums[hivenumber], list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
 		GLOB.hive_datums[hivenumber].xeno_message("A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", "xenoannounce", 5, FALSE, loc, 'sound/voice/alien/help2.ogg',FALSE , null, /atom/movable/screen/arrow/silo_damaged_arrow)
+		INVOKE_NEXT_TICK(SSticker.mode, TYPE_PROC_REF(/datum/game_mode, update_silo_death_timer), GLOB.hive_datums[hivenumber]) // checks all silos next tick after this one is gone
 		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 		playsound(loc,'sound/effects/alien/egg_burst.ogg', 75)
 	return ..()

--- a/tgui/packages/tgui/interfaces/HiveStatus.tsx
+++ b/tgui/packages/tgui/interfaces/HiveStatus.tsx
@@ -28,6 +28,8 @@ type InputPack = {
   hive_tactical_psy_points: number;
   hive_orphan_collapse: number;
   hive_orphan_max: number;
+  hive_silo_collapse: number;
+  hive_silo_collapse_max: number;
   hive_minion_count: number;
   hive_primos: PrimoUpgrades[];
   hive_death_timers: DeathTimer[];
@@ -231,6 +233,8 @@ const GeneralInfo = (_props: any) => {
     hive_orphan_collapse,
     hive_death_timers,
     hive_orphan_max,
+    hive_silo_collapse,
+    hive_silo_collapse_max,
   } = data;
 
   return (
@@ -291,6 +295,14 @@ const GeneralInfo = (_props: any) => {
             max={hive_orphan_max}
             tooltip="Hive must evolve a ruler!"
             left_side="Orphan Hivemind:"
+          />
+        </Flex.Item>
+        <Flex.Item>
+          <XenoCountdownBar
+            time={hive_silo_collapse}
+            max={hive_silo_collapse_max}
+            tooltip="Hive must build a silo or recorrupt generators!"
+            left_side="Siloless Collapse:"
           />
         </Flex.Item>
       </Flex>


### PR DESCRIPTION

## About The Pull Request
Orphan hive collapse will no longer happen during groundside, only shipside.

While groundside, xenos will now begin a 5 minute siloless collapse if they have no silos AND no corrupted generators.
Placing a new silo or recorrupting a generator will stop the timer and allow them to keep fighting.

TLDR: To major marines will need to kill silo and decorrupt generators.
## Why It's Good For The Game
Delayliens are annoying and this places much clearer goals for winning on both teams rather than searching for a mystery shrike.

The general flow of the round (when it is time for silo rush) will now go as follows:
Marines ATTACK silo while xenos DEFEND
Silo dies, marines retreat to go clean generators.
Last, marines DEFEND generators while xenos ATTACK to reclaim gens or can alternatively just make a new silo.
## Changelog
:cl:
add: During groundside, xenos will now collapse after 5 minutes if they have no silos and no corrupted generators.
remove: Orphan collapse will now only happen while shipside.
/:cl:
