### PR TITLE
Fixes Pounce not showing up for Runners and Hunters

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -319,6 +319,7 @@
 	var/leap_pass_flags = PASS_LOW_STRUCTURE|PASS_FIRE|PASS_XENO
 
 /datum/action/ability/activable/xeno/pounce/New(Target)
+	. = ..()
 	desc = "Leap at your target up to [HUNTER_POUNCE_RANGE] tiles away, stunning them for [XENO_POUNCE_STUN_DURATION / (1 SECONDS)] seconds."
 
 /datum/action/ability/activable/xeno/pounce/on_cooldown_finish()


### PR DESCRIPTION
## About The Pull Request
Fixes an issue caused by #18465, where Runners and Hunters would no longer get their Pounce ability.
https://github.com/tgstation/TerraGov-Marine-Corps/blob/7c24aeab9430776666a009f0621b41bea259ba3f/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm#L321-L322
`New()` was no longer calling parent, which caused issues.

## Why It's Good For The Game
can i skip this section for bug fixes yet
bug fix good

## Changelog
:cl: Lewdcifer
fix: Runners and Hunters should get their Pounce ability again.
/:cl:
