### PR TITLE
Fixes Abduct's Widescreen Range

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -647,7 +647,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	for(var/i = 1 to length(turf_line))
 		var/turf/turf_from_line = turf_line[i]
 		if(get_dist(xeno_turf, turf_from_line) > OPPRESSOR_ADBDUCT_RANGE)
-			turf_line.Cut(1, i + 1)
+			turf_line.Cut(i, length(turf_line) + 1)
 			break
 		telegraphed_atoms += new /obj/effect/xeno/abduct_warning(turf_from_line)
 


### PR DESCRIPTION

## About The Pull Request
Targeting a turf beyond the range limit (7) currently reduces the amount of turfs to the range limit rather than just below it (6).

## Why It's Good For The Game
Bugfix. Makes it so that the targeting using widescreen works.

## Changelog
:cl:
fix: Targeting a turf beyond the maximum range (via widescreen) correctly reduces your range to 7 instead of 6.
/:cl:
