### PR TITLE
Robots/synths take burn damage per zombium

### DIFF
--- a/code/__DEFINES/zombie.dm
+++ b/code/__DEFINES/zombie.dm
@@ -6,7 +6,7 @@
 #define ZOMBIE_STRUCTURE_DETECTION_RANGE 15
 ///Defender spawn amount
 #define ZOMBIE_DEFENDER_AMOUNT 13
-///Determines how much burn damage cringe robots and synths should take per zombium
-#define ZOMBIUM_ROBOT_EFFECT_MULTIPLIER 1.5
+///Determines how much burn damage robots and synths should take per zombium
+#define ZOMBIUM_ROBOT_EFFECT_MULTIPLIER 1
 ///Spawner threatened spawning limit
 #define ZOMBIE_THREATENED_CAP 125

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -133,7 +133,7 @@
 		return
 	if(!claw.zombium_per_hit)
 		return
-	if(isrobot(src) || issynth(src))
+	if(species.species_flags & NO_CHEM_METABOLIZATION)
 		apply_damage(modify_by_armor(claw.zombium_per_hit * ZOMBIUM_ROBOT_EFFECT_MULTIPLIER, BIO, 0, zombie.get_limbzone_target()), BURN, zombie.get_limbzone_target())//Zombium is corrosive to machines
 	else
 		reagents.add_reagent(/datum/reagent/zombium, modify_by_armor(claw.zombium_per_hit, BIO, 0, zombie.get_limbzone_target()))


### PR DESCRIPTION
## About The Pull Request

Robots/synths take burn damage per zombium, this could be justified as zombium being corrosive to machinery

## Why It's Good For The Game

- With no random stuns their major weakness that they are more likely to get stunlocked is gone
- Boomers are still completely ineffective against them
- Robots take less damage than humans because they aren't effected by zombium
- Robots still don't have to worry about how much zombium is ticking through their system, they just have the up front damage
- Robots still have the advantage of not having to go through dialysis in order to be revived, meaning they can be revived in the field
- Picking robot in the zombie mode is cringe

## Changelog
:cl:
balance: Robots/synths take burn damage per zombium
/:cl:
