### PR TITLE
Reduced warlock psy lance range from 12 to 9 tiles.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -627,7 +627,7 @@
 			desc = "Launch a blast of psychic energy that deals light burn damage and staggers in an area. Direct hits deal additional light brute damage."
 		if(/datum/ammo/energy/xeno/psy_blast/psy_lance)
 			name = "Psychic Lance ([ability_cost])"
-			desc = "Launch a blast of psychic energy that deals high brute damage with high armor penetration. This can hit multiple mobs and goes through structures."
+			desc = "Launch a blast of psychic energy that deals high burn damage with high armor penetration. This can hit multiple mobs and goes through structures."
 		if(/datum/ammo/energy/xeno/psy_blast/psy_drain)
 			name = "Psychic Drain ([ability_cost])"
 			desc = "Launch a blast of psychic energy that deals light stamina damage, staggers, and knockbacks in a smaller area. Direct hits deal additional light stamina damage and briefly knockdowns."

--- a/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/energy_xenoammo.dm
@@ -80,7 +80,7 @@
 	penetration = 50
 	accuracy = 100
 	sundering = 5
-	max_range = 12
+	max_range = 9
 	hitscan_effect_icon = "beam_hcult"
 	icon_state = "psy_lance"
 	ability_cost = 300


### PR DESCRIPTION
## About The Pull Request

Reduced warlock psy lance range from 12 to 9 tiles. Also fixed slight typo in psy lance ability description.


## Why It's Good For The Game

Psy lance is a strong ability for the warlock once it's unlocked, but its ability to offscreen marines with a range of 12 tiles makes it extremely punishing to deal with. A slight nerf to its range means it's still a worthwhile purchase for a xeno that can stay alive for t3 primordial while making it slightly easier for marines to deal with.

## Changelog

:cl:

balance: Reduced psy lance range from 12 to 9 tiles.
fix: Fixed a typo in the psy lance ability description.

/:cl:
