### PR TITLE
Dreamchecker fixes

### DIFF
--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -281,7 +281,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	var/cells_on_x_axis = src.cells_on_x_axis
 
 	//technically THIS list only contains lists, but inside those lists are grid cell datums and we can go without a SINGLE var init if we do this
-	var/list/datum/spatial_grid_cell/grid_level = grids_by_z_level[center_turf.z]
+	var/list/list/datum/spatial_grid_cell/grid_level = grids_by_z_level[center_turf.z]
 	switch(type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 			for(var/row in BOUNDING_BOX_MIN(center_y) to BOUNDING_BOX_MAX(center_y, cells_on_y_axis))

--- a/code/modules/vehicles/__vehicle.dm
+++ b/code/modules/vehicles/__vehicle.dm
@@ -37,7 +37,7 @@
 	///assoc list "[bitflag]" = list(typepaths)
 	var/list/autogrant_actions_controller
 	///assoc list mob = list(type = action datum assigned to mob)
-	var/list/mob/occupant_actions
+	var/list/list/mob/occupant_actions
 	///This vehicle will follow us when we move (like atrailer duh)
 	var/obj/vehicle/trailer
 	var/are_legs_exposed = FALSE


### PR DESCRIPTION
# About The Pull Request
These decorations don't make any difference in BYOND functionality (in fact, BYOND is likely not bothering with typechecking here—this is just vaguely functional because of the langserver reading the type annotations and telling people when they are fucking up), but it lets the langserver know that we are using datum vars under these special lists.