### PR TITLE
Zombies can unbuckle themselves (zombies are now woke)

### DIFF
--- a/code/modules/ai/ai_behaviors/xeno/zombie.dm
+++ b/code/modules/ai/ai_behaviors/xeno/zombie.dm
@@ -16,11 +16,10 @@
 
 /datum/ai_behavior/xeno/zombie/process()
 	. = ..()
-	var/mob/living/living_parent = mob_parent
-	if(living_parent.buckled)
-		living_parent.buckled.unbuckle_mob(living_parent)
-	if(living_parent.resting)
-		living_parent.get_up()
+	if(mob_parent.buckled)
+		mob_parent.buckled.unbuckle_mob(mob_parent)
+	if(mob_parent.resting)
+		mob_parent.get_up()
 
 /datum/ai_behavior/xeno/zombie/melee_interact(datum/source, atom/interactee, melee_tool)
 	melee_tool = mob_parent.r_hand ? mob_parent.r_hand : mob_parent.l_hand


### PR DESCRIPTION

## About The Pull Request

Zombies can unbuckle themselves

## Why It's Good For The Game

No more sleepy bed time for zombies
<img width="672" height="457" alt="image" src="https://github.com/user-attachments/assets/fe08b5df-1172-4804-88e0-d385fe4a9860" />

## Changelog
:cl:
fix: Zombies can unbuckle themselves
/:cl:
