### PR TITLE
Move silo back in the crashed syndicate shuttle on icy caves

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -23683,8 +23683,8 @@ ZP
 Mr
 tf
 hH
-iP
 xt
+iP
 tf
 SR
 SR


### PR DESCRIPTION

## About The Pull Request

Move silo back in the crashed syndicate shuttle on icy caves

Before:
<img width="590" height="609" alt="image" src="https://github.com/user-attachments/assets/407d8424-9b5f-4697-a0a5-3bdca8162c5c" />

After:
<img width="602" height="569" alt="image" src="https://github.com/user-attachments/assets/00b0c3ec-1993-482f-881f-ee039a1a0e7b" />

## Why It's Good For The Game

Better pathing for zombies, before they spawn in the corner and stay clumped up due to them being in the corner, should help them be less bunched up

## Changelog
:cl:
add: Move silo back in the crashed syndicate shuttle on icy caves
/:cl:
