### PR TITLE
Add human clone to zcrash vendor

### DIFF
--- a/code/game/objects/machinery/vending/zombie_crash_vendor.dm
+++ b/code/game/objects/machinery/vending/zombie_crash_vendor.dm
@@ -136,6 +136,7 @@
 		/obj/item/ammo_magazine/flamer_tank/backtank/X = list(CAT_WEAPONS, "\"X\" Fuel Backpack (500u)", 30, "weapon-flamer"), // 1x backpack = 6.67x tanks; discount of 10 points.
 		// Fun
 		/obj/item/loot_box/tgmclootbox = list(CAT_FUN, "Lootbox", 120, "fun-random"),
+		/mob/living/carbon/human/species/vatgrown = list(CAT_FUN, "Human clone", 15, "fun-random"),
 	)
 	/// The total amount of pooled points that have been gained. Shared across all vendors.
 	var/static/total_pooled_points = 0


### PR DESCRIPTION

## About The Pull Request

Adds human clone to zcrash vendor

## Why It's Good For The Game

Given this uses points which can otherwise be used to buy gamer gear, I don't think this trivializes death, if the team is poor none can be bought
Can be used to compensate dead teammates if you feel your actions lead to their permanent death

## Changelog
:cl:
add: Add human clone to zcrash vendor
/:cl:
