### PR TITLE
Cone updates and cone flamer changes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1149,8 +1149,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
  *	center - where the cone begins, or center of a circle drawn with this
  *	max_dist - how far the cone should expand, in euclidean distance
  *	starting_row - from how far should the turfs start getting included in the cone. -1 required to include center turf due to byond
- *	cone_width - big the angle of the cone is
- *	cone_angle - at what angle should the cone be made, relative to the game board's orientation
+ *	cone_width - width of the cone in degrees
+ *	cone_angle - The direction of the cone in degrees
  *	blocked - whether the cone should take into consideration obstacles
  */
 /proc/generate_cone(atom/center, max_distance = 10, starting_row = 1, cone_width = 60, cone_angle = 0, blocked = TRUE, pass_flags_checked = NONE)
@@ -1158,6 +1158,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	if(!center)
 		return
 	cone_width = min(cone_width, 359) //359 gives us a true circle, but 360 won't function due to north being 0, not 360
+	//NOTE: a width of less than 45 degrees will fail to draw a cone at certain extreme angles, as no adjacent turfs will be in cone width
 	var/right_angle = cone_angle + cone_width * 0.5
 	var/left_angle = cone_angle - cone_width * 0.5
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1147,49 +1147,57 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
  *	Generates a cone shape. Any other checks should be handled with the resulting list. Can work with up to 359 degrees
  *	Variables:
  *	center - where the cone begins, or center of a circle drawn with this
- *	max_row_count - how many rows are checked
+ *	max_dist - how far the cone should expand, in euclidean distance
  *	starting_row - from how far should the turfs start getting included in the cone. -1 required to include center turf due to byond
  *	cone_width - big the angle of the cone is
- *	cone_direction - at what angle should the cone be made, relative to the game board's orientation
+ *	cone_angle - at what angle should the cone be made, relative to the game board's orientation
  *	blocked - whether the cone should take into consideration obstacles
  */
-/proc/generate_cone(atom/center, max_row_count = 10, starting_row = 1, cone_width = 60, cone_direction = 0, blocked = TRUE, pass_flags_checked = NONE)
-	var/right_angle = cone_direction + cone_width/2
-	var/left_angle = cone_direction - cone_width/2
+/proc/generate_cone(atom/center, max_distance = 10, starting_row = 1, cone_width = 60, cone_angle = 0, blocked = TRUE, pass_flags_checked = NONE)
+	center = get_turf(center)
+	if(!center)
+		return
+	cone_width = min(cone_width, 359) //359 gives us a true circle, but 360 won't function due to north being 0, not 360
+	var/right_angle = cone_angle + cone_width * 0.5
+	var/left_angle = cone_angle - cone_width * 0.5
 
-	//These are needed because degrees need to be from 0 to 359 for the checks to function
 	if(right_angle >= 360)
 		right_angle -= 360
-
 	if(left_angle < 0)
 		left_angle += 360
-	center = get_turf(center)
-	var/list/cardinals = GLOB.alldirs
-	var/list/turfs_to_check = list(center)
+
+	var/list/check_list = list(center)
+	var/list/visited = list(center)
 	var/list/cone_turfs = list(center)
 
-	for(var/row in 1 to max_row_count)
-		if(row > 2)
-			cardinals = GLOB.cardinals
-		for(var/turf/old_turf AS in turfs_to_check) //checks the inital turf, then afterwards checks every turf that is added to cone_turfs
-			for(var/direction AS in cardinals)
-				var/turf/turf_to_check = get_step(old_turf, direction) //checks all turfs around X
-				if(cone_turfs.Find(turf_to_check))
-					continue
-				var/turf_angle = Get_Angle(center, turf_to_check)
-				if(right_angle > left_angle && (turf_angle > right_angle || turf_angle < left_angle))
-					continue
-				if(turf_angle > right_angle && turf_angle < left_angle)
-					continue
-				if(blocked && LinkBlocked(old_turf, turf_to_check, pass_flags_checked))
-					continue
+	while(length(check_list))
+		var/old_turf = check_list[1]
+		check_list.Remove(old_turf)
+
+		for(var/direction AS in GLOB.alldirs)
+			var/turf/turf_to_check = get_step(old_turf, direction)
+			if(!turf_to_check || visited.Find(turf_to_check))
+				continue
+			visited += turf_to_check
+
+			var/euclidean_dist = get_dist_euclidean(center, turf_to_check)
+			if(euclidean_dist > max_distance)
+				continue
+
+			var/turf_angle = Get_Angle(center, turf_to_check)
+			if(right_angle > left_angle && (turf_angle > right_angle || turf_angle < left_angle))
+				continue
+			if(turf_angle > right_angle && turf_angle < left_angle)
+				continue
+
+			if(blocked && LinkBlocked(old_turf, turf_to_check, pass_flags_checked))
+				continue
+
+			if(euclidean_dist >= starting_row)
 				cone_turfs += turf_to_check
-				turfs_to_check += turf_to_check
-			turfs_to_check -= old_turf
-		for(var/turf/checked_turf AS in cone_turfs)
-			if(get_dist(center, checked_turf) < starting_row) //if its before the starting row, ignore it.
-				cone_turfs -= checked_turf
-	return	cone_turfs
+			check_list += turf_to_check
+
+	return cone_turfs
 
 GLOBAL_LIST_INIT(survivor_outfits, typecacheof(/datum/outfit/job/survivor))
 

--- a/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/SOM/back_slot.dm
@@ -29,7 +29,7 @@
 	name = "X-fuel tank"
 	desc = "A specialized fuel tank of ultra thick napthal type X, known for its extreme heat and slow burn rate, as well as its distinct blue flames. For use with the V-62 incinerator."
 	item_typepath = /obj/item/ammo_magazine/flamer_tank/backtank/X
-	purchase_cost = 50
+	purchase_cost = 100
 	unlock_cost = 200
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_UNLOCKABLE
 

--- a/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
+++ b/code/datums/gamemodes/campaign/loadout_items/_TGMC/back_slot.dm
@@ -62,7 +62,7 @@
 	name = "X-fuel tank"
 	desc = "A specialized fuel tank of ultra thick napthal type X, known for its extreme heat and slow burn rate, as well as its distinct blue flames. For use with the FL-84 flamethrower and FL-240 incinerator unit."
 	item_typepath = /obj/item/ammo_magazine/flamer_tank/backtank/X
-	purchase_cost = 50
+	purchase_cost = 100
 	unlock_cost = 200
 	loadout_item_flags = LOADOUT_ITEM_ROUNDSTART_UNLOCKABLE
 

--- a/code/modules/projectiles/gun_attachables/flamer.dm
+++ b/code/modules/projectiles/gun_attachables/flamer.dm
@@ -50,6 +50,7 @@
 	pixel_shift_y = 17
 	stream_type = FLAMER_STREAM_CONE
 	burn_time_mod = 0.3
+	range_modifier = 1
 
 ///Funny red wide nozzle that can fill entire screens with flames. Admeme only.
 /obj/item/attachable/flamer_nozzle/wide/red

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -78,7 +78,7 @@
 	///Damage multiplier for mobs caught in the initial stream of fire.
 	var/mob_flame_damage_mod = 2
 	///how wide of a cone the flamethrower produces on wide mode.
-	var/cone_angle = 55
+	var/cone_angle = 60
 
 /obj/item/weapon/gun/flamer/Initialize(mapload)
 	. = ..()
@@ -151,20 +151,20 @@
 	playsound(loc, fire_sound, 50, 1)
 	var/obj/item/attachable/flamer_nozzle/nozzle = attachments_by_slot[ATTACHMENT_SLOT_FLAMER_NOZZLE]
 	var/burn_type = nozzle.stream_type
-	var/old_turfs = list(get_turf(src))
-	var/range = flame_max_range
 	var/start_location = get_turf(src)
 	var/current_target = get_turf(target)
+	var/old_turfs = list(start_location)
+
 	switch(burn_type)
 		if(FLAMER_STREAM_STRAIGHT)
 			var/path_to_target = get_line(start_location, current_target) //todo: use get_traversal_line and change recursive_flame_straight to use get_dist_euclidean for range
 			path_to_target -= start_location
-			recursive_flame_straight(1, old_turfs, path_to_target, range, current_target, flame_max_wall_pen)
+			recursive_flame_straight(1, old_turfs, path_to_target, flame_max_range, current_target, flame_max_wall_pen)
 		if(FLAMER_STREAM_CONE)
 			//direction in degrees
 			var/dir_to_target = Get_Angle(src, target)
-			var/list/turf/turfs_to_ignite = generate_cone(get_turf(src), range, 1, cone_angle, dir_to_target, pass_flags_checked = PASS_AIR|PASS_XENO)
-			recursive_flame_cone(1, turfs_to_ignite, dir_to_target, range, current_target, get_turf(src), flame_max_wall_pen_wide)
+			var/list/turf/turfs_to_ignite = generate_cone(start_location, flame_max_range, 1, cone_angle, dir_to_target, pass_flags_checked = PASS_AIR|PASS_XENO)
+			recursive_flame_cone(1, turfs_to_ignite, dir_to_target, flame_max_range, current_target, start_location, flame_max_wall_pen_wide)
 		if(FLAMER_STREAM_RANGED)
 			return ..()
 	return TRUE
@@ -305,8 +305,8 @@
 	)
 	lit_overlay_icon_state = "v62_lit"
 	lit_overlay_offset_x = 0
-	flame_max_range = 8
-	cone_angle = 40
+	flame_max_range = 7
+	cone_angle = 45
 	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle/wide)
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/large/som
 	allowed_ammo_types = list(
@@ -558,8 +558,8 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	)
 	lit_overlay_icon_state = "c21_lit"
 	lit_overlay_offset_x = 0
-	flame_max_range = 9
-	cone_angle = 40
+	flame_max_range = 8
+	cone_angle = 45
 	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle/wide)
 	default_ammo_type = /obj/item/ammo_magazine/flamer_tank/vsd
 	allowed_ammo_types = list(


### PR DESCRIPTION

## About The Pull Request
Fixes SOM/VSD flamers failing to fire at certain extreme angles.
Drawing a cone now uses euclidean distance instead of steps, to give a more useful/accurate shape, especially in diagonal directions.

Increase the range of the TGMC wide flamer by 1 (the nozzle increases it by 1 now, so the base SOM/VSD flamer had their range decreased by 1 to compensate)
Increase the width of the SOM/VSD flamer to 45 degrees from 40 (needed to fix the bug)
Increase TGMC flamer width to 60 degrees from 55

Increased the price of X-fuel backtanks in campaign to 100 from 50.
## Why It's Good For The Game
Funny flamer not triggering at certain angles is notgud.

Rebalanced flamers in general in HvH. TGMC flamer and SOM flamers have a comparable total tile ignited count (slightly higher for TGMC, but depends on the exact angle), with SOM having the slight range advantage vs TGMC sweeping over a wider area.

X-fuel was already VERY strong. Priced it up as it was already cheap for what you got, and this PR only makes them better (and more reliable).
## Changelog
:cl:
balance: TGMC wide flamer range increased to 7 from 6, and width increased to 60 degrees from 55
balance: SOM/VSD flamer width increased to 45 degrees from 40
balance: Campaign: X-fuel back tank purchase price increased to 100 from 50
fix: fixed SOM and VSD flamers not firing properly at certain specific angles
code: generate_cone() uses euclidean distance
/:cl:
