### PR TITLE
Survival gamemode

### DIFF
--- a/code/datums/gamemodes/survival.dm
+++ b/code/datums/gamemodes/survival.dm
@@ -29,8 +29,8 @@
 /datum/game_mode/survival/process()
 	. = ..()
 
-	if(world.time > last_larva_check + larva_check_interval)
-		last_larva_check = world.time
+	if(world.time > last_balance_check + balance_check_interval)
+		last_balance_check = world.time
 		balance_scales()
 
 
@@ -45,9 +45,6 @@
 		new /obj/effect/ai_node/spawner/zombie(i)
 	addtimer(CALLBACK(src, PROC_REF(balance_scales)), 1 SECONDS)
 	RegisterSignal(SSdcs, COMSIG_GLOB_ZOMBIE_TUNNEL_DESTROYED, PROC_REF(check_finished))
-
-/datum/game_mode/survival/on_nuke_started(datum/source, obj/machinery/nuclearbomb/nuke)
-	return
 
 ///Counts humans and zombies not in valhalla
 /datum/game_mode/survival/proc/count_humans_and_zombies(list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_GROUND, ZTRAIT_RESERVED)), count_flags)
@@ -103,7 +100,6 @@
 	title = "Mission classification: TOP SECRET",
 	type = ANNOUNCEMENT_PRIORITY,
 	color_override = "red")
-	playsound(shuttle, 'sound/machines/warning-buzzer.ogg', 75, 0, 30)
 	balance_scales()
 
 /datum/game_mode/survival/end_round_fluff()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -604,6 +604,7 @@
 #include "code\datums\gamemodes\objective.dm"
 #include "code\datums\gamemodes\objective_items.dm"
 #include "code\datums\gamemodes\sensor_capture.dm"
+#include "code\datums\gamemodes\survival.dm"
 #include "code\datums\gamemodes\zombie_crash.dm"
 #include "code\datums\gamemodes\campaign\campaign_assets.dm"
 #include "code\datums\gamemodes\campaign\campaign_mission.dm"


### PR DESCRIPTION
## About The Pull Request

**Survival gamemode**
Like call of duty zombies, no sentient zombies, all marines start with a pistol and a jaegar suit, each map will have a loadout vendor, cloths vendor, armor vendor with no modules, so they can drip themselves out cosmetically. There will be a 5 minute grace period at the start of the game. Marines will have to last 1.5 hours until the crash shuttle comes to rescue them. There will be only generic survivors and the synth, but survivors can purchase skill perks, with a perk limit of 4

- Miners give every marine passive points income. 
- No zombies will have BAS or mats to account for balance.
- Special zombies have a chance to drop power ups. 
- Walls aren't build-able
- Survivors cant strip/be stripped

**Rounds**
Every x minutes (increasing in length) the round ends, zombies despawn and ghosts can respawn
Every 5 rounds a xeno round will happen, instead of zombies spawning, AI xenos will spawn, a ammo Resupply powerup will spawn at the end of the round
At the end of each round every ghost can respawn
There will be a 3 minute grace period at the end of each round
At the end of each round zombies health increases
Every 5 rounds the zombie to human ratio increases

**Spawning**
Start at 5 zombies per person to a max of 10
No sentients

**Spending points**
Vendors and miners have set spawn positions, but which vendor/miner spawns where is random, vendors and miners have a shared pool of spawn locations
Wall weapons have random spawns too but their spawn position pool is seperate

- Sentry vendor
- Module vendor
- Attachment vendor
- Materials vendor
- Medical vendors
- Pack a punch
- Machinery vendor - dispenses machines like cryo tubes, sleepers, generators
- Wall weapons - survivors can purchase a set weapon from a wall, likely the standard marine weapons, you can also buy a ammo box if you already have the weapon
- Loot crate - gambling for req weapons, volkite guns, emplacements (rare), the mystery box disappears after x uses and changes location

**Powerups**

- Fire sale - Every mystery box location becomes active with less cost
- Resupply - Ammo boxes drop for everyone's weapons, the amount of ammo in each box is divided by the amount of weapons on the player
- Bonus cash - Each survivor gets some money
- Instant kill - Each zombie temporarily has 1 health
- Double points
- Nuke - Every zombie is permad, every survivor gains x points (not scaling)

**Perks**
Perk limit of 4. Players lose all perks upon death, except tombstone

- 1000 - Engineer perk (gives engineer skill)
- 1000 - Medical perk (gives medical skill)
- 3000 - Hale (+30 health)
- 3000 - Zombium resistance (25% less zombium per hit)
- 4000 - Marathon - (30% more stamina, carbon exclusive)
- 3000 - Sprinter - (20% faster, 50% less stamina, carbon exclusive)
- 4000 - Boosted servos - (10% faster, silicon exclusive)
- 2000 - Tombstone - (Keep all weapons and armor for one respawn)
- 3000 - Second wind - (Revives upon death, healing all damage, purges zombium, gives 40 clone damage, robots lose a leg)
- 1500 - Lightning Fingers - No reload duration for weapons like lmgs, reload whole bunches of shells at once

## Why It's Good For The Game
Everyone likes cod zombies
Chill gamemode for lowpop
Unlimited reqslop

## Changelog
:cl:
add: Survival gamemode
/:cl:
