### PR TITLE
agility toggled on/off button icons fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -84,6 +84,10 @@
 	. = ..()
 	desc = "Move on all fours and loosen our scales. Increases movement speed by [abs(speed_modifier)], but reduces all soft armor by [armor_modifier]. Automatically disabled after using an ability."
 
+/datum/action/ability/xeno_action/toggle_agility/update_button_icon()
+	action_icon_state = toggled ? "agility_off" : initial(action_icon_state)
+	return ..()
+
 /datum/action/ability/xeno_action/toggle_agility/action_activate()
 	GLOB.round_statistics.warrior_agility_toggles++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "warrior_agility_toggles")


### PR DESCRIPTION

## About The Pull Request
Agility's button icon now changes when it is toggled.

While it is not toggled, it uses `agility_on`. Otherwise, it uses `agility_off`.
<img width="176" height="104" alt="image" src="https://github.com/user-attachments/assets/7b13221f-4cff-41d5-a254-9da746bbd2cf" />


## Why It's Good For The Game
The sprite is right there in the file. Someone likely forgot (8 years ago) to actually use it.

## Changelog
:cl:
fix: Agility's button icon correctly changes when it is toggled.
/:cl:
