### PR TITLE
Removes TGUI compatibility mode

### DIFF
--- a/code/modules/admin/verbs/poll_managment.dm
+++ b/code/modules/admin/verbs/poll_managment.dm
@@ -229,8 +229,7 @@
 					output += "<hr style='background:#000000; border:0; height:3px'>"
 	var/datum/browser/panel = new(usr, "pmpanel", "Poll Management Panel", 780, 640)
 	panel.add_stylesheet("admin_panelscss", 'html/browser/admin_panels.css')
-	if(usr.client.prefs.tgui_fancy) //some browsers (IE8) have trouble with unsupported css3 elements that break the panel's functionality, so we won't load those if a user is in no frills tgui mode since that's for similar compatability support
-		panel.add_stylesheet("admin_panelscss3", 'html/browser/admin_panels_css3.css')
+	panel.add_stylesheet("admin_panelscss3", 'html/browser/admin_panels_css3.css')
 	panel.set_content(jointext(output, ""))
 	panel.open()
 
@@ -527,8 +526,7 @@
 		panel_height = 320
 	var/datum/browser/panel = new(usr, "popanel", "Poll Option Panel", 370, panel_height)
 	panel.add_stylesheet("admin_panelscss", 'html/browser/admin_panels.css')
-	if(usr.client.prefs.tgui_fancy) //some browsers (IE8) have trouble with unsupported css3 elements that break the panel's functionality, so we won't load those if a user is in no frills tgui mode since that's for similar compatability support
-		panel.add_stylesheet("admin_panelscss3", 'html/browser/admin_panels_css3.css')
+	panel.add_stylesheet("admin_panelscss3", 'html/browser/admin_panels_css3.css')
 	panel.set_content(jointext(output, ""))
 	panel.open()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/ui_style = "Midnight"
 	var/ui_style_color = "#ffffff"
 	var/ui_style_alpha = 230
-	var/tgui_fancy = TRUE
 	var/tgui_lock = FALSE
 	var/ui_scale = TRUE
 	var/tgui_input = TRUE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -201,7 +201,6 @@
 	READ_FILE(S["see_rc_emotes"], see_rc_emotes)
 
 	// Tgui options
-	READ_FILE(S["tgui_fancy"], tgui_fancy)
 	READ_FILE(S["tgui_lock"], tgui_lock)
 	READ_FILE(S["ui_scale"], ui_scale)
 	READ_FILE(S["tgui_input"], tgui_input)
@@ -275,9 +274,8 @@
 	see_chat_non_mob = sanitize_integer(see_chat_non_mob, FALSE, TRUE, initial(see_chat_non_mob))
 	see_rc_emotes = sanitize_integer(see_rc_emotes, FALSE, TRUE, initial(see_rc_emotes))
 
-	tgui_fancy = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_fancy))
-	tgui_lock = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_lock))
-	ui_scale = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_lock))
+	tgui_lock = sanitize_integer(tgui_lock, FALSE, TRUE, initial(tgui_lock))
+	ui_scale = sanitize_integer(ui_scale, FALSE, TRUE, initial(ui_scale))
 	tgui_input = sanitize_integer(tgui_input, FALSE, TRUE, initial(tgui_input))
 	tgui_input_big_buttons = sanitize_integer(tgui_input_big_buttons, FALSE, TRUE, initial(tgui_input_big_buttons))
 	tgui_input_buttons_swap = sanitize_integer(tgui_input_buttons_swap, FALSE, TRUE, initial(tgui_input_buttons_swap))
@@ -358,9 +356,8 @@
 	see_chat_non_mob = sanitize_integer(see_chat_non_mob, FALSE, TRUE, initial(see_chat_non_mob))
 	see_rc_emotes = sanitize_integer(see_rc_emotes, FALSE, TRUE, initial(see_rc_emotes))
 
-	tgui_fancy = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_fancy))
-	tgui_lock = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_lock))
-	ui_scale = sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_lock))
+	tgui_lock = sanitize_integer(tgui_lock, FALSE, TRUE, initial(tgui_lock))
+	ui_scale = sanitize_integer(ui_scale, FALSE, TRUE, initial(ui_scale))
 	tgui_input = sanitize_integer(tgui_input, FALSE, TRUE, initial(tgui_input))
 	tgui_input_big_buttons = sanitize_integer(tgui_input_big_buttons, FALSE, TRUE, initial(tgui_input_big_buttons))
 	tgui_input_buttons_swap = sanitize_integer(tgui_input_buttons_swap, FALSE, TRUE, initial(tgui_input_buttons_swap))
@@ -426,7 +423,6 @@
 	WRITE_FILE(S["see_rc_emotes"], see_rc_emotes)
 
 	// Tgui options
-	WRITE_FILE(S["tgui_fancy"], tgui_fancy)
 	WRITE_FILE(S["tgui_lock"], tgui_lock)
 	WRITE_FILE(S["ui_scale"], ui_scale)
 	WRITE_FILE(S["tgui_input"], tgui_input)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -230,13 +230,3 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 	TOGGLE_BITFIELD(prefs.toggles_deadchat, DISABLE_DEATHRATTLE)
 	to_chat(usr, span_notice("Death announcements have been [(prefs.toggles_deadchat & DISABLE_DEATHRATTLE) ? "disabled" : "enabled"]."))
-
-///Same thing as the character creator preference, but as a byond verb, because not everyone can reach it in tgui preference menu
-/client/verb/toggle_tgui_fancy()
-	set name = "Toggle TGUI Window Compability Mode"
-	set category = "Preferences"
-
-	usr.client.prefs.tgui_fancy = !usr.client.prefs.tgui_fancy
-	usr.client.prefs.save_preferences()
-	SStgui.update_user_uis(usr)
-	to_chat(src, span_interface("TGUI compatibility mode is now [usr.client.prefs.tgui_fancy ? "dis" : "en"]abled."))

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -130,7 +130,6 @@
 			data["radio_tts_flags"] = radio_tts_flags
 			data["accessible_tgui_themes"] = accessible_tgui_themes
 			data["allow_being_shown_health_scan"] = allow_being_shown_health_scan
-			data["tgui_fancy"] = tgui_fancy
 			data["tgui_lock"] = tgui_lock
 			data["ui_scale"] = ui_scale
 			data["tgui_input"] = tgui_input
@@ -706,9 +705,6 @@
 
 		if("allow_being_shown_health_scan")
 			allow_being_shown_health_scan = !allow_being_shown_health_scan
-
-		if("tgui_fancy")
-			tgui_fancy = !tgui_fancy
 
 		if("tgui_lock")
 			tgui_lock = !tgui_lock

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -54,7 +54,7 @@
  */
 /datum/tgui/New(mob/user, datum/src_object, interface, title, ui_x, ui_y)
 	log_tgui(user,
-		"new [interface] fancy [user?.client?.prefs.tgui_fancy]",
+		"new [interface]",
 		src_object = src_object)
 	src.user = user
 	src.src_object = src_object
@@ -95,7 +95,6 @@
 	if(!window.is_ready())
 		window.initialize(
 			strict_mode = TRUE,
-			fancy = user.client.prefs.tgui_fancy,
 			assets = list(
 				get_asset_datum(/datum/asset/simple/tgui),
 			))
@@ -237,7 +236,6 @@
 		"window" = list(
 			"key" = window_key,
 			"size" = window_size,
-			"fancy" = user.client.prefs.tgui_fancy,
 			"locked" = user.client.prefs.tgui_lock,
 			"scale" = user.client.prefs.ui_scale,
 		),

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -51,7 +51,6 @@
  * will be put into the queue until the window finishes loading.
  *
  * optional strict_mode bool - Enables strict error handling and BSOD.
- * optional fancy bool - If TRUE and if this is NOT a panel, will hide the window titlebar.
  * optional assets list - List of assets to load during initialization.
  * optional inline_html string - Custom HTML to inject.
  * optional inline_js string - Custom JS to inject.
@@ -59,7 +58,6 @@
  */
 /datum/tgui_window/proc/initialize(
 		strict_mode = FALSE,
-		fancy = FALSE,
 		assets = list(),
 		inline_html = "",
 		inline_js = "",
@@ -69,7 +67,6 @@
 		window = src)
 	if(!client)
 		return
-	src.initial_fancy = fancy
 	src.initial_assets = assets
 	src.initial_inline_html = inline_html
 	src.initial_inline_js = inline_js
@@ -77,12 +74,7 @@
 	status = TGUI_WINDOW_LOADING
 	fatally_errored = FALSE
 	// Build window options
-	var/options = "file=[id].html;can_minimize=0;auto_format=0;"
-	// Remove titlebar and resize handles for a fancy window
-	if(fancy)
-		options += "titlebar=0;can_resize=0;"
-	else
-		options += "titlebar=1;can_resize=1;"
+	var/options = "file=[id].html;can_minimize=0;auto_format=0;titlebar=0;can_resize=0;"
 	// Generate page html
 	var/html = SStgui.basehtml
 	html = replacetextEx(html, "\[tgui:windowId]", id)
@@ -129,7 +121,6 @@
 /datum/tgui_window/proc/reinitialize()
 	initialize(
 		strict_mode = initial_strict_mode,
-		fancy = initial_fancy,
 		assets = initial_assets,
 		inline_html = initial_inline_html,
 		inline_js = initial_inline_js,

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -2,8 +2,7 @@
  * Creates a TGUI window with a number input. Returns the user's response as num | null.
  *
  * This proc should be used to create windows for number entry that the caller will wait for a response from.
- * If tgui fancy chat is turned off: Will return a normal input. If a max or min value is specified, will
- * validate the input inside the UI and ui_act.
+ * If a max or min value is specified, will validate the input inside the UI and ui_act.
  *
  * Arguments:
  * * user - The user to show the number input to.

--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -50,7 +50,6 @@
 	sleep(3 SECONDS)
 	window.initialize(
 			strict_mode = TRUE,
-			fancy = TRUE,
 			inline_css = file("tgui/public/tgui-say.bundle.css"),
 			inline_js = file("tgui/public/tgui-say.bundle.js"),
 	);

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -2,8 +2,7 @@
  * Creates a TGUI window with a text input. Returns the user's response.
  *
  * This proc should be used to create windows for text entry that the caller will wait for a response from.
- * If tgui fancy chat is turned off: Will return a normal input. If max_length is specified, will return
- * stripped_multiline_input.
+ * If max_length is specified, will return stripped_multiline_input.
  *
  * Arguments:
  * * user - The user to show the text input to.

--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -79,7 +79,6 @@
 					"computer_id" = client.computer_id,
 				),
 				"window" = list(
-					"fancy" = FALSE,
 					"locked" = FALSE,
 				),
 			),

--- a/tgui/docs/tgui-for-custom-html-popups.md
+++ b/tgui/docs/tgui-for-custom-html-popups.md
@@ -39,17 +39,13 @@ TGUI in /tg/station codebase has `/datum/asset`, that packs scripts and styleshe
 
 ```dm
 window.initialize(
-  fancy = user.client.prefs.read_preference(
-    /datum/preference/toggle/tgui_fancy
-  ),
   assets = list(
     get_asset_datum(/datum/asset/simple/tgui),
   ))
 ```
 
-You can see two new arguments:
+You can see new arguments:
 
-- `fancy` - See [Fancy mode](#fancy-mode)
 - `assets` - This is a list of asset datums, and all JS and CSS in the assets will be loaded in the page.
 
 Using asset datums has a big benefit over including `<script>` and `<link>` in normal html popups; If your asset is not available for any reason at the moment (e.g. network is down or packet loss), tgui window will retry loading those assets multiple times.
@@ -92,16 +88,6 @@ window.initialize(
 ```
 
 If you need to inline multiple JS or CSS files, you can concatenate them for now, and separate contents of each file with an `\n` symbol. *This can be a point of improvement (add support for file lists)*.
-
-## Fancy mode
-
-You may have noticed the fancy mode in previous snippets:
-
-```dm
-window.initialize(fancy = TRUE)
-```
-
-This removes the native window titlebar and border, which effectively turns window into a floating panel. TGUI heavily uses this option to draw completely custom, fancy windows. You can use it too, but not having the default titlebar limits usability of the browser window, since you can't even close it or drag around without implementing that functionality yourself. This mode might be useful for creating popups and tooltips.
 
 ## Communication
 

--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -172,7 +172,6 @@ export const backendReducer = (state = initialState, action) => {
 };
 
 export const backendMiddleware = (store) => {
-  let fancyState;
   let suspendInterval;
 
   return (next) => (action) => {
@@ -213,23 +212,6 @@ export const backendMiddleware = (store) => {
         'is-visible': false,
       });
       setTimeout(() => focusMap());
-    }
-
-    if (type === 'backend/update') {
-      const fancy = payload.config?.window?.fancy;
-      // Initialize fancy state
-      if (fancyState === undefined) {
-        fancyState = fancy;
-      }
-      // React to changes in fancy
-      else if (fancyState !== fancy) {
-        logger.log('changing fancy mode to', fancy);
-        fancyState = fancy;
-        Byond.winset(Byond.windowId, {
-          titlebar: !fancy,
-          'can-resize': !fancy,
-        });
-      }
     }
 
     // Resume on incoming update
@@ -348,10 +330,8 @@ const chunkSplitter = {
  */
 export const sendAct = (action: string, payload: object = {}) => {
   // Validate that payload is an object
-  // prettier-ignore
-  const isObject = typeof payload === 'object'
-    && payload !== null
-    && !Array.isArray(payload);
+  const isObject =
+    typeof payload === 'object' && payload !== null && !Array.isArray(payload);
   if (!isObject) {
     logger.error(`Payload for act() must be an object, got this:`, payload);
     return;
@@ -396,7 +376,6 @@ type BackendState<TData> = {
     window: {
       key: string;
       size: [number, number];
-      fancy: BooleanLike;
       locked: BooleanLike;
       scale: BooleanLike;
     };

--- a/tgui/packages/tgui/drag.ts
+++ b/tgui/packages/tgui/drag.ts
@@ -117,14 +117,13 @@ const storeWindowGeometry = async () => {
 // Recall window geometry from local storage and apply it
 export const recallWindowGeometry = async (
   options: {
-    fancy?: BooleanLike;
     pos?: [number, number];
     size?: [number, number];
     locked?: BooleanLike;
     scale?: BooleanLike;
   } = {},
 ) => {
-  const geometry = options.fancy && (await storage.get(windowKey));
+  const geometry = await storage.get(windowKey);
   if (geometry) {
     logger.log('recalled geometry:', geometry);
   }

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/GameSettings.tsx
@@ -197,13 +197,6 @@ export const GameSettings = (props) => {
                 tooltip="How many Multi-Z levels are rendered before they start getting culled. Decrease this to improve performance in case of lag on multi-z maps."
               />
               <ToggleFieldPreference
-                label="TGUI Window Mode"
-                value="tgui_fancy"
-                action="tgui_fancy"
-                leftLabel={'Fancy (default)'}
-                rightLabel={'Compatible (slower)'}
-              />
-              <ToggleFieldPreference
                 label="TGUI Window Placement"
                 value="tgui_lock"
                 action="tgui_lock"

--- a/tgui/packages/tgui/layouts/TitleBar.tsx
+++ b/tgui/packages/tgui/layouts/TitleBar.tsx
@@ -11,7 +11,6 @@ type TitleBarProps = Partial<{
   className: string;
   title: string;
   status: number;
-  fancy: BooleanLike;
   canClose: BooleanLike;
   onClose: (e) => void;
   onDragStart: (e) => void;
@@ -31,16 +30,8 @@ function statusToColor(status: number): string {
 }
 
 export function TitleBar(props: TitleBarProps) {
-  const {
-    className,
-    title,
-    status,
-    canClose,
-    fancy,
-    onDragStart,
-    onClose,
-    children,
-  } = props;
+  const { className, title, status, canClose, onDragStart, onClose, children } =
+    props;
   const dispatch = globalStore.dispatch;
 
   const finalTitle =
@@ -53,7 +44,7 @@ export function TitleBar(props: TitleBarProps) {
     <div className={classes(['TitleBar', className])}>
       <div
         className="TitleBar__dragZone"
-        onMouseDown={(e) => fancy && onDragStart && onDragStart(e)}
+        onMouseDown={(e) => onDragStart?.(e)}
       />
       {status === undefined ? (
         <Icon className="TitleBar__statusIcon" name="tools" opacity={0.5} />
@@ -73,7 +64,7 @@ export function TitleBar(props: TitleBarProps) {
           onClick={() => dispatch(toggleKitchenSink())}
         />
       )}
-      {Boolean(fancy && canClose) && (
+      {!!canClose && (
         <div className="TitleBar__close" onClick={onClose}>
           <Icon className="TitleBar__close--icon" name="times" />
         </div>

--- a/tgui/packages/tgui/layouts/Window.tsx
+++ b/tgui/packages/tgui/layouts/Window.tsx
@@ -104,7 +104,6 @@ export const Window = (props: Props) => {
   }, [isReadyToRender, width, height, scale]);
 
   const dispatch = globalStore.dispatch;
-  const fancy = config.window?.fancy;
 
   // Determine when to show dimmer
   const showDimmer =
@@ -118,7 +117,6 @@ export const Window = (props: Props) => {
       <TitleBar
         title={title || decodeHtmlEntities(config.title)}
         status={config.status}
-        fancy={fancy}
         onDragStart={dragStartHandler}
         onClose={() => {
           logger.log('pressed close');
@@ -132,22 +130,18 @@ export const Window = (props: Props) => {
         {!suspended && children}
         {showDimmer && <div className="Window__dimmer" />}
       </div>
-      {fancy && (
-        <>
-          <div
-            className="Window__resizeHandle__e"
-            onMouseDown={resizeStartHandler(1, 0) as any}
-          />
-          <div
-            className="Window__resizeHandle__s"
-            onMouseDown={resizeStartHandler(0, 1) as any}
-          />
-          <div
-            className="Window__resizeHandle__se"
-            onMouseDown={resizeStartHandler(1, 1) as any}
-          />
-        </>
-      )}
+      <div
+        className="Window__resizeHandle__e"
+        onMouseDown={resizeStartHandler(1, 0) as any}
+      />
+      <div
+        className="Window__resizeHandle__s"
+        onMouseDown={resizeStartHandler(0, 1) as any}
+      />
+      <div
+        className="Window__resizeHandle__se"
+        onMouseDown={resizeStartHandler(1, 1) as any}
+      />
     </Layout>
   );
 };


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/pull/94389

This option's existence causes more problems than it solves and hasn't been needed for years—IE8 (what it was originally added for) is long gone.

Also, the saving/loading sanitization for `tgui_lock` and `ui_scale` seemed fucked up, so I fixed that while I was here.
## Changelog
:cl:
del: TGUI compatibility mode has been removed.
/:cl:
