### PR TITLE
Railgun Ammo is now small mag size instead of full mag size.

### DIFF
--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -375,7 +375,7 @@
 	default_ammo = /datum/ammo/bullet/railgun
 	max_rounds = 1
 	reload_delay = 20 //Hard to reload.
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	icon_state_mini = "mag_railgun"
 
 /obj/item/ammo_magazine/railgun/hvap


### PR DESCRIPTION

## About The Pull Request

Railgun ammos are now small items.
This makes all railgun ammos now fit within webbing vests (the 5 item ones) and smaller in backpacks.
<img width="499" height="93" alt="image" src="https://github.com/user-attachments/assets/a0679e28-6d29-490f-abcc-494c8b5d8216" />

<img width="1911" height="1046" alt="image" src="https://github.com/user-attachments/assets/f354a341-11cb-4fa2-a285-bc4f34d66f6c" />

## Why It's Good For The Game

Railgun ammo carrying capacity has been abysmal since it was changed to 1 shot per mag.
This makes it a little bit better by reducing the size of the mags.

## Changelog
:cl:
balance: railgun canisters reduced to small size from the previous medium size.
/:cl:
