### PR TITLE
consolidate some dupe procs

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -81,24 +81,22 @@
 			return SOUTHWEST
 
 
-//Converts an angle (degrees) into an ss13 direction
-/proc/angle2dir(degree)
-	degree = SIMPLIFY_DEGREES(degree + 22.5)
-	if(degree < 45)
-		return NORTH
-	if(degree < 90)
-		return NORTHEAST
-	if(degree < 135)
-		return EAST
-	if(degree < 180)
-		return SOUTHEAST
-	if(degree < 225)
-		return SOUTH
-	if(degree < 270)
-		return SOUTHWEST
-	if(degree < 315)
-		return WEST
-	return NORTH|WEST
+GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,SOUTHWEST,WEST,NORTHWEST))
+///Returns one of the 8 directions based on an angle
+#define angle2dir(X) (GLOB.modulo_angle_to_dir[round((((X%360)+382.5)%360)/45)+1])
+
+///Returns one of the 4 cardinal directions based on an angle
+/proc/angle2dir_cardinal(degree)
+	degree = SIMPLIFY_DEGREES(degree)
+	switch(round(degree, 0.1))
+		if(315.5 to 360, 0 to 45.5)
+			return NORTH
+		if(45.6 to 135.5)
+			return EAST
+		if(135.6 to 225.5)
+			return SOUTH
+		if(225.6 to 315.5)
+			return WEST
 
 //returns the north-zero clockwise angle in degrees, given a direction
 /proc/dir2angle(D)
@@ -119,6 +117,8 @@
 			return 315
 		if(SOUTHWEST)
 			return 225
+		else
+			return null
 
 
 //Returns the angle in english

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -137,38 +137,6 @@
 	else if(. >= 360)
 		. -= 360
 
-///Returns one of the 8 directions based on an angle
-/proc/angle_to_dir(angle)
-	switch(angle)
-		if(338 to 360, 0 to 22)
-			return NORTH
-		if(23 to 67)
-			return NORTHEAST
-		if(68 to 112)
-			return EAST
-		if(113 to 157)
-			return SOUTHEAST
-		if(158 to 202)
-			return SOUTH
-		if(203 to 247)
-			return SOUTHWEST
-		if(248 to 292)
-			return WEST
-		if(293 to 337)
-			return NORTHWEST
-
-///Returns one of the 4 cardinal directions based on an angle
-/proc/angle_to_cardinal_dir(angle)
-	switch(angle)
-		if(316 to 360, 0 to 45)
-			return NORTH
-		if(46 to 135)
-			return EAST
-		if(136 to 225)
-			return SOUTH
-		if(226 to 315)
-			return WEST
-
 ///returns degrees between two angles
 /proc/get_between_angles(degree_one, degree_two)
 	var/angle = abs(degree_one - degree_two) % 360
@@ -585,7 +553,7 @@
 	return turfs
 
 /proc/get_cardinal_dir(atom/A, atom/B)
-	return angle_to_cardinal_dir(Get_Angle(get_turf(A), get_turf(B)))
+	return angle2dir_cardinal(Get_Angle(get_turf(A), get_turf(B)))
 
 /// If given a diagonal dir, return a corresponding cardinal dir. East/west preferred
 /proc/closest_cardinal_dir(dir)

--- a/code/datums/actions/order_designation/interactions.dm
+++ b/code/datums/actions/order_designation/interactions.dm
@@ -130,7 +130,7 @@
 		message = ";" //radio message
 	switch(order_action)
 		if(ORDER_DESIGNATION_TYPE_MOVE)
-			message += "[ordered ? "[selected_mob], " : "everyone, "]move [dir2text(angle_to_dir(Get_Angle(get_turf(owner), get_turf(target))))]!"
+			message += "[ordered ? "[selected_mob], " : "everyone, "]move [dir2text(angle2dir(Get_Angle(get_turf(owner), get_turf(target))))]!"
 		if(ORDER_DESIGNATION_TYPE_ATTACK)
 			message += "[ordered ? "[selected_mob], " : "everyone, "][pick("attack", "destroy", "target")] [target]!"
 		if(ORDER_DESIGNATION_TYPE_REPAIR)

--- a/code/datums/actions/species_actions/zombie_actions.dm
+++ b/code/datums/actions/species_actions/zombie_actions.dm
@@ -151,7 +151,7 @@
 	if(living_target.faction == owner.faction) //we leap past friendlies
 		return
 
-	if(ishuman(living_target) && (angle_to_dir(Get_Angle(owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
+	if(ishuman(living_target) && (angle2dir(Get_Angle(owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
 		var/mob/living/carbon/human/human_target = living_target
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
 			var/mob/living/living_owner = owner

--- a/code/datums/elements/directional_attack.dm
+++ b/code/datums/elements/directional_attack.dm
@@ -30,7 +30,7 @@
 	if(QDELETED(clicked_atom))
 		return
 
-	var/turf/turf_to_check = get_step(source, angle_to_dir(Get_Angle(source, clicked_atom)))
+	var/turf/turf_to_check = get_step(source, angle2dir(Get_Angle(source, clicked_atom)))
 	if(!turf_to_check || !source.Adjacent(turf_to_check))
 		return
 

--- a/code/game/atoms/atom_movable.dm
+++ b/code/game/atoms/atom_movable.dm
@@ -723,7 +723,7 @@
 		return
 	if(!isturf(loc))
 		return
-	var/dir_to_proj = angle_to_cardinal_dir(Get_Angle(hit_atom, old_throw_source))
+	var/dir_to_proj = angle2dir_cardinal(Get_Angle(hit_atom, old_throw_source))
 	if(ISDIAGONALDIR(dir_to_proj))
 		var/list/cardinals = list(turn(dir_to_proj, 45), turn(dir_to_proj, -45))
 		for(var/direction in cardinals)
@@ -742,7 +742,7 @@
 	else if(new_angle > 360)
 		new_angle -= 360
 
-	step(src, angle_to_dir(new_angle))
+	step(src, angle2dir(new_angle))
 
 /atom/movable/proc/throw_at(atom/target, range, speed = 5, thrower, spin, flying = FALSE, targetted_throw = TRUE)
 	set waitfor = FALSE

--- a/code/game/objects/items/multitool.dm
+++ b/code/game/objects/items/multitool.dm
@@ -32,7 +32,7 @@
 		return
 
 	var/dist = get_dist(src, area_apc)
-	var/direction = angle_to_dir(Get_Angle(get_turf(src), get_turf(area_apc)))
+	var/direction = angle2dir(Get_Angle(get_turf(src), get_turf(area_apc)))
 	to_chat(user, span_notice("The local APC is located at [span_bold("[dist] units [dir2text(direction)]")]."))
 	user.balloon_alert(user, "[dist] units [dir2text(direction)]")
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -249,7 +249,7 @@
 	carbon_owner.visible_message(span_danger("[carbon_owner] slams their shield forwards!"))
 	playsound(carbon_owner, 'sound/effects/alien/tail_swipe2.ogg', 30, 1)
 	var/hit_something = FALSE
-	for(var/mob/living/victim in get_step(carbon_owner, angle_to_dir(Get_Angle(carbon_owner, A))))
+	for(var/mob/living/victim in get_step(carbon_owner, angle2dir(Get_Angle(carbon_owner, A))))
 		if((victim.lying_angle))
 			continue
 		hit_something = TRUE

--- a/code/game/objects/items/weapons/two_handed/boarding_axe.dm
+++ b/code/game/objects/items/weapons/two_handed/boarding_axe.dm
@@ -66,7 +66,7 @@
 	succeed_activate()
 	add_cooldown()
 	var/mob/living/carbon/carbon_owner = owner
-	carbon_owner.Move(get_step(carbon_owner, angle_to_dir(Get_Angle(carbon_owner, A))), get_dir(carbon_owner, A))
+	carbon_owner.Move(get_step(carbon_owner, angle2dir(Get_Angle(carbon_owner, A))), get_dir(carbon_owner, A))
 	carbon_owner.face_atom(A)
 	activate_particles(owner.dir)
 	playsound(owner, 'sound/effects/alien/tail_swipe3.ogg', 50, 0, 5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -361,7 +361,7 @@
 	if(living_target.stat || isxeno(living_target)) //we leap past xenos
 		return
 
-	if(ishuman(living_target) && (angle_to_dir(Get_Angle(xeno_owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
+	if(ishuman(living_target) && (angle2dir(Get_Angle(xeno_owner.throw_source, living_target)) in reverse_nearby_direction(living_target.dir)))
 		var/mob/living/carbon/human/human_target = living_target
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
 			xeno_owner.Paralyze(XENO_POUNCE_SHIELD_STUN_DURATION)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 
 ///Start the acid cone spray in the correct direction
 /datum/action/ability/activable/xeno/spray_acid/cone/proc/start_acid_spray_cone(turf/T, range)
-	var/facing = angle_to_dir(Get_Angle(owner, T))
+	var/facing = angle2dir(Get_Angle(owner, T))
 	owner.setDir(facing)
 	switch(facing)
 		if(NORTH, SOUTH, EAST, WEST)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -276,7 +276,7 @@
 	playsound(loc, 'sound/effects/portal.ogg', 20)
 
 	var/perpendicular_angle = Get_Angle(get_turf(src), get_step(src, dir)) //the angle src is facing, get_turf because pixel_x or y messes with the angle
-	var/direction_to_atom = angle_to_dir(Get_Angle(src, targetted_atom))
+	var/direction_to_atom = angle2dir(Get_Angle(src, targetted_atom))
 	for(var/atom/movable/projectile/reflected_projectile AS in frozen_projectiles)
 		reflected_projectile.projectile_behavior_flags &= ~PROJECTILE_FROZEN
 		reflected_projectile.distance_travelled = 0

--- a/code/modules/vehicles/armored/__armored.dm
+++ b/code/modules/vehicles/armored/__armored.dm
@@ -694,7 +694,7 @@
 ///Rotates the cannon overlay
 /obj/vehicle/sealed/armored/proc/swivel_turret(atom/A, new_weapon_dir)
 	if(!new_weapon_dir)
-		new_weapon_dir = angle_to_cardinal_dir(Get_Angle(get_turf(src), get_turf(A)))
+		new_weapon_dir = angle2dir_cardinal(Get_Angle(get_turf(src), get_turf(A)))
 	if(turret_overlay.dir == new_weapon_dir)
 		return FALSE
 	if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_TANK_SWIVEL)) //Slight cooldown to avoid spam


### PR DESCRIPTION

## About The Pull Request
angle2dir is now a define, and removed the redundant angle_to_dir proc.
Set angle2dir_cardinal instead of angle_to_cardinal_dir
## Why It's Good For The Game
Less redundant/dupe procs, consistant with TG.
## Changelog
:cl:
code: angle_to_dir() replaced with angle2dir. angle_to_cardinal_dir replaced with angle2dir_cardinal
/:cl:
