### PR TITLE
Fix crash map AI nodes pathing for zombie disc rallys

### DIFF
--- a/_maps/map_files/Blue_Moon/bluemoon.dmm
+++ b/_maps/map_files/Blue_Moon/bluemoon.dmm
@@ -15340,6 +15340,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/bluemoon/outside/building/admin)
 "rMc" = (
@@ -37637,7 +37638,7 @@ eya
 qft
 xyx
 gbZ
-gbZ
+xMQ
 uzA
 qft
 dMF
@@ -37784,7 +37785,7 @@ vVJ
 qft
 jlK
 gbZ
-xMQ
+gbZ
 lID
 asA
 aKG
@@ -37931,7 +37932,7 @@ rjG
 qft
 kdU
 gbZ
-gbZ
+xMQ
 iwU
 asA
 qZY

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -38,6 +38,7 @@
 /area/orion_outpost/ground/outpostsw)
 "av" = (
 /obj/effect/landmark/corpsespawner/marine,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/orion_outpost/surface/building/medbay)
 "ax" = (
@@ -1287,6 +1288,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
+"gu" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/administration)
 "gw" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -4868,6 +4874,14 @@
 "xF" = (
 /turf/open/floor/mainship/terragov/north,
 /area/orion_outpost/surface/building/administration)
+"xG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/orion_outpost/surface/building/nebuilding)
 "xH" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7417,6 +7431,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/orion_outpost/surface/building/tadpolepad)
+"Kl" = (
+/obj/effect/spawner/random/misc/structure/supplycrate/normalweighted,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/concrete,
+/area/orion_outpost/surface/building/tadpolepad)
 "Km" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
@@ -8028,6 +8047,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/administration)
 "Nd" = (
@@ -14890,7 +14910,7 @@ Fj
 mt
 mo
 vl
-zC
+gu
 zC
 Kr
 Zv
@@ -15808,7 +15828,7 @@ RU
 oz
 oz
 Ly
-pj
+hu
 AO
 pj
 DX
@@ -19357,7 +19377,7 @@ dF
 rt
 dF
 rt
-dc
+qR
 dc
 nW
 rt
@@ -20017,7 +20037,7 @@ kq
 mp
 fa
 fy
-Fl
+aR
 Su
 Su
 Fl
@@ -21733,13 +21753,13 @@ OD
 OD
 OD
 Vm
-OD
-sd
+xG
+mI
 Wr
 mI
 mI
 mI
-mI
+sd
 ul
 fv
 mI
@@ -23375,11 +23395,11 @@ oq
 TD
 uB
 Xl
-qT
+dn
 qT
 HP
 AM
-SB
+Kl
 Pl
 AM
 SB

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -5222,6 +5222,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison/darkred/corners,
 /area/prison/security/checkpoint/maxsec_highsec)
 "arO" = (
@@ -5392,16 +5393,15 @@
 /area/prison/security/checkpoint/maxsec_highsec)
 "asm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/prison/cellblock/highsec/north/north)
+/obj/effect/ai_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "asn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /obj/structure/disposalpipe/segment{
@@ -5669,6 +5669,7 @@
 /turf/open/floor/prison/darkred,
 /area/prison/security/checkpoint/maxsec_highsec)
 "asV" = (
+/obj/effect/ai_node,
 /turf/open/floor/prison/darkred{
 	dir = 6
 	},
@@ -24947,6 +24948,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -25070,6 +25072,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison/red/full,
 /area/prison/security/checkpoint/highsec/s)
 "bCj" = (
@@ -27092,6 +27095,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
@@ -33232,6 +33236,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/security/head)
 "ceH" = (
@@ -39902,6 +39907,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security)
 "elG" = (
@@ -75989,7 +75995,7 @@ aom
 ars
 atT
 avP
-asm
+ads
 asX
 aty
 acG
@@ -80425,8 +80431,8 @@ pTN
 pTN
 bqO
 pTN
-aFj
 pTN
+aFj
 pTN
 pTN
 brh
@@ -92157,7 +92163,7 @@ afJ
 ahe
 hTd
 ahH
-aiV
+asm
 agq
 aiv
 afM

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -2047,6 +2047,11 @@
 	dir = 8
 	},
 /area/outpost/yard/east)
+"jN" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "jO" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -2562,6 +2567,7 @@
 /obj/structure/bed/chair/office{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "lY" = (
@@ -6392,6 +6398,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/spawner/random/engineering/powercell,
+/obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "Ee" = (
@@ -10941,6 +10948,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 5
 	},
@@ -24685,8 +24693,8 @@ DX
 QK
 wz
 wz
-wz
 yj
+wz
 Cn
 wz
 wz
@@ -25081,8 +25089,8 @@ cR
 Ed
 xY
 fE
-MG
 eE
+MG
 MU
 MG
 CU
@@ -25478,7 +25486,7 @@ ob
 MG
 Bz
 lX
-eE
+MG
 JG
 MG
 MG
@@ -26005,8 +26013,8 @@ hK
 wQ
 hK
 hK
-IH
-wQ
+jN
+hK
 yW
 yW
 yW

--- a/_maps/map_files/desparity/desparity.dmm
+++ b/_maps/map_files/desparity/desparity.dmm
@@ -4252,6 +4252,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/corpsespawner/security/regular,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/lv624/lazarus/security)
 "vW" = (
@@ -8630,6 +8631,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/lv624/lazarus/security)
 "RS" = (

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -3520,6 +3520,7 @@
 "rU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "rV" = (
@@ -9014,6 +9015,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"RY" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "RZ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
@@ -15970,7 +15975,7 @@ fw
 DY
 DY
 DY
-DY
+RY
 DY
 Rf
 wQ


### PR DESCRIPTION
## About The Pull Request

Adjusts crash map AI nodes, so that zombies path to nuke discs better. I've found that zombie hordes only path to discs with AI nodes that are exactly horizontal/vertical/diagonal to the disc generator

## Why It's Good For The Game

Better, more consistent pathing

## Changelog
:cl:
fix: Adjusts crash map AI nodes, so that zombies path to nuke discs better
/:cl:
