### PR TITLE
Acid Dash recast fix + Multi-cast support

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -765,7 +765,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	var/available_recasts = 1
 	/// Have we hit a human with the last ability cast?
 	var/recast_prerequisite_met = FALSE
-	/// The timer id for the callback that will set the ability on cooldown if recast is not used up in time.
+	/// The timer id for the callback that will set the ability on cooldown if recast(s) is not used up in time.
 	var/recast_decay_timer_id
 	/// Should we do acid_spray_act on those we pass over?
 	var/do_acid_spray_act = TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -757,85 +757,101 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ACID_DASH,
 	)
-	paralyze_duration = 0 // Although we don't do anything related to paralyze, it is nice to have this zeroed out.
+	paralyze_duration = 1 SECONDS
 	charge_range = BOILER_CHARGEDISTANCE
-	///Can we use the ability again
-	var/recast_available = FALSE
-	///Is this the recast
-	var/recast = FALSE
-	/// If we should do acid_spray_act on those we pass over.
+	/// The maximum amount of times that we can recast this ability.
+	var/maximum_recasts = 1
+	/// The available amount of times that we can recast this ability.
+	var/available_recasts = 1
+	/// Have we hit a human with the last ability cast?
+	var/recast_prerequisite_met = FALSE
+	/// The timer id for the callback that will set the ability on cooldown if recast is not used up in time.
+	var/recast_decay_timer_id
+	/// Should we do acid_spray_act on those we pass over?
 	var/do_acid_spray_act = TRUE
-	///List of pass_flags given by this action
+	/// List of pass_flags given by this action.
 	var/charge_pass_flags = PASS_LOW_STRUCTURE|PASS_DEFENSIVE_STRUCTURE|PASS_FIRE
-	/// How long we stun tackled targets
-	var/stun_duration = 1 SECONDS
 	/// The duration in deciseconds in which a trail of opaque gas will last.
-	var/gas_trail_duration = 0
+	var/gas_trail_duration = 0 SECONDS
 
 /datum/action/ability/activable/xeno/charge/acid_dash/New(Target)
 	. = ..()
-	desc = "Instantly dash for [charge_range] tiles, tackling the first marine in your path. If you manage to tackle someone, gain another cast of the ability."
+	desc = "Instantly dash for [charge_range] tiles, leaving a trail of acid in your path. If you manage to dash through someone, gain another cast of the ability."
+
+/datum/action/ability/activable/xeno/charge/acid_dash/on_cooldown_finish()
+	available_recasts = maximum_recasts
+	if(recast_decay_timer_id)
+		deltimer(recast_decay_timer_id)
+		recast_decay_timer_id = null
+	recast_prerequisite_met = FALSE
+	return ..()
+
+/datum/action/ability/activable/xeno/charge/acid_dash/can_use_ability(atom/A, silent, override_flags)
+	. = ..()
+	if(!.)
+		return
+	if(!A)
+		return FALSE
+	if(xeno_owner.xeno_flags & XENO_LEAPING)
+		return FALSE
+	if(!available_recasts)
+		return FALSE
 
 /datum/action/ability/activable/xeno/charge/acid_dash/use_ability(atom/A)
-	if(!A)
-		return
-	if(recast && cooldown_timer)
-		if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_ACID_DASH_ACTIVATION))
-			return
+	if(recast_prerequisite_met)
+		available_recasts = clamp(available_recasts - 1, 0, maximum_recasts)
+	xeno_owner.visible_message(span_xenodanger("[xeno_owner] slides towards \the [A]!"), \
+		span_xenodanger("We dash towards \the [A], spraying acid down our path!") )
+	xeno_owner.emote("roar")
 	RegisterSignal(xeno_owner, COMSIG_XENO_OBJ_THROW_HIT, PROC_REF(obj_hit))
 	RegisterSignal(xeno_owner, COMSIG_MOVABLE_POST_THROW, PROC_REF(charge_complete))
 	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_LEAP_BUMP, PROC_REF(mob_hit))
-	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(acid_steps)) //We drop acid on every tile we pass through
-
-	xeno_owner.visible_message(span_danger("[xeno_owner] slides towards \the [A]!"), \
-	span_danger("We dash towards \the [A], spraying acid down our path!") )
-	xeno_owner.emote("roar")
-	xeno_owner.xeno_flags |= XENO_LEAPING //This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown
-	if(recast)
-		succeed_activate(5) //Greatly reduced cost on recast
-	else
-		succeed_activate()
-
+	RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(acid_steps)) // We drop acid on every tile we pass through.
+	xeno_owner.xeno_flags |= XENO_LEAPING // This has to come before throw_at, which checks impact. So we don't do end-charge specials when thrown.
 	xeno_owner.add_pass_flags(charge_pass_flags, type)
-	owner.throw_at(A, charge_range, 2, owner)
+	xeno_owner.throw_at(A, charge_range, 2, xeno_owner)
+	succeed_activate(available_recasts >= maximum_recasts ? null : 5) // Greatly reduced cost for recasts.
 
 /datum/action/ability/activable/xeno/charge/acid_dash/mob_hit(datum/source, mob/living/living_target)
 	. = TRUE
-	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) //we leap past xenos
+	if(living_target.stat || isxeno(living_target) || !(iscarbon(living_target))) // We leap past xenos.
 		return
-	if(!recast)
-		recast_available = TRUE
 	var/mob/living/carbon/carbon_victim = living_target
-	carbon_victim.ParalyzeNoChain(stun_duration)
-
-	to_chat(carbon_victim, span_userdanger("The [owner] tackles us, sending us behind them!"))
-	owner.visible_message(span_xenodanger("\The [owner] tackles [carbon_victim], swapping location with them!"), \
+	to_chat(carbon_victim, span_userdanger("The [xeno_owner] tackles us, sending us behind them!"))
+	xeno_owner.visible_message(span_xenodanger("\The [xeno_owner] tackles [carbon_victim], swapping location with them!"), \
 		span_xenodanger("We push [carbon_victim] in our acid trail!"), visible_message_flags = COMBAT_MESSAGE)
+	carbon_victim.ParalyzeNoChain(paralyze_duration)
+	recast_prerequisite_met = TRUE
 
 /datum/action/ability/activable/xeno/charge/acid_dash/charge_complete()
 	. = ..()
-	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
-	if(recast_available)
-		addtimer(CALLBACK(src, PROC_REF(charge_complete)), 2 SECONDS) //Delayed recursive call, this time you won't gain a recast so it will go on cooldown in 2 SECONDS.
-		TIMER_COOLDOWN_START(src, COOLDOWN_ACID_DASH_ACTIVATION, 0.3 SECONDS) // Small delay before you can recast, to make it harder to misfire.
-		recast = TRUE
-		recast_available = FALSE
-	else
-		recast = FALSE
-		add_cooldown()
+	UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
 	xeno_owner.remove_pass_flags(charge_pass_flags, type)
-	recast_available = FALSE
+	if(!available_recasts || !recast_prerequisite_met)
+		recast_decayed()
+		return
+	if(recast_decay_timer_id)
+		deltimer(recast_decay_timer_id)
+	recast_decay_timer_id = addtimer(CALLBACK(src, PROC_REF(recast_decayed)), 2 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
 
-///Drops an acid puddle on the current owner's tile, will do 0 damage if the owner has no acid_spray_damage. Creates opaque gas if gas_trail_duration is set by mutation.
+/// Drops an acid puddle on the current owner's tile which uses the owner caste's acid_spray_damage. Creates opaque gas if gas_trail_duration is set.
 /datum/action/ability/activable/xeno/charge/acid_dash/proc/acid_steps(atom/A, atom/OldLoc, Dir, Forced)
 	SIGNAL_HANDLER
 	xenomorph_spray(get_turf(xeno_owner), 5 SECONDS, xeno_owner.xeno_caste.acid_spray_damage, xeno_owner, FALSE, do_acid_spray_act)
-	if(gas_trail_duration)
-		if(xeno_owner.stat != CONSCIOUS)
-			return
-		var/datum/effect_system/smoke_spread/xeno/acid/opaque/smoke = new()
-		smoke.set_up(0, get_turf(xeno_owner), gas_trail_duration / (2 SECONDS))
-		smoke.start()
+	if(!gas_trail_duration || xeno_owner.stat != CONSCIOUS)
+		return
+	var/datum/effect_system/smoke_spread/xeno/acid/opaque/smoke = new()
+	smoke.set_up(0, get_turf(xeno_owner), gas_trail_duration / (2 SECONDS))
+	smoke.start()
+
+/// Sets the ability on cooldown and cleans up everything related to recasting.
+/datum/action/ability/activable/xeno/charge/acid_dash/proc/recast_decayed(atom/A, atom/OldLoc, Dir, Forced)
+	if(recast_decay_timer_id)
+		deltimer(recast_decay_timer_id)
+		recast_decay_timer_id = null
+	available_recasts = 0
+	recast_prerequisite_met = FALSE
+	add_cooldown()
 
 // ***************************************
 // *********** High-Pressure Spit

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -514,13 +514,9 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ACID_DASH_MELTER,
 	)
+	paralyze_duration = 0.5 SECONDS
 	charge_range = 7
 	do_acid_spray_act = FALSE
-	stun_duration = 0.5 SECONDS
-
-/datum/action/ability/activable/xeno/charge/acid_dash/melter/New(Target)
-	. = ..()
-	desc = "Instantly dash for [charge_range] tiles, tackling the first marine in your path. If you manage to tackle someone, gain another cast of the ability."
 
 /datum/action/ability/activable/xeno/melter_shroud
 	name = "Melter Shroud"


### PR DESCRIPTION

## About The Pull Request
Fixes an issue where Acid Dash can be recast during the first activation to skip the prerequisite of having to hit a human (which is needed to get the recast in the first place) which also consumes the recast.

Acid Dash's "safety misfire cooldown" (which didn't even work) has been removed/replaced since the above fix does that now.

Acid Dash's description has been changed to be more accurate on what it does.

Acid Dash's `stun_duration` is functionally renamed to `paralyze_duration`.

Acid Dash can allow for more than one recast if it is changed to do so (by changing `maximum_recasts`).
## Why It's Good For The Game
Fixes a bug that made the recast portion of Acid Dash annoying to use if you double clicked too fast. The refactor makes the code look nicer (to me anyways) and opens new stuff for later (e.g. later update to mutations).

## Changelog
:cl:
fix: Acid Dash cannot be activated if you are in a middle of a leap.
spellcheck: Acid Dash's description correctly tells you that you're dashing through people, not pouncing onto people.
refactor: Refactors Acid Dash in general and adds support for multiple recasts.
/:cl:
