### PR TITLE
Remove flashbang effect from ammo cookoff

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -219,7 +219,7 @@
 /obj/item/ammo_magazine/fire_act(burn_level)
 	if(!current_rounds)
 		return
-	explosion(loc, 0, 0, 0, 1, 1, throw_range = FALSE, tiny = TRUE, explosion_cause="ammo mag cookoff")
+	explosion(loc, 0, 0, 0, 1, 0, throw_range = FALSE, tiny = TRUE, explosion_cause="ammo mag cookoff")
 	qdel(src)
 
 //Helper proc, to allow us to see a percentage of how full the magazine is.
@@ -498,7 +498,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 /obj/item/big_ammo_box/fire_act(burn_level)
 	if(!bullet_amount)
 		return
-	explosion(loc, 0, 0, 1, 0, 2, throw_range = FALSE, explosion_cause="ammo box cookoff") //blow it up.
+	explosion(loc, 0, 0, 1, 0, 0, throw_range = FALSE, explosion_cause="ammo box cookoff") //blow it up.
 	qdel(src)
 
 //Deployable shotgun ammo box


### PR DESCRIPTION

## About The Pull Request

Remove flashbang effect from ammo cookoff

## Why It's Good For The Game

It's annoying

## Changelog
:cl:
del: Remove flashbang effect from ammo cookoff
/:cl:
