### PR TITLE
Zombie Crash: No Shipside Zombies

### DIFF
--- a/code/datums/gamemodes/zombie_crash.dm
+++ b/code/datums/gamemodes/zombie_crash.dm
@@ -38,9 +38,9 @@
 
 /datum/game_mode/infestation/crash/zombie/post_setup()
 	. = ..()
-	var/list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP))
+	var/list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_GROUND))
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
-		if(corpse.z in z_levels)
+		if(!(corpse.z in z_levels))
 			continue
 		corpse.create_zombie()
 


### PR DESCRIPTION
## About The Pull Request
Zombies now only spawn groundside if it is Zombie Crash. This means no more shipside zombies (e.g. Pillar of Spring).

## Why It's Good For The Game
Bug. Zombies shouldn't be shipside (nor should they be able to droppod, but one basically fixes the other). 

## Changelog
:cl:
fix: Zombies only spawn groundside on Zombie Crash.
/:cl:
