### PR TITLE
Wallmount fixes

### DIFF
--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -95,8 +95,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/mainship/dropship_one{
-	pixel_x = -6;
-	pixel_y = -16
+	dir = 1
 	},
 /turf/open/shuttle/dropship/floor/out{
 	dir = 4
@@ -234,9 +233,7 @@
 /turf/closed/shuttle/dropship1/finleft,
 /area/shuttle/dropship/alamo)
 "aZ" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	pixel_y = 32
-	},
+/obj/machinery/camera/autoname/mainship/dropship_one,
 /turf/open/shuttle/dropship/five,
 /area/shuttle/dropship/alamo)
 "ba" = (
@@ -362,8 +359,7 @@
 /area/shuttle/dropship/alamo)
 "bI" = (
 /obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
+	dir = 8
 	},
 /turf/open/shuttle/dropship/floor/out{
 	dir = 1
@@ -624,8 +620,7 @@
 /area/shuttle/dropship/alamo)
 "IA" = (
 /obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 4;
-	pixel_x = -16
+	dir = 4
 	},
 /turf/open/shuttle/dropship/floor/out{
 	dir = 1

--- a/code/game/objects/machinery/camera/camera.dm
+++ b/code/game/objects/machinery/camera/camera.dm
@@ -77,12 +77,16 @@
 	switch(dir)
 		if(NORTH)
 			pixel_z = -16
+			pixel_w = 0
 		if(SOUTH)
 			pixel_z = 32
+			pixel_w
 		if(EAST)
-			pixel_w = -16
+			pixel_z = 0
+			pixel_w = -24
 		if(WEST)
-			pixel_w = 16
+			pixel_z = 0
+			pixel_w = 24
 
 
 /obj/machinery/camera/proc/camera_ui_data()

--- a/code/game/objects/machinery/camera/camera.dm
+++ b/code/game/objects/machinery/camera/camera.dm
@@ -80,7 +80,7 @@
 			pixel_w = 0
 		if(SOUTH)
 			pixel_z = 32
-			pixel_w
+			pixel_w = 0
 		if(EAST)
 			pixel_z = 0
 			pixel_w = -24

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -3,8 +3,6 @@
 	desc = "A wall mounted storage locker."
 	icon = 'icons/obj/wallframes.dmi'
 	icon_state = "walllocker"
-	pixel_x = -16
-	pixel_y = -16
 	density = FALSE
 	anchored = TRUE
 	icon_closed = "walllocker"
@@ -16,17 +14,23 @@
 
 /obj/structure/closet/walllocker/Initialize(mapload, ndir)
 	. = ..()
-	if(ndir)
-		dir = ndir
+	setDir(ndir ? ndir : dir)
+
+/obj/structure/closet/walllocker/setDir(newdir)
+	. = ..()
 	switch(dir)
 		if(NORTH)
-			pixel_y = -32
+			pixel_w = -16
+			pixel_z = -48
 		if(SOUTH)
-			pixel_y = 32
+			pixel_w = -16
+			pixel_z = -16
 		if(EAST)
-			pixel_x = -32
+			pixel_w = -48
+			pixel_z = -12
 		if(WEST)
-			pixel_x = 32
+			pixel_w = 16
+			pixel_z = -12
 
 /obj/structure/closet/walllocker/emerglocker //wall mounted emergency closet
 	name = "emergency locker"
@@ -88,8 +92,6 @@
 	name = "secure wall locker"
 	desc = "It's an immobile card-locked storage unit."
 	icon = 'icons/obj/wallframes.dmi'
-	pixel_x = -16
-	pixel_y = -16
 	icon_state = "sec_locker1"
 	icon_closed = "secure"
 	icon_locked = "sec_locker1"
@@ -106,17 +108,23 @@
 
 /obj/structure/closet/secure_closet/walllocker/Initialize(mapload, ndir)
 	. = ..()
-	if(ndir)
-		dir = ndir
+	setDir(ndir ? ndir : dir)
+
+/obj/structure/closet/secure_closet/walllocker/setDir(newdir)
+	. = ..()
 	switch(dir)
 		if(NORTH)
-			pixel_y -= 32
+			pixel_w = -16
+			pixel_z = -48
 		if(SOUTH)
-			pixel_y += 32
+			pixel_w = -16
+			pixel_z = -16
 		if(EAST)
-			pixel_x -= 32
+			pixel_w = -48
+			pixel_z = -12
 		if(WEST)
-			pixel_x += 32
+			pixel_w = 16
+			pixel_z = -12
 
 /obj/structure/closet/secure_closet/walllocker/medical
 	name = "first aid closet"
@@ -147,8 +155,6 @@
 	desc = "It's a secure wall locker for personnel. The first card swiped gains control."
 	icon = 'icons/obj/wallframes.dmi'
 	icon_state = "sec_locker1"
-	pixel_x = -16
-	pixel_y = -16
 	icon_closed = "secure"
 	icon_locked = "sec_locker1"
 	icon_opened = "sec_locker_opened"
@@ -164,14 +170,20 @@
 
 /obj/structure/closet/secure_closet/personal/walllocker/Initialize(mapload, ndir)
 	. = ..()
-	if(ndir)
-		dir = ndir
+	setDir(ndir ? ndir : dir)
+
+/obj/structure/closet/secure_closet/personal/walllocker/setDir(newdir)
+	. = ..()
 	switch(dir)
 		if(NORTH)
-			pixel_y -= 32
+			pixel_w = -16
+			pixel_z = -48
 		if(SOUTH)
-			pixel_y += 32
+			pixel_w = -16
+			pixel_z = -16
 		if(EAST)
-			pixel_x -= 32
+			pixel_w = -48
+			pixel_z = -12
 		if(WEST)
-			pixel_x += 32
+			pixel_w = 16
+			pixel_z = -12


### PR DESCRIPTION

## About The Pull Request
Fixes certain wall mounted objects having extremely cursed offsets, such as wall fire extinguishers.
Fixed the Alamo cameras having weird var edit offsets.
## Why It's Good For The Game
Sane looking objects
## Changelog
:cl:
fix: fixed the position of some wall mounted objects, as well as cameras in the Alamo
/:cl:
