### PR TITLE
Remove default place hologram and select buildtype keybindings

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -223,11 +223,9 @@
 	full_name = "Place Hologram"
 	description = "Place a holographic template of a structure"
 	keybind_signal = COMSIG_ABILITY_PLACE_HOLOGRAM
-	hotkey_keys = list("E")
 
 /datum/keybinding/human/select_buildtype
 	name = "select_buildtype"
 	full_name = "Select Buildtype"
 	description = "Select the structure to use when using Place Hologram"
 	keybind_signal = COMSIG_ABILITY_SELECT_BUILDTYPE
-	hotkey_keys = list("Q")


### PR DESCRIPTION

## About The Pull Request

Read the title

## Why It's Good For The Game

Reason 1: These binds conflict with the most common actions, Drop Item and Quick Equip. Who even thought it was a good idea to use them on E and Q?
Reason 1.2: These binds only confuse new players; regular players likely have their own binds.
Reason 1.3 - WHY THIS STUPID THING CAME OUT WHEN I TRY TO DROP MY AMMO BOX???
Reason 2 (not entirely sure if this applies to this topic?) - Because of how keybinds work, and in particular MAX_COMMANDS_PER_KEY, they are more likely to break existing keybinds. For example, currently, the spitter's spit on Q doesn't work with the default keybinds. Without Drop Item and Quick Equip, the spit works. Other abilities on Q seem to still be broken, though. I'm not entirely sure how this works...

## Changelog
:cl:
del: Remove default place hologram and select buildtype keybindings
/:cl:
