### PR TITLE
carriers no longer stores harmless huggers via active hand

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -865,5 +865,8 @@ GLOBAL_LIST_EMPTY(alive_hugger_list)
 		return FALSE
 	return TRUE
 
+/obj/item/clothing/mask/facehugger/combat/harmless/attack_self(mob/user)
+	return
+
 #undef FACEHUGGER_DEATH
 #undef IMPREGNATION_TIME


### PR DESCRIPTION

## About The Pull Request
Carriers can no longer activate/attack harmless huggers in their active hand to store them.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Carriers can no longer store harmless huggers.
/:cl:
