### PR TITLE
Autocannon buff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	return
 
 
-/datum/ammo/proc/drop_nade(turf/T)
+/datum/ammo/proc/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	return
 
 ///called on projectile process() when AMMO_SPECIAL_PROCESS flag is active

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -109,8 +109,8 @@
 /datum/ammo/energy/bfg/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	proj.proj_max_range -= 10
 
-/datum/ammo/energy/bfg/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 0, explosion_cause=src)
+/datum/ammo/energy/bfg/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 4, 0, 0, explosion_cause=src)
 
 /datum/ammo/energy/bfg/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
@@ -553,11 +553,11 @@
 	max_range = 30
 	hitscan_effect_icon = "beam_incen"
 
-/datum/ammo/energy/lasgun/marine/heavy_laser/drop_nade(turf/T, radius = 1)
-	if(!T || !isturf(T))
+/datum/ammo/energy/lasgun/marine/heavy_laser/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	if(!isturf(target_turf))
 		return
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
-	flame_radius(radius, T, 3, 3, 3, 3)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
+	flame_radius(1, target_turf, 3, 3, 3, 3)
 
 /datum/ammo/energy/lasgun/marine/heavy_laser/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_nade(get_turf(target_mob))
@@ -624,8 +624,8 @@
 	accurate_range = 5
 	max_range = 12
 
-/datum/ammo/energy/plasma/blast/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 3, color = COLOR_DISABLER_BLUE, explosion_cause=src)
+/datum/ammo/energy/plasma/blast/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, weak_impact_range = 3, color = COLOR_DISABLER_BLUE, explosion_cause=src)
 
 /datum/ammo/energy/plasma/blast/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
 	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
@@ -647,9 +647,9 @@
 	///Number of melting stacks to apply
 	var/melting_stacks = 2
 
-/datum/ammo/energy/plasma/blast/melting/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 4, color = COLOR_DISABLER_BLUE, explosion_cause=src)
-	for(var/mob/living/living_victim in viewers(3, T)) //normally using viewers wouldn't work due to darkness and smoke both blocking vision. However explosions clear both temporarily so we avoid this issue.
+/datum/ammo/energy/plasma/blast/melting/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, weak_impact_range = 4, color = COLOR_DISABLER_BLUE, explosion_cause=src)
+	for(var/mob/living/living_victim in viewers(3, target_turf)) //normally using viewers wouldn't work due to darkness and smoke both blocking vision. However explosions clear both temporarily so we avoid this issue.
 		var/datum/status_effect/stacking/melting/debuff = living_victim.has_status_effect(STATUS_EFFECT_MELTING)
 		if(debuff)
 			debuff.add_stacks(melting_stacks)
@@ -663,9 +663,9 @@
 	accurate_range = 9
 	ammo_behavior_flags = AMMO_ENERGY
 
-/datum/ammo/energy/plasma/blast/shatter/drop_nade(turf/T)
-	explosion(T, light_impact_range = 2, weak_impact_range = 5, throw_range = 0, color = COLOR_DISABLER_BLUE, explosion_cause=src)
-	for(var/mob/living/living_victim in viewers(3, T))
+/datum/ammo/energy/plasma/blast/shatter/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, light_impact_range = 2, weak_impact_range = 5, throw_range = 0, color = COLOR_DISABLER_BLUE, explosion_cause=src)
+	for(var/mob/living/living_victim in viewers(3, target_turf))
 		living_victim.apply_status_effect(STATUS_EFFECT_SHATTER, 5 SECONDS)
 
 /datum/ammo/energy/plasma/blast/incendiary
@@ -676,9 +676,9 @@
 	icon_state = "plasma_big"
 	hud_state = "flame"
 
-/datum/ammo/energy/plasma/blast/incendiary/drop_nade(turf/T)
-	flame_radius(2, T, burn_duration = 9, colour = "blue")
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
+/datum/ammo/energy/plasma/blast/incendiary/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	flame_radius(2, target_turf, burn_duration = 9, colour = "blue")
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
 #define PLASMA_CANNON_INNER_STAGGERSTUN_RANGE 3
 #define PLASMA_CANNON_STAGGERSTUN_RANGE 9

--- a/code/modules/projectiles/ammo_types/heavy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/heavy_ammo.dm
@@ -212,9 +212,12 @@
 	hud_state = "hivelo"
 	hud_state_empty = "hivelo_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 40
-	penetration = 45
-	sundering = 4
+	damage = 70
+	penetration = 35
+	sundering = 8
+
+/datum/ammo/bullet/tank_autocannon_ap/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
+	staggerstun(target_mob, proj, slowdown = 1)
 
 /datum/ammo/rocket/tank_autocannon_he
 	name = "autocannon high explosive"
@@ -222,16 +225,20 @@
 	hud_state = "hivelo_fire"
 	hud_state_empty = "hivelo_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	damage = 15
-	penetration = 20
+	armor_type = BOMB
+	damage = 10
+	penetration = 0
 	sundering = 0
+	airburst_multiplier = 2
+	shell_speed = 3
 
-/datum/ammo/rocket/tank_autocannon_he/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 2, tiny = TRUE)
+/datum/ammo/rocket/tank_autocannon_he/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	airburst(target_turf, proj)
+	explosion(target_turf, weak_impact_range = 2, tiny = TRUE)
 
 /datum/ammo/rocket/tank_autocannon_he/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	//this specifically doesn't knockback. Don't change the explosion above weak.
-	drop_nade(get_turf(target_mob))
+	drop_nade(get_turf(target_mob), proj)
 
 // SARDEN
 
@@ -254,8 +261,8 @@
 	sundering = 0.5
 	max_range = 21
 
-/datum/ammo/bullet/sarden/high_explosive/drop_nade(turf/T)
-	explosion(T, light_impact_range = 2, weak_impact_range = 4, explosion_cause=src)
+/datum/ammo/bullet/sarden/high_explosive/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, light_impact_range = 2, weak_impact_range = 4, explosion_cause=src)
 
 /datum/ammo/bullet/sarden/high_explosive/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)

--- a/code/modules/projectiles/ammo_types/mech_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mech_ammo.dm
@@ -34,16 +34,16 @@
 	max_range = 30
 	sundering = 15
 
-/datum/ammo/rocket/mech/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 0, explosion_cause=src)
+/datum/ammo/rocket/mech/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 4, 0, 0, explosion_cause=src)
 
 /datum/ammo/rocket/mech/heavy
 	name = "large heavy explosive rocket"
 	damage = 30
 	penetration = 30
 
-/datum/ammo/rocket/mech/heavy/drop_nade(turf/T)
-	explosion(T, 0, 2, 4, 0, 0, explosion_cause=src)
+/datum/ammo/rocket/mech/heavy/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 4, 0, 0, explosion_cause=src)
 
 /*
 //================================================

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -184,10 +184,10 @@
 	///radius this smoke will encompass
 	var/smokeradius = 1
 
-/datum/ammo/smoke_burst/drop_nade(turf/T)
+/datum/ammo/smoke_burst/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(smokeradius, T, rand(5,9))
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(smokeradius, target_turf, rand(5,9))
 	smoke.start()
 
 /datum/ammo/smoke_burst/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -230,9 +230,9 @@
 /datum/ammo/grenade_container/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
-/datum/ammo/grenade_container/drop_nade(turf/T)
-	var/obj/item/explosive/grenade/G = new nade_type(T)
-	G.visible_message(span_warning("\A [G] lands on [T]!"))
+/datum/ammo/grenade_container/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	var/obj/item/explosive/grenade/G = new nade_type(target_turf)
+	G.visible_message(span_warning("\A [G] lands on [target_turf]!"))
 	G.det_time = 10
 	G.activate()
 

--- a/code/modules/projectiles/ammo_types/mortar_ammo.dm
+++ b/code/modules/projectiles/ammo_types/mortar_ammo.dm
@@ -17,46 +17,46 @@
 	ping = null
 	bullet_color = COLOR_VERY_SOFT_YELLOW
 
-/datum/ammo/mortar/drop_nade(turf/T)
-	explosion(T, 1, 2, 5, 0, 3, explosion_cause=src)
+/datum/ammo/mortar/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 1, 2, 5, 0, 3, explosion_cause=src)
 
 /datum/ammo/mortar/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf)
 
-/datum/ammo/mortar/incend/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 7, throw_range = 0, explosion_cause=src)
-	flame_radius(4, T)
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
+/datum/ammo/mortar/incend/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 3, 0, 7, throw_range = 0, explosion_cause=src)
+	flame_radius(4, target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
 /datum/ammo/mortar/smoke
 	///the smoke effect at the point of detonation
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/tactical
 
-/datum/ammo/mortar/smoke/drop_nade(turf/T)
+/datum/ammo/mortar/smoke/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(10, T, 11)
+	explosion(target_turf, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(10, target_turf, 11)
 	smoke.start()
 
 /datum/ammo/mortar/smoke/plasmaloss
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss
 
-/datum/ammo/mortar/flare/drop_nade(turf/T)
-	new /obj/effect/temp_visual/above_flare(T)
-	playsound(T, 'sound/weapons/guns/fire/flare.ogg', 50, 1, 4)
+/datum/ammo/mortar/flare/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	new /obj/effect/temp_visual/above_flare(target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flare.ogg', 50, 1, 4)
 
 /datum/ammo/mortar/howi
 	name = "150mm shell"
 	icon_state = "howi"
 
-/datum/ammo/mortar/howi/drop_nade(turf/T)
-	explosion(T, 1, 6, 7, 0, 12, explosion_cause=src)
+/datum/ammo/mortar/howi/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 1, 6, 7, 0, 12, explosion_cause=src)
 
-/datum/ammo/mortar/howi/incend/drop_nade(turf/T)
-	explosion(T, 0, 3, 0, 0, 0, 3, throw_range = 0, explosion_cause=src)
-	flame_radius(5, T)
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
+/datum/ammo/mortar/howi/incend/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 0, 0, 0, 3, throw_range = 0, explosion_cause=src)
+	flame_radius(5, target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
 /datum/ammo/mortar/smoke/howi
 	name = "150mm shell"
@@ -65,23 +65,23 @@
 /datum/ammo/mortar/smoke/howi/wp
 	smoketype = /datum/effect_system/smoke_spread/phosphorus
 
-/datum/ammo/mortar/smoke/howi/wp/drop_nade(turf/T)
+/datum/ammo/mortar/smoke/howi/wp/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(6, T, 7)
+	explosion(target_turf, 0, 0, 1, 0, 0, throw_range = 0, explosion_cause=src)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(6, target_turf, 7)
 	smoke.start()
-	flame_radius(4, T)
-	flame_radius(1, T, burn_intensity = 75, burn_duration = 45, burn_damage = 15, fire_stacks = 75)
+	flame_radius(4, target_turf)
+	flame_radius(1, target_turf, burn_intensity = 75, burn_duration = 45, burn_damage = 15, fire_stacks = 75)
 
 /datum/ammo/mortar/smoke/howi/plasmaloss
 	smoketype = /datum/effect_system/smoke_spread/plasmaloss
 
-/datum/ammo/mortar/smoke/howi/plasmaloss/drop_nade(turf/T)
+/datum/ammo/mortar/smoke/howi/plasmaloss/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 5, 0, 0, throw_range = 0, explosion_cause=src)
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(10, T, 11)
+	explosion(target_turf, 0, 0, 5, 0, 0, throw_range = 0, explosion_cause=src)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(10, target_turf, 11)
 	smoke.start()
 
 /datum/ammo/mortar/rocket
@@ -89,49 +89,49 @@
 	icon_state = "rocket"
 	shell_speed = 1.5
 
-/datum/ammo/mortar/rocket/drop_nade(turf/T)
-	explosion(T, 1, 2, 5, 0, 3, explosion_cause=src)
+/datum/ammo/mortar/rocket/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 1, 2, 5, 0, 3, explosion_cause=src)
 
-/datum/ammo/mortar/rocket/incend/drop_nade(turf/T)
-	explosion(T, 0, 3, 0, 0, 3, throw_range = 0, explosion_cause=src)
-	flame_radius(5, T)
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
+/datum/ammo/mortar/rocket/incend/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 0, 0, 3, throw_range = 0, explosion_cause=src)
+	flame_radius(5, target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
-/datum/ammo/mortar/rocket/minelayer/drop_nade(turf/T)
-	var/obj/item/explosive/mine/mine = new /obj/item/explosive/mine(T)
+/datum/ammo/mortar/rocket/minelayer/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	var/obj/item/explosive/mine/mine = new /obj/item/explosive/mine(target_turf)
 	mine.deploy_mine(null, TGMC_LOYALIST_IFF)
 
 /datum/ammo/mortar/rocket/smoke
 	///the smoke effect at the point of detonation
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/tactical
 
-/datum/ammo/mortar/rocket/smoke/drop_nade(turf/T)
+/datum/ammo/mortar/rocket/smoke/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 1, 0, 3, throw_range = 0, explosion_cause=src)
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(10, T, 11)
+	explosion(target_turf, 0, 0, 1, 0, 3, throw_range = 0, explosion_cause=src)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(10, target_turf, 11)
 	smoke.start()
 
 /datum/ammo/mortar/rocket/mlrs
 	shell_speed = 2.5
 
-/datum/ammo/mortar/rocket/mlrs/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 2, explosion_cause=src)
+/datum/ammo/mortar/rocket/mlrs/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 4, 0, 2, explosion_cause=src)
 
-/datum/ammo/mortar/rocket/mlrs/incendiary/drop_nade(turf/T)
-	explosion(T, 0, 0, 2, 0, 2, explosion_cause=src)
-	flame_radius(3, T)
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
+/datum/ammo/mortar/rocket/mlrs/incendiary/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 2, 0, 2, explosion_cause=src)
+	flame_radius(3, target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 35, 1, 4)
 
 /datum/ammo/mortar/rocket/smoke/mlrs
 	shell_speed = 2.5
 	smoketype = /datum/effect_system/smoke_spread/mustard
 
-/datum/ammo/mortar/rocket/smoke/mlrs/drop_nade(turf/T)
+/datum/ammo/mortar/rocket/smoke/mlrs/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	explosion(T, 0, 0, 2, 0, 0, throw_range = 0, explosion_cause=src)
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(5, T, 6)
+	explosion(target_turf, 0, 0, 2, 0, 0, throw_range = 0, explosion_cause=src)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(5, target_turf, 6)
 	smoke.start()
 
 /datum/ammo/mortar/rocket/smoke/mlrs/cloak

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -24,22 +24,22 @@
 	bullet_color = LIGHT_COLOR_FIRE
 	barricade_clear_distance = 2
 
-/datum/ammo/rocket/drop_nade(turf/T)
-	explosion(T, 0, 4, 6, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 4, 6, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)
 	staggerstun(target_mob, proj, max_range, knockback = 1, hard_size_threshold = 3)
-	drop_nade(target_turf)
+	drop_nade(target_turf, proj)
 
 /datum/ammo/rocket/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
-	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_obj.loc, proj)
 
 /datum/ammo/rocket/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj)
 
 /datum/ammo/rocket/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj)
 
 /datum/ammo/rocket/he
 	name = "high explosive rocket"
@@ -55,8 +55,8 @@
 	damage = 100
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG // We want this one to specifically go over onscreen range.
 
-/datum/ammo/rocket/he/unguided/drop_nade(turf/T)
-	explosion(T, 0, 7, 0, 0, 2, throw_range = 4, explosion_cause=src)
+/datum/ammo/rocket/he/unguided/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 7, 0, 0, 2, throw_range = 4, explosion_cause = proj)
 
 /datum/ammo/rocket/ap
 	name = "kinetic penetrator"
@@ -67,8 +67,8 @@
 	penetration = 200
 	sundering = 0
 
-/datum/ammo/rocket/ap/drop_nade(turf/T)
-	explosion(T, flash_range = 1, explosion_cause=src)
+/datum/ammo/rocket/ap/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/ltb
 	name = "cannon round"
@@ -82,8 +82,8 @@
 	sundering = 20
 	barricade_clear_distance = 4
 
-/datum/ammo/rocket/ltb/drop_nade(turf/T)
-	explosion(T, 0, 2, 5, 0, 3, explosion_cause=src)
+/datum/ammo/rocket/ltb/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 5, 0, 3, explosion_cause = proj)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -94,8 +94,8 @@
 		staggerstun(target_mob, proj, max_range, knockback = 1, hard_size_threshold = 3)
 	drop_nade(target_turf)
 
-/datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf)
-	explosion(target_turf, 1, 4, 6, 0, 3, explosion_cause=src)
+/datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 1, 4, 6, 0, 3, explosion_cause = proj)
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"
@@ -110,8 +110,8 @@
 	accurate_range = 21
 	handful_amount = 1
 
-/datum/ammo/rocket/heavy_isg/drop_nade(turf/T)
-	explosion(T, 0, 7, 8, 12, explosion_cause=src)
+/datum/ammo/rocket/heavy_isg/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 7, 8, 12, explosion_cause = proj)
 
 /datum/ammo/rocket/heavy_isg/unguided
 	hud_state = "bigshell_he_unguided"
@@ -155,11 +155,11 @@
 	///The radius for the non explosion effects
 	var/effect_radius = 3
 
-/datum/ammo/rocket/wp/drop_nade(turf/T)
-	if(!T || !isturf(T))
+/datum/ammo/rocket/wp/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	if(!isturf(target_turf))
 		return
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
-	flame_radius(effect_radius, T, 27, 27, 27, 17)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
+	flame_radius(effect_radius, target_turf, 27, 27, 27, 17)
 
 /datum/ammo/rocket/wp/quad
 	name = "thermobaric rocket"
@@ -176,14 +176,14 @@
 /datum/ammo/rocket/wp/quad/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/phosphorus()
 
-/datum/ammo/rocket/wp/quad/drop_nade(turf/T)
+/datum/ammo/rocket/wp/quad/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	set_smoke()
-	smoke_system.set_up(effect_radius, T)
+	smoke_system.set_up(effect_radius, target_turf)
 	smoke_system.start()
 	smoke_system = null
-	T.visible_message(span_danger("The rocket explodes into white gas!") )
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
-	flame_radius(effect_radius, T, 27, 27, 27, 17)
+	target_turf.visible_message(span_danger("The rocket explodes into white gas!") )
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
+	flame_radius(effect_radius, target_turf, 27, 27, 27, 17)
 
 /datum/ammo/rocket/wp/quad/som
 	name = "white phosphorous RPG"
@@ -221,8 +221,8 @@
 	penetration = 50
 	sundering = 50
 
-/datum/ammo/rocket/recoilless/drop_nade(turf/T)
-	explosion(T, 0, 3, 4, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/recoilless/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 4, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/recoilless/heat
 	name = "HEAT shell"
@@ -233,8 +233,8 @@
 	penetration = 100
 	sundering = 0
 
-/datum/ammo/rocket/recoilless/heat/drop_nade(turf/T)
-	explosion(T, flash_range = 1, explosion_cause=src)
+/datum/ammo/rocket/recoilless/heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/recoilless/heat/mech //for anti mech use in HvH
 	name = "HEAM shell"
@@ -247,8 +247,8 @@
 	if(isvehicle(target_obj) || ishitbox(target_obj))
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
-/datum/ammo/rocket/recoilless/heat/mech/drop_nade(turf/T)
-	explosion(T, 0, 1, 0, 0, 1, explosion_cause=src)
+/datum/ammo/rocket/recoilless/heat/mech/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/recoilless/light
 	name = "light explosive shell"
@@ -261,8 +261,8 @@
 	penetration = 50
 	sundering = 25
 
-/datum/ammo/rocket/recoilless/light/drop_nade(turf/T)
-	explosion(T, 0, 1, 8, 0, 1, explosion_cause=src)
+/datum/ammo/rocket/recoilless/light/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 1, 8, 0, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/recoilless/chemical
 	name = "low velocity chemical shell"
@@ -279,12 +279,12 @@
 	/// Radius this smoke will encompass on detonation.
 	var/smokeradius = 7
 
-/datum/ammo/rocket/recoilless/chemical/drop_nade(turf/T)
+/datum/ammo/rocket/recoilless/chemical/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype()
-	playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-	smoke.set_up(smokeradius, T, rand(5,9))
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(smokeradius, target_turf, rand(5,9))
 	smoke.start()
-	explosion(T, flash_range = 1, explosion_cause=src)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/recoilless/chemical/cloak
 	name = "low velocity chemical shell"
@@ -315,8 +315,8 @@
 	penetration = 15
 	sundering = 25
 
-/datum/ammo/rocket/recoilless/low_impact/drop_nade(turf/T)
-	explosion(T, 0, 1, 8, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/recoilless/low_impact/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 1, 8, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/oneuse
 	name = "explosive rocket"
@@ -336,8 +336,8 @@
 	penetration = 20
 	sundering = 20
 
-/datum/ammo/rocket/som/drop_nade(turf/T)
-	explosion(T, 0, 3, 6, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/som/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 6, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/som/light
 	name = "low impact RPG"
@@ -348,8 +348,8 @@
 	damage = 60
 	penetration = 10
 
-/datum/ammo/rocket/som/light/drop_nade(turf/T)
-	explosion(T, 0, 2, 7, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/som/light/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 7, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/som/thermobaric
 	name = "thermobaric RPG"
@@ -357,8 +357,8 @@
 	hud_state = "rpg_thermobaric"
 	damage = 30
 
-/datum/ammo/rocket/som/thermobaric/drop_nade(turf/T)
-	explosion(T, 0, 4, 5, 0, 4, 4, explosion_cause=src)
+/datum/ammo/rocket/som/thermobaric/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj)
 
 /datum/ammo/rocket/som/heat //Anti tank, or mech
 	name = "HEAT RPG"
@@ -376,8 +376,8 @@
 	if(isvehicle(target_obj) || ishitbox(target_obj))
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
-/datum/ammo/rocket/som/heat/drop_nade(turf/T)
-	explosion(T, 0, 1, 0, 0, 1, explosion_cause=src)
+/datum/ammo/rocket/som/heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/som/rad
 	name = "irrad RPG"
@@ -394,15 +394,15 @@
 	///Range for the minimal rad effects
 	var/outer_range = 8
 
-/datum/ammo/rocket/som/rad/drop_nade(turf/T)
-	playsound(T, 'sound/effects/portal_opening.ogg', 50, 1)
-	for(var/mob/living/victim in hearers(outer_range, T))
+/datum/ammo/rocket/som/rad/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	playsound(target_turf, 'sound/effects/portal_opening.ogg', 50, 1)
+	for(var/mob/living/victim in hearers(outer_range, target_turf))
 		var/strength
 		var/sound_level
-		if(get_dist(victim, T) <= inner_range)
+		if(get_dist(victim, target_turf) <= inner_range)
 			strength = rad_strength
 			sound_level = 4
-		else if(get_dist(victim, T) <= mid_range)
+		else if(get_dist(victim, target_turf) <= mid_range)
 			strength = rad_strength * 0.7
 			sound_level = 3
 		else
@@ -412,7 +412,7 @@
 		strength = victim.modify_by_armor(strength, BIO, 25)
 		victim.apply_radiation(strength, sound_level)
 
-	explosion(T, weak_impact_range = 4, explosion_cause=src)
+	explosion(target_turf, weak_impact_range = 4, explosion_cause = proj)
 
 /datum/ammo/rocket/atgun_shell
 	name = "high explosive ballistic cap shell"
@@ -427,8 +427,8 @@
 	max_range = 30
 	handful_amount = 1
 
-/datum/ammo/rocket/atgun_shell/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/atgun_shell/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/atgun_shell/on_hit_turf(turf/target_turf, atom/movable/projectile/proj) //no explosion every time it hits a turf
 	proj.proj_max_range -= 10
@@ -442,8 +442,8 @@
 	penetration = 70
 	sundering = 25
 
-/datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/T)
-	explosion(T, flash_range = 1, explosion_cause=src)
+/datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -466,8 +466,8 @@
 	penetration = 50
 	sundering = 35
 
-/datum/ammo/rocket/atgun_shell/he/drop_nade(turf/T)
-	explosion(T, 0, 3, 5, explosion_cause=src)
+/datum/ammo/rocket/atgun_shell/he/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 5, explosion_cause = proj)
 
 /datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
@@ -484,8 +484,8 @@
 	bonus_projectiles_scatter = 8
 	var/bonus_projectile_quantity = 10
 
-/datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/T)
-	explosion(T, flash_range = 1, explosion_cause=src)
+/datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/turf/det_turf = get_step_towards(target_mob, proj)
@@ -559,8 +559,8 @@
 	///Number in degrees that the projectile will change during each process
 	var/turn_rate = 5
 
-/datum/ammo/rocket/homing/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 4, 1, explosion_cause=src)
+/datum/ammo/rocket/homing/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 3, 4, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/homing/ammo_process(atom/movable/projectile/proj, damage)
 	if(QDELETED(proj.original_target))
@@ -583,8 +583,8 @@
 	sundering = 5
 	turn_rate = 10
 
-/datum/ammo/rocket/homing/microrocket/drop_nade(turf/T)
-	explosion(T, 0, 0, 0, 4, 1, explosion_cause=src)
+/datum/ammo/rocket/homing/microrocket/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 0, 4, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/homing/microrocket/mech
 	name = "homing mech HE microrocket"
@@ -594,8 +594,8 @@
 	sundering = 3
 	turn_rate = 10
 
-/datum/ammo/rocket/homing/microrocket/mech/drop_nade(turf/T)
-	explosion(T, 0, 0, 0, 2, 1, explosion_cause=src)
+/datum/ammo/rocket/homing/microrocket/mech/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 0, 2, 1, explosion_cause = proj)
 
 /datum/ammo/rocket/homing/tow
 	name = "TOW-III missile"
@@ -608,8 +608,8 @@
 	sundering = 10
 	max_range = 30
 
-/datum/ammo/rocket/homing/tow/drop_nade(turf/T)
-	explosion(T, 0, 0, 4, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/homing/tow/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 4, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/coilgun
 	name = "kinetic penetrator"
@@ -629,8 +629,8 @@
 	bullet_color = LIGHT_COLOR_TUNGSTEN
 	barricade_clear_distance = 4
 
-/datum/ammo/rocket/coilgun/drop_nade(turf/T)
-	explosion(T, 0, 3, 5, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/coilgun/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 3, 5, 0, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/coilgun/holder //only used for tankside effect checks
 	ammo_behavior_flags = AMMO_ENERGY
@@ -641,8 +641,8 @@
 	penetration = 40
 	sundering = 5
 
-/datum/ammo/rocket/coilgun/low/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 4, explosion_cause=src)
+/datum/ammo/rocket/coilgun/low/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 3, 4, explosion_cause = proj)
 
 /datum/ammo/rocket/coilgun/high
 	damage_falloff = 0
@@ -652,8 +652,8 @@
 	sundering = 20
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG|AMMO_PASS_THROUGH_MOB
 
-/datum/ammo/rocket/coilgun/high/drop_nade(turf/T)
-	explosion(T, 1, 4, 5, 6, 2, explosion_cause=src)
+/datum/ammo/rocket/coilgun/high/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 1, 4, 5, 6, 2, explosion_cause = proj)
 
 /datum/ammo/rocket/coilgun/high/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	if(ishuman(target_mob) && prob(50)) //it only has AMMO_PASS_THROUGH_MOB so it can keep going if it gibs a mob
@@ -674,8 +674,8 @@
 	penetration = 100
 	sundering = 0
 
-/datum/ammo/rocket/icc_lowvel_heat/drop_nade(turf/T)
-	explosion(T, flash_range = 1, explosion_cause=src)
+/datum/ammo/rocket/icc_lowvel_heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj)
 
 /datum/ammo/rocket/icc_lowvel_high_explosive
 	name = "Low Velocity HE shell"
@@ -685,5 +685,5 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG // We want this to specifically go over onscreen range.
 	shell_speed = 1
 
-/datum/ammo/rocket/icc_lowvel_high_explosive/drop_nade(turf/T)
-	explosion(T, 0, 2, 3, 0, 2, explosion_cause=src)
+/datum/ammo/rocket/icc_lowvel_high_explosive/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj)

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -130,8 +130,8 @@
 	damage_falloff = 0.5
 	penetration = 0
 
-/datum/ammo/bullet/shotgun/frag/drop_nade(turf/T)
-	explosion(T, weak_impact_range = 2, tiny = TRUE, explosion_cause=src)
+/datum/ammo/bullet/shotgun/frag/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, weak_impact_range = 2, tiny = TRUE, explosion_cause=src)
 
 /datum/ammo/bullet/shotgun/frag/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_nade(get_turf(target_mob))

--- a/code/modules/projectiles/ammo_types/turret_ammo.dm
+++ b/code/modules/projectiles/ammo_types/turret_ammo.dm
@@ -75,9 +75,9 @@
 	max_range = 7
 	bullet_color = LIGHT_COLOR_FIRE
 
-/datum/ammo/flamer/drop_nade(turf/T)
-	flame_radius(2, T)
-	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
+/datum/ammo/flamer/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	flame_radius(2, target_turf)
+	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
 
 
 /datum/ammo/flamer/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -110,8 +110,8 @@
 	handful_greyscale_colors = COLOR_AMMO_HIGH_EXPLOSIVE
 	projectile_greyscale_colors = COLOR_AMMO_HIGH_EXPLOSIVE
 
-/datum/ammo/tx54/he/drop_nade(turf/T)
-	explosion(T, 0, 0, 1, 3, 1, explosion_cause=src)
+/datum/ammo/tx54/he/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	explosion(target_turf, 0, 0, 1, 3, 1, explosion_cause=src)
 
 /datum/ammo/tx54/he/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_nade(get_turf(target_mob))

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -31,13 +31,13 @@
 	///AOE damage amount
 	var/aoe_damage = 45
 
-/datum/ammo/energy/xeno/psy_blast/drop_nade(turf/T, atom/movable/projectile/proj)
-	if(!T || !isturf(T))
+/datum/ammo/energy/xeno/psy_blast/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	if(!isturf(target_turf))
 		return
-	playsound(T, 'sound/effects/EMPulse.ogg', 50)
-	var/list/turf/target_turfs = generate_cone(T, aoe_range, -1, 359, 0, pass_flags_checked = PASS_AIR)
-	for(var/turf/target_turf AS in target_turfs)
-		for(var/atom/movable/target AS in target_turf)
+	playsound(target_turf, 'sound/effects/EMPulse.ogg', 50)
+	var/list/turf/target_turfs = generate_cone(target_turf, aoe_range, -1, 359, 0, pass_flags_checked = PASS_AIR)
+	for(var/turf/cone_turf AS in target_turfs)
+		for(var/atom/movable/target AS in cone_turf)
 			if(isliving(target))
 				var/mob/living/living_victim = target
 				if(living_victim.stat == DEAD)
@@ -59,7 +59,7 @@
 			if(target.anchored)
 				continue
 
-	new /obj/effect/temp_visual/shockwave(T, aoe_range + 2)
+	new /obj/effect/temp_visual/shockwave(target_turf, aoe_range + 2)
 
 /datum/ammo/energy/xeno/psy_blast/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_nade(get_turf(target_mob), proj)
@@ -113,21 +113,21 @@
 	aoe_range = 1
 	aoe_damage = 31.5 // 45 * 0.7 = 31.5
 
-/datum/ammo/energy/xeno/psy_blast/psy_drain/drop_nade(turf/T, atom/movable/projectile/proj)
-	if(!T || !isturf(T))
+/datum/ammo/energy/xeno/psy_blast/psy_drain/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	if(!isturf(target_turf))
 		return
-	playsound(T, 'sound/effects/portal_opening.ogg', 50)
-	var/list/turf/target_turfs = generate_cone(T, aoe_range, -1, 359, 0, pass_flags_checked = PASS_AIR)
-	for(var/turf/target_turf AS in target_turfs)
-		for(var/mob/living/carbon/human/affected_human in target_turf)
+	playsound(target_turf, 'sound/effects/portal_opening.ogg', 50)
+	var/list/turf/target_turfs = generate_cone(target_turf, aoe_range, -1, 359, 0, pass_flags_checked = PASS_AIR)
+	for(var/turf/cone_turf AS in target_turfs)
+		for(var/mob/living/carbon/human/affected_human in cone_turf)
 			if(affected_human.stat == DEAD)
 				continue
 			affected_human.apply_damage(aoe_damage, STAMINA, null, ENERGY, FALSE, FALSE, TRUE, penetration, attacker = proj.firer)
 			staggerstun(affected_human, proj, 10, slowdown = 1)
 			affected_human.do_jitter_animation(500)
-			if(target_turf != T)
-				step_away(affected_human, T, 1)
-	new /obj/effect/temp_visual/shockwave(T, aoe_range + 2)
+			if(cone_turf != target_turf)
+				step_away(affected_human, target_turf, 1)
+	new /obj/effect/temp_visual/shockwave(target_turf, aoe_range + 2)
 
 /datum/ammo/energy/xeno/psy_blast/psy_drain/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_nade(get_turf(target_mob), proj)

--- a/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/gas_xenoammo.dm
@@ -74,7 +74,7 @@
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 
 /datum/ammo/xeno/boiler_gas/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	drop_nade(get_turf(target_mob), proj.firer)
+	drop_nade(get_turf(target_mob))
 	if(target_mob.stat == DEAD || !ishuman(target_mob))
 		return
 	var/mob/living/carbon/human/human_victim = target_mob
@@ -96,27 +96,28 @@
 	if(ismecha(target_obj))
 		proj.damage *= 7 //Globs deal much higher damage to mechs.
 	var/turf/target_turf = get_turf(target_obj)
-	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_turf, proj.firer)
+	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : target_turf)
 
 /datum/ammo/xeno/boiler_gas/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf) //we don't want the gas globs to land on dense turfs, they block smoke expansion.
 
 /datum/ammo/xeno/boiler_gas/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, proj.firer)
+	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf)
 
 /datum/ammo/xeno/boiler_gas/set_smoke()
 	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro()
 
-/datum/ammo/xeno/boiler_gas/drop_nade(turf/T, atom/firer, range = 1)
+/datum/ammo/xeno/boiler_gas/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	set_smoke()
-	if(isxeno(firer))
-		var/mob/living/carbon/xenomorph/X = firer
-		smoke_system.strength = X.xeno_caste.bomb_strength
+	var/range = 1
+	if(isxeno(proj.firer))
+		var/mob/living/carbon/xenomorph/xeno = proj.firer
+		smoke_system.strength = xeno.xeno_caste.bomb_strength
 		range = fixed_spread_range
-	smoke_system.set_up(range, T)
+	smoke_system.set_up(range, target_turf)
 	smoke_system.start()
 	smoke_system = null
-	T.visible_message(danger_message)
+	target_turf.visible_message(danger_message)
 
 /datum/ammo/xeno/boiler_gas/corrosive
 	name = "glob of acid"

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -235,10 +235,10 @@
 /datum/ammo/xeno/acid/on_shield_block(mob/target_mob, atom/movable/projectile/proj)
 	airburst(target_mob, proj)
 
-/datum/ammo/xeno/acid/drop_nade(turf/T) //Leaves behind an acid pool; defaults to 1-3 seconds.
-	if(T.density)
+/datum/ammo/xeno/acid/drop_nade(turf/target_turf, atom/movable/projectile/proj) //Leaves behind an acid pool; defaults to 1-3 seconds.
+	if(target_turf)
 		return
-	xenomorph_spray(T, puddle_duration, puddle_acid_damage)
+	xenomorph_spray(target_turf, puddle_duration, puddle_acid_damage)
 
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
@@ -323,10 +323,10 @@
 	/// smoke type created when the projectile fails to reach max range
 	var/datum/effect_system/smoke_spread/smoketype_fail = /datum/effect_system/smoke_spread/xeno/acid/fast
 
-/datum/ammo/xeno/acid/smokescreen/drop_nade(turf/T)
+/datum/ammo/xeno/acid/smokescreen/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/smoke = new smoketype_fail()
-	playsound(T, 'sound/effects/smoke.ogg', 10, 1, 2)
-	smoke.set_up(1, T)
+	playsound(target_turf, 'sound/effects/smoke.ogg', 10, 1, 2)
+	smoke.set_up(1, target_turf)
 	smoke.start()
 
 /datum/ammo/xeno/acid/smokescreen/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
@@ -369,29 +369,25 @@
 	/// smoke type created when the projectile fails to reach max range
 	var/datum/effect_system/smoke_spread/smoketype_fail = /datum/effect_system/smoke_spread/xeno/acid/fast
 
-/datum/ammo/xeno/acid/smokescreen_bomblet/drop_nade(turf/T, max_range_reached = FALSE)
-	if(!max_range_reached)
-		var/datum/effect_system/smoke_spread/smoke = new smoketype_fail()
-		playsound(T, 'sound/effects/smoke.ogg', 10, 1, 2)
-		smoke.set_up(smoke_radius, T)
-		smoke.start()
-	else
-		var/datum/effect_system/smoke_spread/smoke = new smoketype()
-		playsound(T, 'sound/effects/smoke.ogg', 25, 1, 4)
-		smoke.set_up(smoke_radius, T, smoke_duration)
-		smoke.start()
+///Drops a smoke bomblet
+/datum/ammo/xeno/acid/smokescreen_bomblet/proc/drop_bomblet(turf/target_turf, max_range_reached = FALSE)
+	var/chosen_smoke = max_range_reached ? smoketype : smoketype_fail
+	var/datum/effect_system/smoke_spread/smoke = new chosen_smoke()
+	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
+	smoke.set_up(smoke_radius, target_turf, smoke_duration)
+	smoke.start()
 
 ///Hitting an object causes the bomblet to fail and release transparent fast-dissipating smoke
 /datum/ammo/xeno/acid/smokescreen_bomblet/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
-	drop_nade(target_obj.density ? get_step_towards(target_obj, proj) : get_turf(target_obj), FALSE)
+	drop_bomblet(target_obj.density ? get_step_towards(target_obj, proj) : get_turf(target_obj), FALSE)
 
 ///Hitting a mob causes the bomblet to fail and release transparent fast-dissipating smoke
 /datum/ammo/xeno/acid/smokescreen_bomblet/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, FALSE)
+	drop_bomblet(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, FALSE)
 
 ///Reaching max range causes the bomblet to detonate and release opaque long-lasting smoke
 /datum/ammo/xeno/acid/smokescreen_bomblet/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	drop_nade(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, TRUE)
+	drop_bomblet(target_turf.density ? get_step_towards(target_turf, proj) : target_turf, TRUE)
 
 /datum/ammo/xeno/acid/smokescreen/neurotoxin
 	damage_type = STAMINA
@@ -450,10 +446,10 @@
 	if(isvehicle(target_obj))
 		target_obj.take_damage(XADAR_VEHICLE_DAMAGE)
 
-/datum/ammo/rocket/he/xadar/drop_nade(turf/T)
-	new /obj/effect/temp_visual/xadar_blast(locate((T.x - 1),(T.y - 1),T.z)) // Gets the tile SE of the impact zone to center the effect properly
-	playsound(T, 'sound/effects/xadarblast.ogg', 50, 1)
-	for(var/mob/living/carbon/human/human_victim AS in cheap_get_humans_near(T,2))
+/datum/ammo/rocket/he/xadar/drop_nade(turf/target_turf, atom/movable/projectile/proj)
+	new /obj/effect/temp_visual/xadar_blast(locate((target_turf.x - 1),(target_turf.y - 1),target_turf.z)) // Gets the tile SE of the impact zone to center the effect properly
+	playsound(target_turf, 'sound/effects/xadarblast.ogg', 50, 1)
+	for(var/mob/living/carbon/human/human_victim AS in cheap_get_humans_near(target_turf,2))
 		human_victim.adjust_stagger(4 SECONDS)
 		human_victim.apply_damage(90, BURN, BODY_ZONE_CHEST, ACID,  penetration = 10)
 		var/throwlocation = human_victim.loc
@@ -462,5 +458,5 @@
 		if(human_victim.stat == DEAD)
 			continue
 		human_victim.throw_at(throwlocation, 6, 1.5, src, TRUE)
-	for(var/acid_tile in filled_turfs(get_turf(T), 1.5, "circle", pass_flags_checked = PASS_AIR|PASS_PROJECTILE))
+	for(var/acid_tile in filled_turfs(get_turf(target_turf), 1.5, "circle", pass_flags_checked = PASS_AIR|PASS_PROJECTILE))
 		xenomorph_spray(acid_tile, 5 SECONDS, 40, null, TRUE)

--- a/code/modules/projectiles/ammo_types/zombie_ammo.dm
+++ b/code/modules/projectiles/ammo_types/zombie_ammo.dm
@@ -32,9 +32,9 @@
 /datum/ammo/bile_spit/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf.density ? proj.loc : target_turf)
 
-/datum/ammo/bile_spit/drop_nade(turf/T)
+/datum/ammo/bile_spit/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	var/datum/effect_system/smoke_spread/xeno/neuro/light/extinguishing/smoke_system = new
 	smoke_system.strength = 1.5
 	smoke_system.lifetime = 2
-	smoke_system.set_up(3, T)
+	smoke_system.set_up(3, target_turf)
 	smoke_system.start()

--- a/code/modules/vehicles/armored/armored_weapons.dm
+++ b/code/modules/vehicles/armored/armored_weapons.dm
@@ -370,7 +370,7 @@
 	fire_mode = GUN_FIREMODE_AUTOMATIC
 	variance = 2
 	projectile_delay = 0.45 SECONDS
-	rearm_time = 9 SECONDS
+	rearm_time = 4 SECONDS
 	hud_state_empty = "hivelo_empty"
 
 /obj/item/armored_weapon/apc_cannon


### PR DESCRIPTION

## About The Pull Request
Buffs tank autocannon.

- AP rounds are 70 damage, 35 AP, 8 sunder. Previously 40 damage, 45 AP, 4 sunder.
- HE rounds are 10 damage on direct hit, with an additional 20 AOE damage
- HE rounds have 3 shell speed instead of 2

Also cleans up the drop_nade proc, with various mismatching args.
## Why It's Good For The Game
AC is pretty dogwater right now. Hopefully buffing it enough to be viable, with consistant DPS to apply pressure, but without the killing power to just mow things down.
## Changelog
:cl:
balance: Buffed the tank autocannon
/:cl:
