### PR TITLE
mech sword nerf against humans

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -576,7 +576,19 @@
 
 ///Hits a mob in the way
 /obj/item/mecha_parts/mecha_equipment/laser_sword/proc/do_bump_attack(mob/living/bumped_mob)
-	bumped_mob.attackby(src, cutter)
+	if((bumped_mob.mob_size > MOB_SIZE_HUMAN) || (bumped_mob.mob_size == MOB_SIZE_HUMAN && prob(60)))
+		bumped_mob.attackby(src, cutter)
+		return
+
+	//mech sword is less reliable at instantly obliterating humans
+	playsound(get_turf(bumped_mob), SFX_SWING_HIT, 50, null, 9)
+
+	var/knock_dir = pick(LeftAndRightOfDir(get_dir(chassis, bumped_mob), always_diag = TRUE))
+	bumped_mob.knockback(chassis, 3, 3, knock_dir)
+
+	bumped_mob.ParalyzeNoChain(modify_by_armor(1 SECONDS, MELEE, def_zone = BODY_ZONE_CHEST) * 100 / bumped_mob.maxHealth)
+	bumped_mob.adjust_stagger(1 SECONDS)
+	bumped_mob.apply_damage(40, BRUTE, BODY_ZONE_CHEST, MELEE, FALSE, FALSE, TRUE, 0, cutter)
 
 ///Ends dash and executes attack
 /obj/item/mecha_parts/mecha_equipment/laser_sword/proc/end_dash(datum/source)

--- a/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/greyscale_weapons.dm
@@ -576,7 +576,7 @@
 
 ///Hits a mob in the way
 /obj/item/mecha_parts/mecha_equipment/laser_sword/proc/do_bump_attack(mob/living/bumped_mob)
-	if((bumped_mob.mob_size > MOB_SIZE_HUMAN) || (bumped_mob.mob_size == MOB_SIZE_HUMAN && prob(60)))
+	if((bumped_mob.mob_size > MOB_SIZE_HUMAN) || (bumped_mob.mob_size == MOB_SIZE_HUMAN && prob(25)))
 		bumped_mob.attackby(src, cutter)
 		return
 


### PR DESCRIPTION

## About The Pull Request
Mech sword (specifically the dash, not the end swing or direct melee hit) has a 75% chance to knock human sized mobs out of the way instead of instantly obliterating them. Smaller sized mobs are always knocked away.

Knockback is diagonal to the direction of the dash for 3 tiles, with a very small scaling stun (i.e. high hp/armour targets are stunned even less) and stagger, plus 40 damage.
## Why It's Good For The Game
Melee mech is hilariously deadly, being able to 1 hit crit basically any target in the game with its instant transmission sword dash.

This change means mechs can still line up shots for the guaranteed obliteration (or just click them in melee range) but the dash bullshit will no longer be reliable instant kills, while still being very strong.
## Changelog
:cl:
balance: Mech sword dash has a high chance of knocking human sized targets out of the way instead of instantly critting them
/:cl:
