### PR TITLE
resisting out of UV grabs no longer give movement delay

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -154,6 +154,13 @@
 	else
 		next_move_delay = move_delay
 
+/obj/vehicle/unmanned/stop_pulling()
+	if(ismob(pulling))
+		var/mob/M = pulling
+		if(M.client)
+			M.client.move_delay = world.time
+	return ..()
+
 ///Try to desequip the turret
 /obj/vehicle/unmanned/wrench_act(mob/living/user, obj/item/I)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
In line with resisting out of grabs from living beings, doing the same for grabs by unmanned vehicles will now reset your movement delay.

## Why It's Good For The Game
Bugfix. UVs can impose one second long immobilize on anything that they release from their grab (which their grab is instant too).

## Changelog
:cl:
fix: Resisting out of grabs caused by unmanned vehicle claw correctly resets your movement delay to normal.
/:cl:
