### PR TITLE
Rain fire fix

### DIFF
--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -55,7 +55,7 @@
 		to_chat(L, span_danger("You feel the acid rain melting you away!"))
 	L.wash()
 	if(L.fire_stacks > -20)
-		L.fire_stacks = max(-20, L.fire_stacks - 1)
+		L.adjust_fire_stacks(-1)
 
 /datum/weather/acid_rain/harmless
 	target_trait = ZTRAIT_RAIN
@@ -81,7 +81,7 @@
 /datum/weather/acid_rain/harmless/weather_act(mob/living/L)
 	L.wash()
 	if(L.fire_stacks > -20)
-		L.fire_stacks = max(-20, L.fire_stacks - 1)
+		L.adjust_fire_stacks(-1)
 		if(prob(20))
 			if(isrobot(L) || isxeno(L))
 				return


### PR DESCRIPTION

## About The Pull Request
Rain now updates icon states as it extinguishes fire, no more endlessly burning xenos.
## Why It's Good For The Game
Visual fix
## Changelog
:cl:
fix: Rain now properly updates fire sprites when extinguishing.
/:cl:
