### PR TITLE
chair layer improvement

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -19,6 +19,7 @@
 	buckle_lying = 0
 	buckling_y = 0
 	max_integrity = 20
+	layer = BELOW_TABLE_LAYER
 	var/propelled = 0 //Check for fire-extinguisher-driven chairs
 
 //directional variants mostly used for random spawners
@@ -48,7 +49,7 @@
 	if(LAZYLEN(buckled_mobs) && dir == NORTH)
 		layer = FLY_LAYER
 	else
-		layer = OBJ_LAYER
+		layer = initial(layer)
 
 
 /obj/structure/bed/chair/post_buckle_mob(mob/buckling_mob)


### PR DESCRIPTION

## About The Pull Request
Chairs now are at the same layer as tables, instead of the object layer.

<img width="443" height="426" alt="image" src="https://github.com/user-attachments/assets/ffdc549f-ac89-43dc-a1fc-5e70f4db7e4e" />
## Why It's Good For The Game
Being on the object layer means chairs layer over objects. Some chairs have large sprites than can completely hide objects under them. In particular, the APC has a massive problem with this.
## Changelog
:cl:
qol: chairs layer under objects
/:cl:
