### PR TITLE
fixes rogue space tiles in the TGMC airfield map

### DIFF
--- a/_maps/map_files/Campaign maps/tgmc_airfield/tgmc_airfield.dmm
+++ b/_maps/map_files/Campaign maps/tgmc_airfield/tgmc_airfield.dmm
@@ -8346,11 +8346,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue,
 /area/campaign/tgmc_airfield/base/barracks/mess_hall)
-"St" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/open/floor/plating/plating_catwalk,
-/area/campaign/tgmc_airfield/outside/airstrip_south)
 "Sv" = (
 /obj/effect/turf_decal/sandedge/corner{
 	dir = 4
@@ -8921,7 +8916,7 @@
 "Vg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating/ground/desertdam/asphalt,
 /area/campaign/tgmc_airfield/outside/airstrip_south)
 "Vi" = (
 /obj/structure/cable,
@@ -23966,8 +23961,8 @@ ga
 Ly
 Vg
 Vg
-St
-St
+Vg
+Vg
 um
 GJ
 WI


### PR DESCRIPTION
## About The Pull Request

<img width="240" height="457" alt="image" src="https://github.com/user-attachments/assets/376399f3-86f8-43b3-87bf-3d0820a2122f" />
i put ground here so that its not just outer space

## Why It's Good For The Game

h978yfgdsh9augdshguasiohyvfsdakihtojin gqedubg 3rqemhgibhnjadfs

## Changelog

:cl: Joe13413
fix: replaced rogue space tiles in tgmc airfield map
/:cl:
