### PR TITLE
Legacy PowerShell fix

### DIFF
--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -33,7 +33,7 @@ function Verify-Node {
 	Write-Output "Verifying Node checksum"
 	$FileHash = Get-FileHash $NodeTarget -Algorithm SHA256
 	$ActualSha = $FileHash.Hash
-	$LoginResponse = Invoke-WebRequest "https://nodejs.org/download/release/v$NodeVersion/SHASUMS256.txt"
+	$LoginResponse = Invoke-WebRequest "https://nodejs.org/download/release/v$NodeVersion/SHASUMS256.txt" -UseBasicParsing
 	$ShaArray = $LoginResponse.Content.split("`n")
 	foreach ($ShaArrayEntry in $ShaArray) {
 		$EntrySplit = $ShaArrayEntry -split "\s+"


### PR DESCRIPTION
# About the Pull Request
[PowerShell `5.1`: Invoke-WebRequest: Preventing script execution from web content](https://support.microsoft.com/en-us/topic/powershell-5-1-invoke-webrequest-preventing-script-execution-from-web-content-7cb95559-655e-43fd-a8bd-ceef2406b705)

Adds the `-UseBasicParsing` switch when verifying the Node checksum in `node_.ps1`.

This has no effect on modern PowerShell (>=`6.0.0`) as basic parsing is the default behavior on modern PowerShell, but this improves support for legacy PowerShell and allows users who recently (~2 months) updated Windows to compile without this prompt:
<img width="1012" height="187" alt="image" src="https://github.com/user-attachments/assets/e92b95c8-39f6-4212-a196-d31e8e25f4a9" />

# Changelog
No player-facing changes.
