### PR TITLE
Xenos no longer get hungry

### DIFF
--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -17,6 +17,9 @@
 	nutrition = max(amount, 0)
 	adjust_nutrition_speed(.)
 
+/mob/living/carbon/xenomorph/adjust_nutrition(amount)
+	return //xenos don't need food, but admemes can still directly set it if desired
+
 /mob/living/carbon/proc/adjust_nutrition_speed(old_nutrition)
 	switch(nutrition)
 		if(0 to NUTRITION_HUNGRY)


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
This has apparently been an issue for 10 years or whatever. Wowza.
## Why It's Good For The Game
Slowdown meme on xeno bad.
## Changelog
:cl:
fix: Xenos no longer get hungry
/:cl:
