### PR TITLE
Fuel component fixes

### DIFF
--- a/code/datums/components/fuel_component.dm
+++ b/code/datums/components/fuel_component.dm
@@ -46,8 +46,9 @@
 ///Attempts to refuel something
 /datum/component/fuel_storage/proc/attempt_refuel(obj/source, obj/item/attacking, mob/user)
 	SIGNAL_HANDLER
-	if(!fuel_tank.total_volume)
-		user?.balloon_alert(user, "no fuel!")
+	if(user.a_intent == INTENT_HARM)
+		return
+	if(!attacking.reagents)
 		return
 	attacking.try_refuel(parent, fuel_type, user)
 	return COMPONENT_NO_AFTERATTACK
@@ -75,10 +76,13 @@
 
 ///Checks if src can be refueled by a container
 /obj/proc/can_refuel(atom/refueler, fuel_type, mob/user)
+	if(!refueler.reagents.total_volume)
+		user?.balloon_alert(user, "no fuel!")
+		return
 	if(fuel_type != get_fueltype())
 		user?.balloon_alert(user, "wrong fuel")
 		return FALSE
-	if(reagents?.total_volume == reagents?.maximum_volume)
+	if(reagents.total_volume == reagents.maximum_volume)
 		user?.balloon_alert(user, "full")
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Fixes #18493
You can actually hit fuel tank type objects.
No 'full' balloon alerts if non harm intent hitting said objects with something that doesn't actually take fuel.
## Why It's Good For The Game
Bug fixes
## Changelog
:cl:
fix: fixed not being able to hit fuel tanks
fix: fixed some unneeded fuel tank balloon alerts
/:cl:
