### PR TITLE
Multitile vehicles are not slowed by sticky weeds/resin

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -147,32 +147,11 @@
 /obj/alien/weeds/footstep_override(atom/movable/source, list/footstep_overrides)
 	footstep_overrides[FOOTSTEP_RESIN] = layer
 
-///special behavior when atoms enter our loc
-/obj/alien/weeds/proc/on_loc_entered(datum/source, atom/movable/crosser)
-	SIGNAL_HANDLER
+/obj/alien/weeds/on_loc_entered(datum/source, atom/movable/crosser)
 	if(!isxeno(crosser))
 		return
 	var/mob/living/carbon/xenomorph/xeno = crosser
 	xeno.next_move_slowdown += xeno?.xeno_caste?.weeds_speed_mod
-
-///Slows down non xeno crossers
-/obj/alien/weeds/proc/slow_down_crosser(atom/movable/crosser)
-	if(isxeno(crosser))
-		return
-	if(crosser.throwing || crosser.buckled)
-		return
-	if(crosser.pass_flags & PASS_LOW_STRUCTURE)
-		return
-	if(issealedvehicle(crosser))
-		var/obj/vehicle/sealed/vehicle = crosser
-		COOLDOWN_INCREMENT(vehicle, cooldown_vehicle_move, WEED_SLOWDOWN)
-		return
-	if(!ishuman(crosser))
-		return
-	var/mob/living/carbon/human/victim = crosser
-	if(victim.lying_angle)
-		return
-	victim.next_move_slowdown += WEED_SLOWDOWN
 
 /obj/alien/weeds/sticky
 	name = "sticky weeds"
@@ -181,7 +160,7 @@
 
 /obj/alien/weeds/sticky/on_loc_entered(datum/source, atom/movable/crosser)
 	. = ..()
-	slow_down_crosser(crosser)
+	slow_down_crosser(crosser, WEED_SLOWDOWN)
 
 /obj/alien/weeds/resting
 	name = "resting weeds"
@@ -324,7 +303,7 @@
 
 /obj/alien/weeds/node/sticky/on_loc_entered(datum/source, atom/movable/crosser)
 	. = ..()
-	slow_down_crosser(crosser)
+	slow_down_crosser(crosser, WEED_SLOWDOWN)
 
 //Resting weed node
 /obj/alien/weeds/node/resting

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -20,11 +20,6 @@
 	if(!ignore_weed_destruction)
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, PROC_REF(weed_removed))
 
-/// Destroy the alien effect when the weed it was on is destroyed
-/obj/alien/proc/weed_removed()
-	SIGNAL_HANDLER
-	obj_destruction(damage_flag = "melee")
-
 /obj/alien/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(.)
@@ -57,6 +52,35 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
 		take_damage(rand(2, 20) * 0.1, BURN, ACID)
 
+/// Destroy the alien effect when the weed it was on is destroyed
+/obj/alien/proc/weed_removed()
+	SIGNAL_HANDLER
+	obj_destruction(damage_flag = "melee")
+
+///special behavior when atoms enter our loc
+/obj/alien/proc/on_loc_entered(datum/source, atom/movable/crosser)
+	SIGNAL_HANDLER
+	return
+
+///Slows down non xeno crossers
+/obj/alien/proc/slow_down_crosser(atom/movable/crosser, slow_amount = 1)
+	if(isxeno(crosser))
+		return
+	if(crosser.throwing || crosser.buckled)
+		return
+	if(crosser.pass_flags & PASS_LOW_STRUCTURE)
+		return
+	if(ismecha(crosser))
+		var/obj/vehicle/sealed/vehicle = crosser
+		COOLDOWN_INCREMENT(vehicle, cooldown_vehicle_move, slow_amount)
+		return
+	if(!ishuman(crosser))
+		return
+	var/mob/living/carbon/human/victim = crosser
+	if(victim.lying_angle)
+		return
+	victim.next_move_slowdown += slow_amount
+
 /*
 * Resin
 */
@@ -83,6 +107,7 @@
 	plane = FLOOR_PLANE
 	layer = ABOVE_WEEDS_LAYER
 	hit_sound = SFX_ALIEN_RESIN_MOVE
+	///slows things by this much on cross
 	var/slow_amt = 8
 	/// Does this refund build points when destoryed?
 	var/refundable = TRUE
@@ -92,35 +117,12 @@
 /obj/alien/resin/sticky/Initialize(mapload)
 	. = ..()
 	var/static/list/connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(slow_down_crosser)
+		COMSIG_ATOM_ENTERED = PROC_REF(on_loc_entered)
 	)
 	AddElement(/datum/element/connect_loc, connections)
 
-/obj/alien/resin/sticky/proc/slow_down_crosser(datum/source, atom/movable/crosser)
-	SIGNAL_HANDLER
-	if(crosser.throwing || crosser.buckled)
-		return
-
-	if(issealedvehicle(crosser))
-		var/obj/vehicle/sealed/vehicle = crosser
-		COOLDOWN_INCREMENT(vehicle, cooldown_vehicle_move, WEED_SLOWDOWN)
-		return
-
-	if(!ishuman(crosser))
-		return
-
-	if(HAS_TRAIT(crosser, TRAIT_TANK_DESANT))
-		return
-
-	if(CHECK_MULTIPLE_BITFIELDS(crosser.allow_pass_flags, HOVERING))
-		return
-
-	var/mob/living/carbon/human/victim = crosser
-
-	if(victim.lying_angle)
-		return
-
-	victim.next_move_slowdown += slow_amt
+/obj/alien/resin/sticky/on_loc_entered(datum/source, atom/movable/crosser)
+	slow_down_crosser(crosser, slow_amt)
 
 /obj/alien/resin/sticky/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

Also cleaned up the code to remove unneeded duplication.
## Why It's Good For The Game
Vehicles aren't super fast to begin with, so weed slowdown really cripples them.
Mechs stay affected because they ARE fast, so the slowdown is an important balance lever for them (even though they're out of HvX atm).
## Changelog
:cl:
balance: Multitile vehicles are not slowed by sticky weeds/resin
/:cl:
