### PR TITLE
Changes how zombie spawn types are calculated

### DIFF
--- a/code/controllers/subsystem/spawning.dm
+++ b/code/controllers/subsystem/spawning.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(spawning)
  * Arguments:
  * * spawner: atom to be registered
  * * delaytime: time in byond ticks between respawns dont make this lower than SS wait or perish
- * * spawntypes: can be both a list as well as a specific type for the spawner to spawn
+ * * spawntypes: can be a list, list of lists or a specific type for the spawner to spawn
  * * postspawn: Callback to be invoked on the spawned squad, use for equipping and such
  */
 /datum/controller/subsystem/spawning/proc/registerspawner(atom/spawner, delaytime = 30 SECONDS, spawntypes, maxmobs = 10, spawnamount = 1, datum/callback/postspawn)

--- a/code/modules/ai/spawners/spawner.dm
+++ b/code/modules/ai/spawners/spawner.dm
@@ -1,7 +1,6 @@
 /obj/effect/ai_node/spawner
 	name = "AI spawner node"
 	invisibility = INVISIBILITY_OBSERVER
-	///typepath or list of typepaths for the spawner to pick from, include weights of spawn_types for proper picking out
 	/**
 	 * Possible spawn typepaths
 	 * Can support a single typepath, a list of typepaths, or a list of lists

--- a/code/modules/ai/spawners/zombie.dm
+++ b/code/modules/ai/spawners/zombie.dm
@@ -19,8 +19,9 @@
 	spawnamount = 2
 	spawndelay = 15 SECONDS
 	maxamount = 50
+	///Currently is considered under threat
 	var/threat_warning = FALSE
-
+	///proxy sensor holder
 	var/datum/proximity_monitor/proximity_monitor
 	COOLDOWN_DECLARE(proxy_alert_cooldown)
 	COOLDOWN_DECLARE(defender_spawn_cooldown)


### PR DESCRIPTION
## About The Pull Request
Changes how spawners work to support nested lists to better manage scenarios where you want a fixed probability of a group of options, while still making it easy to tweak the probabilities inside said group.
i.e. common/uncommon/rare spawns etc.

Zombies now have a 95% common spawn chance, and a 5% for special spawns.
## Why It's Good For The Game
Easier to manage code.
## Changelog
:cl:
code: Spawners support lists of lists for spawntypes
/:cl:
