### PR TITLE
Removes stray groundside generators

### DIFF
--- a/_maps/map_files/LV759/LV759.dmm
+++ b/_maps/map_files/LV759/LV759.dmm
@@ -84873,7 +84873,7 @@
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/lv759/indoors/spaceport/cuppajoes)
 "pjO" = (
-/obj/machinery/power/geothermal,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/electical_systems/substation2)
 "pjQ" = (
@@ -93287,8 +93287,8 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/northeast)
 "qKo" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/urban_plating,
 /area/lv759/indoors/electical_systems/substation2)
 "qKr" = (

--- a/_maps/map_files/corsat/corsat.dmm
+++ b/_maps/map_files/corsat/corsat.dmm
@@ -21149,8 +21149,8 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/hallwaysouth)
 "jBd" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/grayscale/black,
 /area/corsat/omega/maint)
 "jBi" = (

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -59073,8 +59073,8 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/desert_dam/exterior/valley/valley_medical_south)
 "wTo" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/interior/east_engineering)
 "wTu" = (

--- a/_maps/map_files/kutjevo/kutjevo.dmm
+++ b/_maps/map_files/kutjevo/kutjevo.dmm
@@ -17638,7 +17638,7 @@
 /area/kutjevo/interior/complex/med/auto_doc)
 "sGW" = (
 /obj/structure/cable,
-/obj/machinery/power/geothermal,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
 "sHg" = (
@@ -18786,7 +18786,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/geothermal,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/kutjevo/colors/orange,
 /area/kutjevo/interior/power)
 "tQL" = (

--- a/_maps/map_files/lavaoutpost/LavaOutpost.dmm
+++ b/_maps/map_files/lavaoutpost/LavaOutpost.dmm
@@ -170,8 +170,8 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/north)
 "bM" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/one)
 "bP" = (
@@ -2874,17 +2874,17 @@
 /turf/open/floor/plating,
 /area/lavaland/cave/central)
 "Ew" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/three)
 "Ey" = (
 /turf/open/floor/tile/white,
 /area/lavaland/security)
 "Ez" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/three)
 "EB" = (
@@ -3057,9 +3057,9 @@
 /turf/closed/wall,
 /area/lavaland/cave/west)
 "Gg" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/one)
 "Gh" = (
@@ -3920,8 +3920,8 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/central)
 "Qc" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/two)
 "Qi" = (
@@ -3929,11 +3929,11 @@
 /turf/open/liquid/lava/autosmoothing,
 /area/lavaland/lava)
 "Qm" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/lavaland/engie/two)
 "Qt" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -1033,7 +1033,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "RD" = (
-/obj/machinery/power/geothermal/bigred,
+/obj/structure/prop/mainship/brokengen,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering/east)
 "RW" = (


### PR DESCRIPTION

## About The Pull Request
Removes groundside generators that are away from the central cluster on certain maps.
Companion PR to #18484 
## Why It's Good For The Game
Generators are an objective we expect both teams to be able to reasonably interact with so having random sets of generators away from the main ones makes it too difficult to reclaim generators.
## Changelog
:cl:
del: Removed stray groundside generators on certain maps.
/:cl:
