### PR TITLE
[s] Fixes HTML injection on carbon copies

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -37,7 +37,7 @@
 
 	if (copied == 0)
 		var/obj/item/paper/carbon/c = src
-		var/copycontents = html_decode(c.info)
+		var/copycontents = c.info
 		var/obj/item/paper/carbon/copy = new /obj/item/paper/carbon (usr.loc)
 		copycontents = replacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
 		copycontents = replacetext(copycontents, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.


### PR DESCRIPTION

## About The Pull Request

Fixes HTML begin decoded and possibly injected into game clients using carbon copies

## Why It's Good For The Game

This has been exploited downstream, was told to bring up upstream.

## Changelog
:cl:
fix: fixed HTML Injection with carbon copies
/:cl:
