### PR TITLE
Gamemodes cant start on maps with a blacklisted ground map (without bypass)

### DIFF
--- a/code/datums/gamemodes/_game_mode.dm
+++ b/code/datums/gamemodes/_game_mode.dm
@@ -85,7 +85,7 @@ GLOBAL_VAR(common_report) //Contains common part of roundend report
 /datum/game_mode/proc/can_start(bypass_checks = FALSE)
 	if((!(config_tag in SSmapping.configs[GROUND_MAP].gamemodes) || (SSmapping.configs[GROUND_MAP].map_name in blacklist_ground_maps)) && !bypass_checks)
 		log_world("Attempted to start [name] on "+SSmapping.configs[GROUND_MAP].map_name+" which doesn't support it.")
-		to_chat(world, "<b>Unable to start [name].</b> [SSmapping.configs[GROUND_MAP].map_name] is blacklisted on [name], likely because it doesn't support it.")
+		to_chat(world, "<b>Unable to start [name].</b> [SSmapping.configs[GROUND_MAP].map_name] isn't supported on [name].")
 		// start a gamemode vote, in theory this should never happen.
 		addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), "gamemode", "SERVER"), 10 SECONDS)
 		return FALSE

--- a/code/datums/gamemodes/zombie_crash.dm
+++ b/code/datums/gamemodes/zombie_crash.dm
@@ -24,7 +24,7 @@
 /datum/game_mode/infestation/crash/zombie/can_start(bypass_checks = FALSE)
 	if((!(config_tag in SSmapping.configs[GROUND_MAP].gamemodes) || (SSmapping.configs[GROUND_MAP].map_name in blacklist_ground_maps)) && !bypass_checks)
 		log_world("attempted to start [name] on "+SSmapping.configs[GROUND_MAP].map_name+" which doesn't support it.")
-		to_chat(world, "<b>Unable to start [name].</b> [SSmapping.configs[GROUND_MAP].map_name] is blacklisted on [name], likely because it doesn't support it.")
+		to_chat(world, "<b>Unable to start [name].</b> [SSmapping.configs[GROUND_MAP].map_name] isn't supported on [name].")
 		// start a gamemode vote, in theory this should never happen.
 		addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), "gamemode", "SERVER"), 10 SECONDS)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

Gamemodes cant start on maps with a blacklisted ground map (without bypass)
Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/18433

## Why It's Good For The Game

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/18433

## Changelog
:cl:
fix: Gamemodes cant start on maps with a blacklisted ground map (without bypass)
/:cl:
