### PR TITLE
Mechs trampling zombies pulps a limb

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -391,8 +391,10 @@
 		var/datum/limb/limb = pick(H.limbs)
 		if(limb.body_part == CHEST || limb.body_part == GROIN)
 			limb = H.get_limb("head")//Total chance 3/11 = 27%
-		limb.droplimb(FALSE, TRUE, FALSE, TRUE)
-		H.visible_message(span_danger("[H]'s [parse_zone(limb.name)] is pulped by [src]!"))
+
+		if(!(limb.limb_status & LIMB_DESTROYED))
+			H.visible_message(span_danger("[H]'s [parse_zone(limb.name)] is pulped by [src]!"))
+			limb.droplimb(FALSE, TRUE, FALSE, TRUE)
 
 	if(crushed.stat == DEAD)
 		return

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -386,6 +386,14 @@
 	var/turf/below_us = get_turf(src)
 	below_us.add_mob_blood(crushed)
 
+	if(iszombie(crushed))
+		var/mob/living/carbon/human/H = crushed
+		var/datum/limb/limb = pick(H.limbs)
+		if(limb.body_part == CHEST || limb.body_part == GROIN)
+			limb = H.get_limb("head")//Total chance 3/11 = 27%
+		limb.droplimb(FALSE, TRUE, FALSE, TRUE)
+		H.visible_message(span_danger("[H]'s [parse_zone(limb.name)] is pulped by [src]!"))
+
 	if(crushed.stat == DEAD)
 		return
 	log_combat(src, crushed, "stomped on", addition = "(DAMTYPE: [uppertext(BRUTE)])")


### PR DESCRIPTION

## About The Pull Request

Mechs trampling zombies pulps a limb
There is a 27% chance of the head being pulped permaing the zombie

## Why It's Good For The Game

It is satisfying watching a mech gradually reduce a zombies limbs, and I made it randomly effect a limb because if it was a guaranteed chance that the head is pulped I think that would be too OP.

## Changelog
:cl:
add: Mechs trampling zombies pulps a limb. There is a 27% chance of the head being pulped permaing the zombie
/:cl:
