### PR TITLE
Remote weapons heavy seasonal

### DIFF
--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -372,7 +372,7 @@ SUBSYSTEM_DEF(persistence)
 		/obj/vehicle/unmanned/heavy = 1,
 		/obj/item/deployable_vehicle/tiny = 3,
 		/obj/item/uav_turret = 1,
-		/obj/item/ammo_magazine/box11x35mm = 3.
+		/obj/item/ammo_magazine/box11x35mm = 3,
 		/obj/item/uav_turret/heavy = 1,
 		/obj/item/ammo_magazine/box12x40mm = 3,
 		/obj/item/uav_turret/claw = 1,


### PR DESCRIPTION

## About The Pull Request
Adds a new heavy seasonal, including unmanned vehicles and MLRS.
Contents include:
6 unmanned vehicle remotes
1 each of Iguana, Gecko, and Komodo unmanned vehicle bodies
1 each of light gun, heavy gun, and claw attachments.
3 Skink drones
2 MLRS Kits
4 Gas rockets
<img width="274" height="360" alt="image" src="https://github.com/user-attachments/assets/13c78935-909a-4ff0-a6b3-4afcd62f07a5" />
## Why It's Good For The Game
Heavy seasonals are fun, more stuff to chew on and try out without needing to commit piles of req points or engi points for.
This seasonal provides various tools and toys for fobbits to provide support to the front from the comfort of the fob.

Considering this only has two actual guns the power level should be on par or lower than other heavy seasonals.
## Changelog
:cl:
add: Added a new heavy seasonal: Remote Weapons
/:cl:
