### PR TITLE
remove +25 plasma cost tax on Hivelord's Secrete Resin

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -61,7 +61,6 @@
 // *********** Resin building
 // ***************************************
 /datum/action/ability/activable/xeno/secrete_resin/hivelord
-	ability_cost = 25
 	buildable_structures = list(
 		/turf/closed/wall/resin/regenerating/thick,
 		/obj/alien/resin/sticky,


### PR DESCRIPTION

## About The Pull Request
Removes Hivelord's additional +25 plasma cost for building anything with Secrete Resin.

This aligns Hivelord's building costs with all other builder castes from/for:
- Sticky Resin: 50 -> 25
- Thick Resin Wall: 100 -> 75
- Thick Resin Door: 75-> 50

## Why It's Good For The Game
I have no idea why Hivelord uniquely has a tax on their building costs. Widow and Hivemind don't have the tax despite having additional range just like Hivelord (along with thick walls/doors in Widow's case).

If you ignore plasma regeneration and only focus on their plasma capacity limit, Drones can build more than Hivelord:
- Drone: 14 walls OR 20 doors OR 40 sticky resin (based on 1000 plasma)
- Hivelord: 12 walls OR 16 doors OR 24 sticky resin (based on 1200 plasma with the +25 flat tax)

I think it is odd that the caste who is suppose to be good at building is not actually that good at building.

## Changelog
:cl:
balance: Hivelord's Secrete Resin no longer has an additional +25 plasma cost (compared to all other building castes).
/:cl:
