### PR TITLE
ASL radio fix

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -294,9 +294,10 @@
 			var/datum/job/J = squad_leader.job
 			squad_leader.comm_title = J.comm_title
 		if(istype(squad_leader.wear_ear, /obj/item/radio/headset/mainship/marine))
-			var/obj/item/radio/headset/mainship/marine/R = squad_leader.wear_ear
-			R.recalculateChannels()
-			R.use_command = FALSE
+			var/obj/item/radio/headset/mainship/marine/headset = squad_leader.wear_ear
+			headset.squad_leader = FALSE
+			headset.use_command = FALSE
+			headset.recalculateChannels()
 		var/obj/item/card/id/ID = squad_leader.get_idcard()
 		if(istype(ID))
 			ID.access -= list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_TADPOLE)
@@ -328,11 +329,10 @@
 			ID.access += list(ACCESS_MARINE_LEADER, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_TADPOLE)
 
 	if(istype(squad_leader.wear_ear, /obj/item/radio/headset/mainship/marine))
-		var/obj/item/radio/headset/mainship/marine/R = squad_leader.wear_ear
-		R.channels[RADIO_CHANNEL_COMMAND] = TRUE
-		R.secure_radio_connections[RADIO_CHANNEL_COMMAND] = add_radio(R, GLOB.radiochannels[RADIO_CHANNEL_COMMAND])
-		R.use_command = TRUE
-
+		var/obj/item/radio/headset/mainship/marine/headset = squad_leader.wear_ear
+		headset.squad_leader = TRUE
+		headset.use_command = TRUE
+		headset.recalculateChannels()
 	squad_leader.hud_set_job(faction)
 	squad_leader.update_inv_head()
 	squad_leader.update_inv_wear_suit()

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -450,6 +450,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/mainship/marine
 	keyslot = /obj/item/encryptionkey/general
+	///Is designated as the squad leader, ensures correct radio channels
+	var/squad_leader = FALSE
 
 /obj/item/radio/headset/mainship/marine/Initialize(mapload, datum/squad/squad, rank)
 	if(squad)
@@ -472,6 +474,12 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			keyslot2 = /obj/item/encryptionkey/med
 		name = dat + " radio headset"
 	return ..()
+
+/obj/item/radio/headset/mainship/marine/recalculateChannels()
+	. = ..()
+	if(squad_leader)
+		channels[RADIO_CHANNEL_COMMAND] = TRUE
+		secure_radio_connections[RADIO_CHANNEL_COMMAND] = add_radio(src, GLOB.radiochannels[RADIO_CHANNEL_COMMAND])
 
 /obj/item/radio/headset/mainship/marine/alpha
 	name = "marine alpha radio headset"


### PR DESCRIPTION

## About The Pull Request
Fixes #18414 

Setting a squad leader now sets an actual var on their headset and sets radio channels internally instead of in squad code, avoiding ASL channel access breaking from the 500 different scenarios that trigger channel recalc.
## Why It's Good For The Game
Bug fix
## Changelog
:cl:
fix: Command radio access from ASL is no longer lost when unequipping or swapping radio keys
/:cl:
