### PR TITLE
Remove crash prebuilt cades

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -288,9 +288,6 @@
 	id = "port_umbilical_outer";
 	name = "outer door-control"
 	},
-/obj/structure/barricade/folding{
-	dir = 8
-	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "bj" = (
@@ -420,11 +417,6 @@
 /obj/machinery/door_control{
 	id = "starboard_umbilical_outer";
 	name = "outer door-control"
-	},
-/obj/structure/barricade/folding{
-	dir = 4;
-	is_wired = 1;
-	linked = 1
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
@@ -571,16 +563,7 @@
 /obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
-"gv" = (
-/obj/structure/barricade/folding,
-/turf/open/floor/mainship/stripesquare,
-/area/shuttle/canterbury)
 "hc" = (
-/obj/structure/barricade/folding{
-	dir = 4;
-	is_wired = 1;
-	linked = 1
-	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "iy" = (
@@ -679,12 +662,6 @@
 /obj/machinery/vending/weapon/crash,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
-"pY" = (
-/obj/structure/barricade/folding{
-	dir = 8
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/shuttle/canterbury)
 "qh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/large_stack,
@@ -701,6 +678,9 @@
 /obj/item/storage/box/crate/sentry,
 /obj/item/storage/box/crate/sentry,
 /obj/item/storage/box/crate/sentry,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/stack/sheet/plasteel/small_stack,
+/obj/item/stack/sheet/plasteel/small_stack,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "qE" = (
@@ -1110,7 +1090,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Xb" = (
-/obj/structure/barricade/folding,
 /obj/machinery/door_control{
 	dir = 8;
 	id = "aft_engine_podlock"
@@ -1222,9 +1201,9 @@ Ui
 ac
 ab
 bi
-pY
-pY
-pY
+hc
+hc
+hc
 ab
 aS
 TE
@@ -1404,7 +1383,7 @@ Yn
 qE
 XO
 ac
-gv
+hc
 bW
 Uo
 "}
@@ -1437,7 +1416,7 @@ ac
 ac
 ac
 ac
-gv
+hc
 bW
 Uo
 "}
@@ -1470,7 +1449,7 @@ an
 an
 an
 an
-gv
+hc
 bW
 Uo
 "}
@@ -1503,7 +1482,7 @@ ac
 ac
 ac
 ac
-gv
+hc
 bW
 Uo
 "}

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -140,6 +140,7 @@
 /obj/item/tool/wrench,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/tool/screwdriver,
+/obj/item/stack/sheet/plasteel/large_stack,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aw" = (
@@ -180,9 +181,6 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aA" = (
-/obj/structure/barricade/folding{
-	dir = 8
-	},
 /turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "aB" = (
@@ -201,12 +199,6 @@
 /area/shuttle/canterbury/medical)
 "aD" = (
 /turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
-"aF" = (
-/obj/structure/barricade/folding{
-	dir = 4
-	},
-/turf/open/floor/mainship/stripesquare,
 /area/shuttle/canterbury)
 "aH" = (
 /obj/machinery/door/poddoor/mainship{
@@ -702,18 +694,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/barricade/folding,
 /obj/machinery/air_alarm{
 	dir = 4
 	},
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
-"cZ" = (
-/obj/structure/barricade/folding,
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury)
 "da" = (
-/obj/structure/barricade/folding,
 /obj/machinery/door_control{
 	dir = 8;
 	id = "aft_engine_podlock"
@@ -1003,7 +989,7 @@ aJ
 aJ
 aJ
 aJ
-cZ
+aD
 co
 "}
 (9,1,1) = {"
@@ -1104,9 +1090,9 @@ aa
 aa
 an
 ay
-aF
-aF
-aF
+aA
+aA
+aA
 an
 bp
 bq


### PR DESCRIPTION
## About The Pull Request

Removed the prebuilt folding plasteel cades on 2 crash ships, and added material stacks to compensate. Gonna do the same with widebury after it merges.

**Canterbury**
Removed 9 folding cades (45 plasteel)
Added 1 large plasteel stack (50 plasteel)

**Bigbury**
Removed 13 folding cades (65 plasteel)
Added 1 large, 2 small plasteel stacks (70 plasteel)

## Why It's Good For The Game

<img width="889" height="101" alt="image" src="https://github.com/user-attachments/assets/a99c63c5-6bc4-49bd-992b-49232f852a32" />
.

Now that marine quick build is here, we can finally get rid of the prebuilt cades and the tedium that comes with disassembling them during pre landing setup.

## Changelog

:cl: Scav
del: Removed the prebuilt folding cades on all crash ships
add: Added extra materials to compensate
/:cl:
