### PR TITLE
Change name of puppet to the victim it was raised from.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/abilities_puppeteer.dm
@@ -176,6 +176,7 @@
 	ADD_TRAIT(victim, TRAIT_HOLLOW, TRAIT_GENERIC)
 	victim.spawn_gibs()
 	var/mob/living/carbon/xenomorph/puppet/puppet = new(victim_turf, owner)
+	puppet.name = victim.name
 	puppet.voice = victim.voice
 	add_puppet(puppet)
 	add_cooldown()


### PR DESCRIPTION

## About The Pull Request
Changes the name of a puppet from just puppet to the name of the unfortunate victim IF you raise a puppet that way.
## Why It's Good For The Game
RP and plays more on the puppeter  aspect of puppeter.
## Changelog
:cl:
add: names of victims to puppets.
/:cl:
