### PR TITLE
Warrior spur nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/mutations_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/mutations_warrior.dm
@@ -41,27 +41,23 @@
 //*********************//
 /datum/mutation_upgrade/spur/enhanced_strength
 	name = "Enhanced Strength"
-	desc = "Lunge can be activated from 1/2/3 additional tiles away. Fling and Grapple Toss can now sends your target 1/2/3 tiles further."
+	desc = "Fling and Grapple Toss can now sends your target 1/2/3 tiles further."
 	/// For each structure, the amount to increase the range by.
 	var/range_per_structure = 1
 
 /datum/mutation_upgrade/spur/enhanced_strength/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Lunge can be activated from [get_range(new_amount)] additional tiles away. Fling and Grapple Toss can now sends your target [get_range(new_amount)] tiles further."
+	return "Fling and Grapple Toss can now sends your target [get_range(new_amount)] tiles further."
 
 /datum/mutation_upgrade/spur/enhanced_strength/on_structure_update(previous_amount, new_amount)
 	. = ..()
-	var/datum/action/ability/activable/xeno/warrior/lunge/lunge_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/warrior/lunge]
-	if(!lunge_ability)
-		return
 	var/datum/action/ability/activable/xeno/warrior/fling/fling_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/warrior/fling]
 	if(!fling_ability)
 		return
 	var/datum/action/ability/activable/xeno/warrior/grapple_toss/toss_ability = xenomorph_owner.actions_by_path[/datum/action/ability/activable/xeno/warrior/grapple_toss]
 	if(!toss_ability)
 		return
-	lunge_ability.starting_lunge_distance += get_range(new_amount - previous_amount)
 	fling_ability.starting_fling_distance += get_range(new_amount - previous_amount)
 	toss_ability.starting_toss_distance += get_range(new_amount - previous_amount)
 


### PR DESCRIPTION

## About The Pull Request
Spur now only increases fling/grapple range for warrior, and no longer boosts lunge range.
## Why It's Good For The Game
This is a blatantly OP as balls mutation, even after the nerf its still exceptionally powerful and has zero downside which is problematic, but this at least reduces the bullshit.
## Changelog
:cl:
balance: Warrior spur mutation no longer buffs lunge range
/:cl:
