### PR TITLE
Fixes extra disk spawn on ice colony

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -13139,7 +13139,6 @@
 	},
 /area/ice_colony/underground/security/interrogation)
 "bFc" = (
-/obj/structure/nuke_disk_candidate,
 /turf/open/floor/tile/dark/red2{
 	dir = 10
 	},


### PR DESCRIPTION

## About The Pull Request

Makes the disk location on the south facility the one it should be (it had an extra SOMEHOW, I SWEAR I CHECKED BRO)
The disk location is set here
<img width="599" height="375" alt="imagen" src="https://github.com/user-attachments/assets/69a8ab83-d323-4297-af38-5155e4deb16a" />
Green dot is the proper disk location
## Why It's Good For The Game

Weird bug fix (probably an error on my end)

## Changelog

:cl:
balance: The south facility new disk location gets an expansion.
fix: Deletes rogue disk location and some silly areas around the disk
/:cl:
