### PR TITLE
God mode visual fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -196,7 +196,6 @@
 	if(!. || QDELING(src)) // For godmode / if they got gibbed via update_stat.
 		return
 	med_hud_set_health() // Todo: Make all damage update health so we can just kill pointless life updates entirely.
-	update_wounds()
 
 /mob/living/carbon/xenomorph/handle_slowdown()
 	if(slowdown)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -105,6 +105,8 @@
 /mob/living/carbon/xenomorph/proc/update_wounds()
 	if(QDELETED(src))
 		return
+	if(status_flags & GODMODE)
+		return //we'll incorrectly lose any wound overlays due to how godmode sets your 'health'
 
 	remove_overlay(WOUND_LAYER)
 	remove_filter("wounded_filter")


### PR DESCRIPTION

## About The Pull Request
Godmode no longer makes xenos appear at full hp due to no wound overlays.

Deleted a redundant proc call also.
## Why It's Good For The Game
Bug fix
## Changelog
:cl:
fix: Godmode xenos won't show as full hp when they're not
/:cl:
