### PR TITLE
job outfit duplication

### DIFF
--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -57,7 +57,7 @@ GLOBAL_PROTECT(exp_specialmap)
 	///whether the job has multiple outfits
 	var/multiple_outfits = FALSE
 	///list of outfit variants
-	var/list/datum/outfit/job/outfits = list()
+	var/list/datum/outfit/job/outfits
 	///Skills for this job
 	var/skills_type = /datum/skills
 	///Any special traits that are assigned for this job
@@ -80,6 +80,11 @@ GLOBAL_PROTECT(exp_specialmap)
 			stack_trace("Job created with an invalid outfit parameter ([outfit])")
 		else
 			outfit = new outfit //Can be improved to reference a singleton.
+	if(length(outfits))
+		var/list/options_list = outfits.Copy()
+		outfits.Cut()
+		for(var/path in options_list)
+			outfits += new path
 
 ///called during gamemode pre_setup, use for stuff like roundstart poplock
 /datum/job/proc/on_pre_setup()
@@ -324,7 +329,6 @@ GLOBAL_PROTECT(exp_specialmap)
 			valid_outfits += variant
 
 	var/datum/outfit/chosen_variant = pick(valid_outfits)
-	chosen_variant = new chosen_variant
 	chosen_variant.equip(src)
 
 


### PR DESCRIPTION

## About The Pull Request
Cleans up some funny job code to avoid outfit datums being created and not deleted.
## Why It's Good For The Game
Bad code.
## Changelog
:cl:
code: Stopped outfit datums getting duplicated needlessly
/:cl:
