### PR TITLE
[Synth] Adds dispenser backpack to equipment vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -650,6 +650,7 @@ GLOBAL_LIST_INIT(synthetic_clothes_listed_products, list(
 		/obj/item/storage/backpack/lightpack = list(CAT_BAK, "Lightweight combat pack", 0, "black"),
 		/obj/item/storage/backpack/marine/satchel/officer_cloak = list(CAT_BAK, "Officer cloak", 0, "black"),
 		/obj/item/storage/backpack/marine/satchel/officer_cloak_red = list(CAT_BAK, "Officer cloak, red", 0, "black"),
+		/obj/item/storage/backpack/dispenser = list(CAT_BAK, "Dispenser", 0, "black"),
 		/obj/item/armor_module/storage/uniform/webbing = list(CAT_WEB, "Webbing", 0, "black"),
 		/obj/item/armor_module/storage/uniform/black_vest = list(CAT_WEB, "Tactical Black Vest", 0, "black"),
 		/obj/item/armor_module/storage/uniform/white_vest = list(CAT_WEB, "White medical vest", 0, "black"),


### PR DESCRIPTION
## About The Pull Request
Adds the dispenser backpack to the synth equipment/loadout vendor (currently available in the engineer equipment vendor). No new items or mechanics are introduced; it's simply extending access to an existing tool that's fitting for synths given their support role in engineering

The dispenser backpack offers a crazy huge storage capacity for materials, but requires deployment to access its contents preventing it from being OP as mobile inventory. Its has the ability of healing/repairing synths and robots, making it a specialized stationary support option.

## Why It's Good For The Game
-Adds Player Choice: Gives synths another backpack option in their vendor, allowing them to choose the dispenser for its massive material storage/utility during builds or repairs. Diversifies loadouts without forcing it as a must-pick..
-Balanced Extension: The enormous capacity is gated by deployment, so no inventory or combat overpowering. The synth/robot repair feature is niche and thematic, maintaining synths' support focus.

## Changelog
:cl:
add: Added TX-9000 DISPENSER backpack to synth clothing vendor
/:cl: