### PR TITLE
Zombie nerfs, slower spawning, bigger waves

### DIFF
--- a/code/modules/ai/spawners/zombie.dm
+++ b/code/modules/ai/spawners/zombie.dm
@@ -16,8 +16,8 @@
 			/mob/living/carbon/human/species/zombie/ai/strong/patrol = 1,
 		) = 5,
 	)
-	spawnamount = 2
-	spawndelay = 25 SECONDS
+	spawnamount = 3
+	spawndelay = 34 SECONDS
 	maxamount = 50
 	///Currently is considered under threat
 	var/threat_warning = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -1,7 +1,7 @@
 /datum/species/zombie
 	name = "Zombie"
 	icobase = 'icons/mob/human_races/r_husk.dmi'
-	total_health = 125
+	total_health = 110
 	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|PARALYSE_RESISTANT|SPECIES_NO_HUG
 	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	blood_color = "#110a0a"
@@ -23,7 +23,7 @@
 	///Time before resurrecting if dead
 	var/revive_time = 1 MINUTES
 	///How much burn and burn damage can you heal every Life tick (half a sec)
-	var/heal_rate = 10
+	var/heal_rate = 7
 	var/faction = FACTION_ZOMBIE
 	var/claw_type = /obj/item/weapon/zombie_claw
 	///Whether this zombie type can jump

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -1,7 +1,7 @@
 /datum/species/zombie
 	name = "Zombie"
 	icobase = 'icons/mob/human_races/r_husk.dmi'
-	total_health = 110
+	total_health = 100
 	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|PARALYSE_RESISTANT|SPECIES_NO_HUG
 	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	blood_color = "#110a0a"

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -43,7 +43,7 @@
 	attack_speed = 8 //Same as unarmed delay
 	pry_capable = IS_PRY_CAPABLE_FORCE
 	///How much zombium is transferred per hit. Set to zero to remove transmission
-	var/zombium_per_hit = 9
+	var/zombium_per_hit = 7
 
 /obj/item/weapon/zombie_claw/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Zombie healrate reduced by 30%, regular zombie health reduced by 20%, zombium per hit reduced by 22%
Increased time between spawn waves, increased zombie tunnel wave size

## Why It's Good For The Game

- Fire damage for comparison is 10, which was the same as regular zombie heal rate, it shouldn't be able to keep pace with literally being on fire.
- They are too tanky in general it is better to have more weaker zombies than less stronger ones, like left 4 dead. 
- They inflict too much zombium. Currently humans must constantly be using meds and have in their mind how much zombium they probably have at all times. The current number is a derivative of a placeholder number of zombium before zombie crash was TMed, its not based on anything.

Zombies have very high win rate, I looked through #game_updates and marines won once out of a dozen games

## Changelog
:cl:
balance: Zombie healrate reduced by 30%, regular zombie health reduced by 20%, zombium per hit reduced by 22%
balance: Increased time between spawn waves, increased zombie tunnel wave size
/:cl:
