### PR TITLE
Attachment layering fix

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -369,7 +369,8 @@
 			else
 				icon = attachment_data[OVERLAY_ICON]
 				suffix = attachment.icon == icon ? "_a" : ""
-		var/mutable_appearance/new_overlay = mutable_appearance(icon, icon_state + suffix, attachment_data[ATTACHMENT_LAYER])
+		//if we have no specific attachment layer, we need to pass null as the layer so it uses the default layer for MA. However -null = -0 instead of staying as null so we use a ternary
+		var/mutable_appearance/new_overlay = mutable_appearance(icon, icon_state + suffix, attachment_data[ATTACHMENT_LAYER] ? -attachment_data[ATTACHMENT_LAYER] : null)
 		if(CHECK_BITFIELD(attachment_data[FLAGS_ATTACH_FEATURES], ATTACH_SAME_ICON))
 			new_overlay.overlays += attachment.overlays
 		if(attachment_data[MOB_PIXEL_SHIFT_X])


### PR DESCRIPTION

## About The Pull Request
Fixes #18657
Fixes attachment layering not working correctly.
Specifically, capes/kama's will no longer layer over everything, hiding guns.
<img width="169" height="147" alt="image" src="https://github.com/user-attachments/assets/c103225c-7684-4773-8eea-388083e2e032" />
## Why It's Good For The Game
HOrrible bug that leads to balance problems of hiding weapons and such.
## Changelog
:cl:
fix: fixed attachments such as capes from laying incorrectly
/:cl:
