### PR TITLE
Add recommended pop for maps to the groundmap vote like how it is in the admin panel

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -290,7 +290,24 @@ SUBSYSTEM_DEF(vote)
 							continue
 						if(VM.config_min_users && players < VM.config_min_users)
 							continue
-					maps += VM.map_name
+
+					var/mapname = VM.map_name
+
+					if(VM.config_min_users > 0 || VM.config_max_users > 0)
+						mapname += " \["
+						if(VM.config_min_users > 0)
+							mapname += "[VM.config_min_users]"
+						else
+							mapname += "0"
+						mapname += "-"
+						if(VM.config_max_users > 0)
+							mapname += "[VM.config_max_users]"
+						else
+							mapname += "inf"
+						mapname += "\]"
+
+					maps += mapname
+
 					shuffle_choices = TRUE
 				for(var/valid_map in maps)
 					choices.Add(valid_map)


### PR DESCRIPTION
## About The Pull Request

Add recommended pop for maps to the groundmap vote like how it is in the admin panel

<img width="388" height="204" alt="image" src="https://github.com/user-attachments/assets/fd492b6c-6d2d-4521-bee4-94ab64146d2d" />


## Why It's Good For The Game
- More info is good
- Good for newer players
- I've played a lot but even still sometimes I forget how big each map is, this is especially important for zombie crash this determines how many zombie spawners there are

## Changelog
:cl:
add: Adds recommended pop for maps to the groundmap vote like how it is in the admin panel
/:cl:
