### PR TITLE
Damaging a human's limb transfers target to the chest if there is no limb

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -510,8 +510,8 @@
 		def_zone = ran_zone(def_zone)
 	if(!organ)
 		organ = victim.get_limb(check_zone(def_zone))
-	if(!organ)
-		return FALSE
+	if(!organ || (organ.limb_status & LIMB_DESTROYED))
+		organ = victim.get_limb("chest")
 
 	if(isnum(blocked))
 		damage -= clamp(damage * (blocked - penetration) * 0.01, 0, damage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Damaging a human's limb transfers target to the chest if there is no limb (due to it being destroyed/amputated), previously this caused all damage to be lost

## Why It's Good For The Game

Some people view this as a bug. Many people only aim chest because targeting a limb, destroying it and then dealing 0 damage to the human thereafter is annoying. Opens up more interesting gameplay people dont have to worry they're dealing 0 damage because they chose to interact with a system after successfully destroying a limb

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
fix: Damaging a human's limb transfers target to the chest if there is no limb 
/:cl:
