### PR TITLE
liguana turret crate fix

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -406,7 +406,7 @@
 	name = "\improper Light UV Machinegun Crate"
 	desc = "A crate containing a light unmanned vehicle machinegun and some spare ammo."
 
-/obj/structure/closet/crate/uav_crate/light_turret/PopulateContents()
+/obj/structure/closet/crate/uav_crate/turret/PopulateContents()
 	new /obj/item/uav_turret(src)
 	new /obj/item/ammo_magazine/box11x35mm(src)
 	new /obj/item/ammo_magazine/box11x35mm(src)


### PR DESCRIPTION

## About The Pull Request
Fixed the 'light UV machinegun' crate just being an actual UV crate.
Fixes #18508
## Why It's Good For The Game
bug fix
## Changelog
:cl:
fix: fixed the UV machinegun option in the engineer vendor having the incorrect contents
/:cl:
