### PR TITLE
Footstep layering fix

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -385,3 +385,6 @@
 /// Increment this define if you make a huge map. We unit test for it too just to make it easy for you
 /// If you modify this, you'll need to modify the tsx file too
 #define MAX_EXPECTED_Z_DEPTH 3
+
+///returns a number that combined plane and layer such that anything visually higher has a higher number, to ensure sound consistancy for footstep overrides
+#define get_footstep_layer(layer, plane) TOPDOWN_LAYER * 2 * (100 + plane) + layer

--- a/code/game/objects/effects/decals/turfdecals/environmental.dm
+++ b/code/game/objects/effects/decals/turfdecals/environmental.dm
@@ -90,7 +90,7 @@
 	AddElement(/datum/element/connect_loc, connections)
 
 /obj/effect/turf_decal/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_WET] = layer
+	footstep_overrides[FOOTSTEP_WET] = get_footstep_layer(layer, plane)
 
 /obj/effect/turf_decal/riverdecal/edge
 	icon_state = "riverdecal_edge"

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /obj/effect/particle_effect/foam/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_WET] = layer
+	footstep_overrides[FOOTSTEP_WET] = get_footstep_layer(layer, plane)
 
 ///Finishes the foam, stopping it from processing and doing whatever it has to do.
 /obj/effect/particle_effect/foam/proc/kill_foam()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -145,7 +145,7 @@
 
 ///overrides the turf's normal footstep sound
 /obj/alien/weeds/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_RESIN] = layer
+	footstep_overrides[FOOTSTEP_RESIN] = get_footstep_layer(layer, plane)
 
 ///special behavior when atoms enter our loc
 /obj/alien/weeds/proc/on_loc_entered(datum/source, atom/movable/crosser)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -404,7 +404,7 @@
 	return TRUE
 
 /obj/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_PLATING] = layer
+	footstep_overrides[FOOTSTEP_PLATING] = get_footstep_layer(layer, plane)
 
 /obj/proc/do_deploy(mob/user, turf/location)
 	if(!istype(location))

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -14,7 +14,7 @@
 
 /obj/structure/flora/footstep_override(atom/movable/source, list/footstep_overrides)
 	//set at the flora level, but the connection is only set where desired
-	footstep_overrides[FOOTSTEP_VEGETATION] = layer
+	footstep_overrides[FOOTSTEP_VEGETATION] = get_footstep_layer(layer, plane)
 
 /obj/structure/flora/ex_act(severity)
 	switch(severity)
@@ -236,7 +236,7 @@
 	AddComponent(/datum/component/submerge_modifier, 10)
 
 /obj/structure/flora/grass/tallgrass/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_GRASS] = layer
+	footstep_overrides[FOOTSTEP_GRASS] = get_footstep_layer(layer, plane)
 
 /obj/structure/flora/grass/tallgrass/tallgrasscorner
 	name = "tall grass"

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -101,7 +101,7 @@
 	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/catwalk/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_CATWALK] = layer
+	footstep_overrides[FOOTSTEP_CATWALK] = get_footstep_layer(layer, plane)
 
 /obj/structure/catwalk/lava_act()
 	return FALSE

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -248,7 +248,7 @@
 	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/stairs/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_CATWALK] = layer
+	footstep_overrides[FOOTSTEP_CATWALK] = get_footstep_layer(layer, plane)
 
 //stand alone stairs
 /obj/structure/stairs/edge

--- a/code/game/objects/structures/rocks.dm
+++ b/code/game/objects/structures/rocks.dm
@@ -252,7 +252,7 @@
 	AddElement(/datum/element/connect_loc, connections)
 
 /obj/structure/rock/variable/jungle_large/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_CONCRETE] = layer
+	footstep_overrides[FOOTSTEP_CONCRETE] = get_footstep_layer(layer, plane)
 
 //drought rocks
 /obj/structure/rock/variable/drought

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -343,7 +343,7 @@
 	AddElement(/datum/element/debris, DEBRIS_WOOD, -40, 5)
 
 /obj/structure/table/wood/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_WOOD] = layer
+	footstep_overrides[FOOTSTEP_WOOD] = get_footstep_layer(layer, plane)
 
 /obj/structure/table/wood/fancy
 	name = "fancy wooden table"

--- a/code/modules/vehicles/_hitbox.dm
+++ b/code/modules/vehicles/_hitbox.dm
@@ -60,7 +60,7 @@
 	root.Shake(pixelshiftx, pixelshifty, duration, shake_interval)
 
 /obj/hitbox/footstep_override(atom/movable/source, list/footstep_overrides)
-	footstep_overrides[FOOTSTEP_HULL] = 4.5
+	footstep_overrides[FOOTSTEP_HULL] = get_footstep_layer(root.layer, root.plane)
 
 ///signal handler for handling PASS_WALKOVER
 /obj/hitbox/proc/can_cross_hitbox(datum/source, atom/mover)


### PR DESCRIPTION

## About The Pull Request
Footstep overrides should layer correctly again.
Changes to layers and planes broke this, so for example weed footstep overrode tank footsteps, because the layer is technically higher even though its on a lower plane.

It now uses a define to use plane and layer to get a simple number that ensures sound layering matches visual layering.
## Why It's Good For The Game
Consistancy good.
## Changelog
:cl:
fix: fixed some footstep overrides applying in the wrong order
/:cl:
