### PR TITLE
Moves ice colony's underground disk further south

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -13139,6 +13139,7 @@
 	},
 /area/ice_colony/underground/security/interrogation)
 "bFc" = (
+/obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/dark/red2{
 	dir = 10
 	},
@@ -23088,10 +23089,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/bar)
-"kgh" = (
-/obj/structure/nuke_disk_candidate,
-/turf/open/floor/plating,
-/area/ice_colony/underground/engineering/substation)
 "kgl" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment/corner{
@@ -56141,7 +56138,7 @@ bsh
 rKs
 buH
 buj
-kgh
+buj
 btz
 bpm
 bYY


### PR DESCRIPTION

## About The Pull Request

Disk is the last one on 90% of games, the rest of the map is omega marine sided, so moving it further south should make the fight harder for marines and gives xenos a bit more leeway.
<img width="266" height="709" alt="imagen" src="https://github.com/user-attachments/assets/798f258d-3301-4d66-aaa1-0e06be86c9a0" />
Moved from red dot to green dot, nuke is unchanged.
## Why It's Good For The Game

Marines need to push 5 meters into a 10 tiles room where the disk and apc are 6 steps away, tad can park RIGHT ABOVE IT and screen away there is a miner, cmon bro you can push a bit further than that.

The rest of the map is otherwise unused in normal games because the only time marines walk down that hallway is when xenos already ate shit and are collapsing

## Changelog

:cl:
balance: Moved ice colony's last disk further south.
/:cl:
