### PR TITLE
greyscale ammo fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -168,8 +168,9 @@
 	if (ammo.projectile_greyscale_config && ammo.projectile_greyscale_colors)
 		set_greyscale_config(ammo.projectile_greyscale_config)
 		set_greyscale_colors(ammo.projectile_greyscale_colors)
+	else //greyscale sets icon
+		icon = ammo.icon
 
-	icon = ammo.icon
 	icon_state = ammo.icon_state
 	damage = ammo.damage + bonus_damage //Mainly for emitters.
 	penetration = ammo.penetration


### PR DESCRIPTION

## About The Pull Request
Dragon broke greyscale projectiles, like the GL54. Dragon go home.
## Why It's Good For The Game
Invisible grenades R bad
## Changelog
:cl:
fix: fixed greyscale projectiles being invisible
/:cl:
