### PR TITLE
Pillar of Spring Major changes: Spring 2026

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -4,9 +4,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "aat" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/bread,
-/turf/open/floor/mainship,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "abX" = (
 /obj/machinery/camera/autoname/mainship{
@@ -17,11 +16,10 @@
 	},
 /area/mainship/living/pilotbunks)
 "acl" = (
-/obj/machinery/air_alarm{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/table/mainship/nometal,
+/obj/item/toy/deck/kotahi,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "acn" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -46,14 +44,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "adg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/rack,
-/obj/item/conveyor_switch_construct,
-/obj/item/paper/factoryhowto,
-/obj/item/tool/wrench,
-/obj/item/stack/conveyor/thirty,
-/obj/item/tool/screwdriver,
-/obj/item/tool/crowbar,
+/obj/machinery/vending/engivend,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -156,14 +147,6 @@
 /obj/machinery/door/window/secure/bridge,
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
-"alq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/marine/general/smart,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "alH" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/mainship/tcomms,
@@ -352,19 +335,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "aAu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/electricshock{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/mainship/black{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/computer/cloning_console/vats,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/squads/general)
 "aAQ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -398,17 +375,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
-"aCM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
-	},
-/turf/open/floor/whitecyanfour{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
 "aDc" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small,
@@ -806,9 +772,6 @@
 /area/mainship/hallways/hangar)
 "aWF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/marine_selector/clothes,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -899,6 +862,16 @@
 /obj/effect/spawner/random/medical/firstaid/alwaysspawns,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"baH" = (
+/obj/machinery/quick_vendor/beginner,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "bbl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -1068,14 +1041,13 @@
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
 "bnq" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
 	},
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship/black{
-	dir = 10
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
 	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "bnt" = (
 /obj/structure/closet/radiation,
@@ -1498,11 +1470,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "bNl" = (
 /obj/structure/bed/bunkbed,
@@ -1792,12 +1760,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
-"cef" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/sugary_snack,
-/obj/effect/spawner/random/food_or_drink/bread,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "cei" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -1875,16 +1837,6 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
-"ciZ" = (
-/obj/item/trash/cigbutt{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "cjl" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/storage/backpack/marine/engineerpack,
@@ -1975,11 +1927,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "cqY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/table/mainship/nometal,
+/obj/item/toy/deck,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "csh" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -2135,7 +2086,8 @@
 	},
 /area/mainship/command/cic)
 "cCg" = (
-/turf/open/floor/mainship/cargo,
+/obj/item/trash/cigbutt,
+/turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "cCy" = (
 /turf/closed/wall/mainship/outer,
@@ -2149,10 +2101,8 @@
 /area/mainship/hull/lower_hull)
 "cCZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/item/reagent_containers/jerrycan,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/obj/structure/closet/crate/ammo,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "cDN" = (
 /obj/machinery/light/mainship/small{
@@ -2935,10 +2885,6 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
-"dvX" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "dvZ" = (
 /obj/item/attachable/bayonet,
 /obj/structure/table/mainship/nometal,
@@ -2980,8 +2926,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
@@ -3060,19 +3006,6 @@
 	},
 /turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
-"dIo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/smartgunner,
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "dIH" = (
 /obj/machinery/atm,
 /turf/closed/wall/mainship,
@@ -3537,18 +3470,44 @@
 /turf/open/floor/plating,
 /area/mainship/engineering/upper_engineering)
 "ejJ" = (
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/effect/turf_decal/medical_decals/doc{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
 	},
-/turf/open/floor/whitecyantwo,
-/area/mainship/medical/lower_medical)
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/structure/sign/nosmoking_2{
+	dir = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/surgical_tray,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "ekh" = (
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/structure/bed/chair/nometal,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "ekk" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -3745,13 +3704,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "ezY" = (
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/command/self_destruct)
 "eAd" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
@@ -3768,16 +3725,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
-"eBB" = (
-/obj/machinery/quick_vendor/beginner,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "eCc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3897,10 +3844,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "eIM" = (
-/obj/machinery/camera/autoname/mainship,
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/benchpress,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "eJJ" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -3990,13 +3936,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "eOG" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/cell_charger,
-/obj/effect/spawner/random/engineering/powercell,
-/obj/effect/spawner/random/engineering/powercell,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/green{
 	dir = 10
 	},
@@ -4094,8 +4037,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "eUy" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
-/turf/open/floor/mainship,
+/obj/machinery/door/airlock/mainship/marine/general/smart,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/general)
 "eUN" = (
 /obj/machinery/light/mainship{
@@ -4103,13 +4047,6 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"eWu" = (
-/obj/machinery/loadout_vendor,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "eWJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -4119,6 +4056,13 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"eWM" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "eXm" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4191,8 +4135,9 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
 "fbp" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/cable,
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
+	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "fbC" = (
@@ -4508,7 +4453,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/tankerbunks)
 "fsZ" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -4679,10 +4624,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "fAy" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/sugary_snack,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/bed/chair/nometal{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "fAJ" = (
 /turf/closed/wall/mainship,
 /area/crew_quarters/toilet)
@@ -4868,9 +4814,6 @@
 "fJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "fKj" = (
@@ -5456,10 +5399,8 @@
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
 "gqI" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "gqZ" = (
 /obj/machinery/camera/autoname/mainship{
@@ -5471,25 +5412,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"gsd" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/box/small,
-/obj/effect/turf_decal/warning_stripes/smartgunner,
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "gsj" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "gsM" = (
-/obj/machinery/vending/cargo_supply,
-/obj/item/tool/wirecutters,
-/obj/item/tool/screwdriver,
+/obj/machinery/vending/tool,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -5786,10 +5714,6 @@
 "gUa" = (
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"gUo" = (
-/obj/machinery/light/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "gUp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/personal{
 	dir = 2;
@@ -5930,6 +5854,20 @@
 /obj/machinery/landinglight/tadpole,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"hdY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "heh" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -5949,7 +5887,6 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
-/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -6051,9 +5988,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "hlO" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/packagedbar,
-/obj/effect/spawner/random/food_or_drink/sugary_snack,
+/obj/effect/turf_decal/warning_stripes/smartgunner,
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/box/small,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hlS" = (
@@ -6203,12 +6142,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"hvp" = (
-/obj/structure/sign/restroom{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "hvL" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
@@ -6274,10 +6207,11 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/mechpilotquarters)
 "hDh" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/donut_box,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/machinery/door_control/mainship/droppod{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "hDi" = (
 /obj/structure/cable,
 /obj/effect/urban/decal/trash/fifteen,
@@ -6625,8 +6559,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "hXJ" = (
-/obj/structure/closet/crate/ammo,
 /obj/structure/disposalpipe/segment,
+/obj/structure/closet/crate/weapon,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "hYl" = (
@@ -6907,13 +6841,6 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
-"inU" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "iom" = (
 /obj/machinery/photocopier,
 /turf/open/floor/mainship/floor,
@@ -6958,17 +6885,15 @@
 	},
 /area/mainship/squads/general)
 "isK" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/obj/effect/turf_decal/warning_stripes/box/arrow,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "isR" = (
 /turf/open/floor/wood,
 /area/mainship/living/mechpilotquarters)
 "its" = (
 /obj/machinery/bot/roomba,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "iuw" = (
 /obj/structure/disposalpipe/segment,
@@ -7071,17 +6996,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/boxingring)
 "iBL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "iCT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7446,9 +7364,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "iZI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -7594,20 +7511,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jlV" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "jmu" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -7940,11 +7846,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "jOQ" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/item/paper/factoryhowto,
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "jPt" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 8
@@ -7998,12 +7902,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "jTU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/mainship/marine/general/smart,
-/turf/open/floor/mainship,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "jTZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8099,11 +8000,9 @@
 	},
 /area/mainship/living/chapel)
 "kbg" = (
-/obj/structure/sign/electricshock{
-	dir = 8
-	},
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/black{
-	dir = 8
+	dir = 1
 	},
 /area/mainship/squads/general)
 "kbE" = (
@@ -8134,12 +8033,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "kdD" = (
-/obj/structure/sign/prop1{
-	dir = 1
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "supply_elevator_railing"
 	},
-/obj/machinery/marine_selector/gear/smartgun,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/machinery/gear{
+	id = "supply_elevator_gear"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/req)
 "kfm" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
@@ -8340,16 +8242,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kuk" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/misc/paperbin{
-	pixel_y = 5
+/obj/structure/bed/chair/nometal{
+	dir = 8
 	},
-/obj/item/clipboard{
-	pixel_x = 5
-	},
-/obj/item/tool/pen,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/general)
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "kuy" = (
 /obj/machinery/light/mainship/small{
 	dir = 4
@@ -8592,9 +8489,6 @@
 /area/mainship/command/cic)
 "kId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "kJM" = (
@@ -8667,7 +8561,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/weapon,
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "kML" = (
@@ -8864,12 +8761,6 @@
 /obj/structure/window/framed/mainship/white,
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
-"kWc" = (
-/obj/machinery/door/poddoor/railing{
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
 "kWu" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/poddoor/shutters/opened/medbay{
@@ -9036,12 +8927,11 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/squads/req)
 "lht" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "supply_elevator_railing"
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/squads/req)
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "lhG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -9069,7 +8959,10 @@
 /obj/machinery/vending/nanomed{
 	dir = 8
 	},
-/obj/machinery/vending/engivend,
+/obj/structure/table/mainship/nometal,
+/obj/effect/spawner/random/engineering/powercell,
+/obj/effect/spawner/random/engineering/powercell,
+/obj/machinery/cell_charger,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -9231,6 +9124,12 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
+"lpn" = (
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "lpt" = (
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
@@ -9242,21 +9141,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "lqS" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/light/floor,
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = -10;
-	pixel_y = 15
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/sleep_console{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = 10;
-	pixel_y = 13
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lrn" = (
 /obj/structure/cable,
@@ -9598,14 +9489,9 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "lIW" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/soundplayer/deltaplayer,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "lJt" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
@@ -9700,10 +9586,12 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "lNe" = (
-/obj/item/trash/cigbutt,
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/packagedbar,
-/obj/effect/spawner/random/food_or_drink/sugary_snack,
+/obj/machinery/door/airlock/mainship/marine/general/smart{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lOk" = (
@@ -9740,6 +9628,16 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lQb" = (
@@ -9748,11 +9646,14 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "lQN" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/bot/cleanbot,
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lRc" = (
 /obj/machinery/light/mainship/small{
@@ -9855,11 +9756,10 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "lTL" = (
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/holopad,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "lTQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -10136,11 +10036,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mnb" = (
-/obj/structure/sign/poster{
-	dir = 1
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "mng" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 9
@@ -10178,7 +10080,7 @@
 "mpj" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/tankerbunks)
 "mps" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10288,10 +10190,8 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "mxo" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/mainship,
+/obj/machinery/air_alarm,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "mxq" = (
 /obj/machinery/landinglight/cas{
@@ -10666,11 +10566,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "mUU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/sleep_console{
-	dir = 8
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
@@ -10775,7 +10675,7 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/ntlogo/nt3,
 /area/mainship/squads/general)
 "nbC" = (
 /obj/effect/ai_node,
@@ -10799,15 +10699,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "ncI" = (
-/obj/machinery/computer/cryopod{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/command/self_destruct)
 "ncO" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"ndA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "ndG" = (
 /obj/structure/bed/chair/sofa/right,
 /obj/item/bedsheet/ce{
@@ -10926,9 +10834,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "njf" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "vehicle_elevator_railing"
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "njE" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -10997,12 +10908,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"nmm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "nnF" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -11033,12 +10938,12 @@
 /turf/open/shuttle/escapepod/zero,
 /area/mainship/command/self_destruct)
 "nsl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "nsC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -11119,11 +11024,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "nyh" = (
-/obj/structure/sign/pods{
-	dir = 1
-	},
 /obj/machinery/light/mainship{
 	dir = 8
+	},
+/obj/structure/sign/pods{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
@@ -11183,12 +11088,14 @@
 	},
 /area/mainship/squads/general)
 "nAM" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "nBk" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -11358,9 +11265,19 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "nNV" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/mainship/ntlogo/nt2,
-/area/mainship/squads/general)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/computer/cloning_console/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "nNY" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/ship_ammo/cas/heavygun,
@@ -11629,15 +11546,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
-"ocK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/obj/item/tool/weldpack,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "oda" = (
 /obj/structure/sink{
 	dir = 1
@@ -11724,6 +11632,15 @@
 /obj/structure/prop/flag,
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
+"onk" = (
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/effect/turf_decal/medical_decals/doc{
+	dir = 4
+	},
+/turf/open/floor/whitecyantwo,
+/area/mainship/medical/lower_medical)
 "onC" = (
 /obj/structure/sink{
 	dir = 4
@@ -11795,29 +11712,12 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"osF" = (
-/obj/structure/closet/crate/weapon,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/req)
 "osQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"osT" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/food_or_drink/donut,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"otn" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/req)
 "ouq" = (
 /obj/structure/cable,
 /obj/structure/table/mainship/nometal,
@@ -11874,12 +11774,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oyZ" = (
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/whitecyanthree{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "ozU" = (
 /obj/structure/disposalpipe/segment,
@@ -11940,13 +11846,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"oGN" = (
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "oGO" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -11958,8 +11857,13 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "oGT" = (
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/squads/general)
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/turf/open/floor/whitecyanthree{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "oHj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -12133,6 +12037,11 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldpack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -12296,9 +12205,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pbh" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/general)
 "pbx" = (
 /obj/machinery/light/mainship,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -12349,12 +12257,6 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar/droppod)
-"peH" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "peU" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 5
@@ -12527,10 +12429,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "pnf" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "pnF" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -13849,12 +13751,20 @@
 	},
 /area/mainship/living/chapel)
 "qRu" = (
-/obj/machinery/holopad,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "qRK" = (
 /mob/living/simple_animal/corgi/walten,
 /obj/item/reagent_containers/food/snacks/meatsteak,
@@ -13968,7 +13878,7 @@
 	pixel_x = 5;
 	pixel_y = -8
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
 "qXC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14307,12 +14217,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
-"rug" = (
-/obj/machinery/light/floor{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "ruM" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -14496,13 +14400,20 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "rGl" = (
-/obj/machinery/bot/cleanbot,
-/obj/machinery/bodyscanner{
-	dir = 1
+/obj/structure/table/mainship/nometal,
+/obj/machinery/light/floor,
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = -10;
+	pixel_y = 15
 	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = 10;
+	pixel_y = 13
+	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "rHh" = (
@@ -14894,11 +14805,10 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
 "sjY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/donut_box,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "skU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -15233,13 +15143,14 @@
 	},
 /area/mainship/medical/lower_medical)
 "sGk" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "sGA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -15254,9 +15165,16 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "sHF" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/ntlogo,
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 8
+	},
+/turf/open/floor/whitecyanfour{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "sIN" = (
 /obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/mainship/sterile/dark,
@@ -15325,12 +15243,6 @@
 /obj/structure/ship_ammo/cas/rocket/widowmaker,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"sPp" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "sPS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15472,10 +15384,6 @@
 /turf/open/floor/mainship/blue{
 	dir = 9
 	},
-/area/mainship/squads/general)
-"sYd" = (
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "sYv" = (
 /obj/structure/cable,
@@ -16259,40 +16167,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tWq" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/structure/sign/nosmoking_2{
-	dir = 4;
-	pixel_y = -4
-	},
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/machinery/power/apc/mainship{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "tWD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -16320,13 +16208,6 @@
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
-/area/mainship/squads/general)
-"tXJ" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/machinery/marine_selector/clothes/smartgun,
-/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "tXZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -16477,13 +16358,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"ugL" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "uhj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16519,11 +16393,13 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "uiX" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
+/obj/item/stack/conveyor/thirty,
+/obj/item/tool/screwdriver,
+/obj/item/tool/crowbar,
+/obj/item/tool/wrench,
+/obj/structure/rack,
+/obj/item/conveyor_switch_construct,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "ujw" = (
 /obj/effect/soundplayer/deltaplayer,
@@ -16750,22 +16626,6 @@
 "uyy" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
-"uzm" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "supply_elevator_railing"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 1
-	},
-/area/mainship/squads/req)
 "uzy" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/mono,
@@ -17137,25 +16997,21 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uVk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
 	},
-/obj/machinery/quick_vendor/beginner,
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "uVF" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/structure/bed/chair/nometal{
+	dir = 4
 	},
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "uWB" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
@@ -17448,15 +17304,6 @@
 "vou" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/pilotbunks)
-"voR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/bed/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "vqo" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -17641,7 +17488,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vAb" = (
@@ -17669,20 +17515,8 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "vBY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/cargo,
+/area/mainship/squads/general)
 "vCB" = (
 /obj/structure/table/mainship,
 /obj/item/whistle,
@@ -18024,11 +17858,20 @@
 	},
 /area/mainship/living/chapel)
 "wfO" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
+/obj/item/trash/cigbutt{
+	pixel_x = 5;
+	pixel_y = -8
 	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/item/trash/cigbutt,
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/bed/chair/nometal{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "wgn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -18272,10 +18115,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "wtS" = (
@@ -18349,11 +18190,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "wyY" = (
-/obj/structure/prop/mainship/gelida/lightstick,
 /obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "wAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18417,12 +18258,9 @@
 	},
 /area/mainship/squads/general)
 "wDN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/structure/table/mainship/nometal,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "wDQ" = (
 /obj/machinery/door/airlock/mainship/secure{
 	dir = 2
@@ -18639,16 +18477,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
-"wQH" = (
-/obj/structure/bed/chair/wood/normal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "wQJ" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/port_umbilical)
@@ -18776,14 +18604,6 @@
 "wWQ" = (
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
-"wXm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "wXr" = (
 /obj/structure/dropship_equipment/shuttle/tangle_emitter,
 /turf/open/floor/mainship/orange{
@@ -18850,28 +18670,13 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/brig)
-"xbi" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id = "qm_warehouse";
-	name = "\improper Warehouse Shutters"
-	},
-/turf/open/floor/mainship/green/full,
-/area/mainship/squads/req)
 "xbv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "xbA" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/camera/autoname/mainship{
@@ -18908,9 +18713,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "xdN" = (
@@ -19019,10 +18822,13 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/upper_engineering)
 "xkF" = (
+/obj/machinery/door/poddoor/railing{
+	id = "supply_elevator_railing"
+	},
 /obj/machinery/gear{
 	id = "supply_elevator_gear"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "xlo" = (
 /obj/structure/cable,
@@ -19076,7 +18882,7 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "xnW" = (
-/obj/vehicle/ridden/powerloader,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "xoE" = (
@@ -19174,9 +18980,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "xuy" = (
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "xuA" = (
 /obj/item/clothing/head/warning_cone,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19302,10 +19107,7 @@
 /area/mainship/command/corporateliaison)
 "xAr" = (
 /obj/machinery/light/mainship,
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "xAX" = (
 /obj/structure/sign/safety/cryogenic{
@@ -19319,10 +19121,8 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "xBf" = (
 /obj/structure/window/reinforced/toughened{
@@ -19383,19 +19183,18 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "xBS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/quick_vendor/beginner,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "xBT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19483,7 +19282,11 @@
 	name = "\improper Warehouse Shutters"
 	},
 /obj/structure/plasticflaps/sturdy,
-/turf/open/floor/mainship/green/full,
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
+	},
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "xHU" = (
 /turf/open/floor/mainship/orange{
@@ -19665,12 +19468,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "xTr" = (
-/obj/vehicle/ridden/motorbike{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4
 	},
+/obj/item/tool/wirecutters,
+/obj/machinery/vending/cargo_supply,
+/obj/item/tool/screwdriver,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "xTN" = (
@@ -19845,6 +19648,10 @@
 	dir = 2;
 	id = "qm_warehouse";
 	name = "\improper Warehouse Shutters"
+	},
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
@@ -20084,6 +19891,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/machinery/door_control/mainship/droppod,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 
@@ -47689,7 +47497,7 @@ xBT
 cYZ
 kWu
 ouq
-lQN
+eWM
 mNf
 qFX
 iMF
@@ -47697,7 +47505,7 @@ uQU
 mgw
 mgw
 nMm
-ncI
+yjx
 mvs
 mbQ
 xGl
@@ -48719,12 +48527,12 @@ mvs
 xZy
 gnK
 xjD
-rGl
+lQN
 bnL
 xVO
 lAT
 lAT
-xBS
+hdY
 yjx
 mvs
 mbQ
@@ -48974,14 +48782,14 @@ lSk
 dpY
 nRz
 usa
-vBY
+tWq
 gNc
 mnH
 gNc
 rHK
-lTL
+lpn
 lAT
-aAu
+nNV
 yjx
 mvs
 mbQ
@@ -49232,10 +49040,10 @@ fwq
 mvs
 jUl
 lxg
-oyZ
+oGT
 aiP
 aiP
-aCM
+sHF
 rrp
 lAT
 nMm
@@ -49487,7 +49295,7 @@ brN
 aWk
 aQX
 mvs
-lqS
+rGl
 hGO
 bYJ
 pDg
@@ -49746,13 +49554,13 @@ cYZ
 mvs
 kYM
 bFG
-ejJ
+onk
 dIk
 ksa
 jWB
 dnQ
 lAT
-xbv
+oyZ
 yjx
 mvs
 nla
@@ -50008,7 +49816,7 @@ pEN
 rkq
 xSi
 foU
-mUU
+lqS
 mam
 yjx
 mvs
@@ -50264,7 +50072,7 @@ oCo
 loc
 dNQ
 nRH
-jlV
+qRu
 aDU
 wNF
 lTH
@@ -50521,7 +50329,7 @@ qOa
 uCj
 onC
 lXB
-tWq
+ejJ
 mHW
 fom
 oOM
@@ -50771,7 +50579,7 @@ gcM
 tzk
 aWk
 dpY
-pbh
+lIW
 dpY
 mvs
 mvs
@@ -50781,7 +50589,7 @@ mvs
 mvs
 dTh
 gQY
-lIW
+mUU
 nRz
 pdj
 pdj
@@ -51029,6 +50837,7 @@ tzk
 aWk
 dpY
 dpY
+dpY
 tWD
 vAn
 vAn
@@ -51036,13 +50845,12 @@ vAn
 vAn
 fDJ
 vAn
-vAn
 vhl
 vAn
 vAn
 swv
 vAn
-vAn
+hDh
 jjY
 vAn
 vAn
@@ -51286,8 +51094,8 @@ eDF
 xGr
 qST
 rEw
+eks
 xlo
-vgo
 vgo
 vgo
 vgo
@@ -51543,12 +51351,12 @@ dpY
 dpY
 dpY
 dpY
+dpY
 yaf
 vAn
 wLx
 wLx
 wLx
-vAn
 vAn
 vAn
 bYG
@@ -51800,12 +51608,12 @@ dpY
 dpY
 dpY
 eAd
+dpY
 ybP
 cHE
 wYz
 xfo
 wYz
-cHE
 cHE
 lxK
 fQO
@@ -52057,13 +51865,13 @@ dpY
 dpY
 dpY
 dpY
+dpY
 sPS
 cHE
 wYz
 wYz
 wYz
 cHE
-peH
 hhf
 prY
 ekT
@@ -52304,6 +52112,7 @@ nyF
 kfB
 gup
 dpY
+dpY
 fFw
 jMP
 pke
@@ -52316,10 +52125,9 @@ tTW
 sVI
 qNE
 lBs
-kWc
 xKE
-kWc
-kWc
+xKE
+xKE
 xkF
 hhf
 doG
@@ -52328,8 +52136,8 @@ igh
 iYf
 iYf
 iYf
-ocK
-osF
+iYf
+iYf
 hXJ
 cCZ
 qsI
@@ -52561,6 +52369,7 @@ hFZ
 kDx
 qPc
 dpY
+dpY
 nwX
 tHk
 nzB
@@ -52577,7 +52386,6 @@ gMb
 gMb
 gMb
 gMb
-nAM
 xHi
 iiU
 djj
@@ -52818,6 +52626,7 @@ csW
 lGv
 qPc
 dpY
+dpY
 nwX
 cfw
 kDx
@@ -52834,8 +52643,7 @@ gMb
 gMb
 gMb
 gMb
-nAM
-xbi
+xZo
 eGl
 kPn
 xjF
@@ -53075,6 +52883,7 @@ kDx
 cxw
 qPc
 dpY
+dpY
 nwX
 cfw
 kDx
@@ -53085,20 +52894,19 @@ kDx
 kDx
 cxw
 vPk
-uzm
+ubU
 gMb
 gMb
 qvM
 gMb
 gMb
-otn
 xZo
 cim
 vcN
 dmU
 gUa
 gUa
-gUa
+uiX
 qHj
 gUa
 gUa
@@ -53332,6 +53140,7 @@ kDx
 kwo
 qPc
 dpY
+dpY
 nwX
 cfw
 kDx
@@ -53348,14 +53157,13 @@ gMb
 gMb
 gMb
 gMb
-nAM
-xbi
+xZo
 qKL
 vcN
 xjF
 gUa
 gUa
-gUa
+jOQ
 gUa
 gUa
 gUa
@@ -53589,6 +53397,7 @@ kDx
 cxw
 qPc
 dpY
+dpY
 nwX
 nbW
 qWy
@@ -53605,8 +53414,7 @@ gMb
 gMb
 gMb
 gMb
-nAM
-xbi
+xZo
 qKL
 vcN
 peU
@@ -53846,6 +53654,7 @@ kDx
 kwo
 qPc
 dpY
+dpY
 qfG
 jrk
 sAI
@@ -53858,18 +53667,17 @@ yki
 hdc
 qNE
 dmm
-lht
 eXm
-lht
-lht
-xkF
+eXm
+eXm
+kdD
 hhf
 iOD
 gbc
 aYd
 aYd
 aYd
-aYd
+wyY
 fmo
 rKk
 uvy
@@ -54104,6 +53912,7 @@ cxw
 mxq
 dpY
 dpY
+dpY
 pfU
 dpY
 pCc
@@ -54119,7 +53928,6 @@ cHE
 unN
 eFA
 cHE
-inU
 hhf
 lgN
 rKk
@@ -54361,6 +54169,7 @@ kwo
 qPc
 dpY
 dpY
+dpY
 aHp
 dpY
 exV
@@ -54376,7 +54185,6 @@ cHE
 cHE
 cHE
 cHE
-uiX
 lxK
 hhf
 rKk
@@ -54627,8 +54435,8 @@ vmD
 vmD
 vmD
 rWD
-aHG
 vmD
+aHG
 vmD
 vmD
 vmD
@@ -54876,7 +54684,7 @@ nZU
 diD
 rWK
 xdE
-ykH
+mnb
 ykH
 vzN
 ykH
@@ -54884,13 +54692,13 @@ ykH
 rCU
 uMj
 uNt
+uMj
 jOm
 niH
 niH
 kVt
 rWK
 bjC
-wXm
 niH
 qQf
 ndN
@@ -54930,9 +54738,9 @@ fYB
 bby
 mBc
 vmD
-nmm
+vmD
 gqZ
-wNG
+vmD
 vmD
 rKm
 vmD
@@ -55131,7 +54939,7 @@ hFZ
 kDx
 oZN
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
@@ -55186,12 +54994,12 @@ pGb
 syR
 jfZ
 hme
-rUF
-jTU
-rUF
-alq
-rUF
-mqK
+fUs
+vmD
+vmD
+vmD
+vmD
+ezY
 xZL
 xZL
 xZL
@@ -55388,20 +55196,20 @@ fmN
 lHG
 fku
 vmD
-vmD
-vmD
-vmD
-vmD
-vmD
-vmD
+bLP
 mXm
-fbp
-oGN
-oGN
-oGN
-ezY
-oGN
 mOo
+fbp
+fbp
+fbp
+nsl
+fbp
+mOo
+mXm
+mXm
+mXm
+mXm
+miU
 omW
 lVR
 kGc
@@ -55437,18 +55245,18 @@ cmb
 rUF
 koX
 pGb
-oGT
+pbh
 xkC
 kHp
 syR
 gFW
 rUF
-sMn
-iBL
+xuy
+xuy
 uVF
-cqY
-acl
-mqK
+uVF
+xuy
+ezY
 hPb
 wuQ
 bdT
@@ -55645,20 +55453,20 @@ dpY
 dpY
 qvN
 vmD
-vmD
-vmD
-vmD
-rug
-vmD
-vmD
+bLP
 mXm
-sGk
+njf
 eFo
 eFo
 eFo
 eFo
 eFo
 pqQ
+mXm
+mXm
+mXm
+mXm
+miU
 tpi
 tFb
 kGc
@@ -55701,11 +55509,11 @@ fYB
 elQ
 rUF
 eIM
+ekh
 sjY
-xcf
 wDN
 wfO
-mqK
+ezY
 vHA
 wuQ
 oXX
@@ -55902,20 +55710,20 @@ kHN
 eFh
 nPF
 vmD
-vmD
-vmD
-vmD
-vmD
-vmD
-hvp
+bLP
 mXm
-sGk
+njf
 eFo
 eFo
 eFo
 eFo
 eFo
 pqQ
+hTV
+mXm
+mXm
+mXm
+miU
 eel
 pgh
 vDH
@@ -55936,7 +55744,7 @@ cPg
 lTQ
 lOp
 aDz
-cCg
+vBY
 eMz
 eMz
 eMz
@@ -55958,11 +55766,11 @@ pyS
 hGE
 rUF
 xuy
-sjY
-vIv
+ekh
+acl
 cqY
 fAy
-mqK
+ezY
 ukb
 wuQ
 nuZ
@@ -56159,20 +55967,20 @@ vou
 vou
 vou
 pqC
-ekx
-ekx
-ekx
-ekx
-dWi
-ekx
+iBL
 mXm
-sGk
+njf
 eFo
 eFo
 lpt
 eFo
 eFo
 pqQ
+mXm
+mXm
+mXm
+mXm
+miU
 miU
 eQb
 fqj
@@ -56214,12 +56022,12 @@ rUF
 oXs
 rUF
 ekL
-ikM
-sjY
-ikM
-cqY
-cef
-mqK
+lht
+uVF
+uVF
+xuy
+xuy
+ezY
 lys
 plr
 plr
@@ -56416,20 +56224,20 @@ vou
 mds
 thc
 vou
-eQW
-xSN
-xSN
-xSN
-kdC
-ekx
 mXm
-sGk
+mXm
+njf
 eFo
 eFo
 eFo
 eFo
 eFo
 pqQ
+mXm
+mXm
+mXm
+mXm
+miU
 tpi
 eQb
 kGc
@@ -56466,18 +56274,18 @@ cey
 xxM
 wCD
 cey
-kbg
+aAu
 fee
 jqy
 iae
 mBc
-tXJ
+ekh
 sjY
-iFI
-nsl
-jOQ
-mqK
-lRc
+wDN
+wfO
+xuy
+ezY
+uKH
 lAn
 xTN
 fSq
@@ -56673,20 +56481,20 @@ gKG
 shB
 mJw
 vou
-fsZ
-fXX
-njf
-fXX
-dlz
-ekx
 mXm
-sGk
+mXm
+njf
 eFo
 eFo
 eFo
 eFo
 eFo
 pqQ
+mXm
+mXm
+mXm
+mXm
+miU
 eel
 vyj
 ciN
@@ -56706,8 +56514,8 @@ xVU
 bSp
 kMf
 tfQ
-eYx
-sHF
+fPM
+rHh
 cPg
 cMq
 its
@@ -56715,7 +56523,7 @@ cPg
 cPg
 kQp
 cPg
-cPg
+buS
 tis
 cPg
 cPg
@@ -56729,11 +56537,11 @@ cPg
 llW
 rUF
 ekh
-sjY
-cPg
+acl
 cqY
-wfO
-mqK
+fAy
+xuy
+ezY
 uKH
 eOT
 dGh
@@ -56930,20 +56738,20 @@ vou
 vou
 vou
 vou
-fpg
-fpg
-vmD
-vmD
-ikO
-ekx
 dzr
-wyY
+mXm
+qtr
 eXp
 tXl
 eXp
 eXp
 eXp
-qtr
+mOo
+hTV
+mXm
+mXm
+mXm
+miU
 miU
 fqj
 eQb
@@ -56964,33 +56772,33 @@ bSp
 dfI
 oCN
 eYx
-tJA
-rFS
-rDn
+cPg
+cPg
+cPg
 qXc
 cPg
-rDn
+cPg
 bNh
-rDn
 cPg
-cPg
-rDn
-rFS
-ciZ
 tJA
 cPg
-rDn
-rFS
+cPg
+cPg
+xLV
+tJA
+cPg
+cPg
+cPg
 cPg
 cPg
 lOp
 rUF
-kdD
-sjY
-jDj
-cqY
-cef
-mqK
+xuy
+kuk
+kuk
+xuy
+xuy
+ezY
 uKH
 nse
 jBA
@@ -57187,20 +56995,20 @@ gKG
 mvX
 fgN
 vou
-ekx
-ekx
-vmD
-ekx
-ekx
-ekx
 luk
-bLP
-hTV
 mXm
 mXm
 mXm
 mXm
 mXm
+mXm
+mXm
+mXm
+mXm
+mXm
+mXm
+mXm
+miU
 tpi
 tpi
 miU
@@ -57221,33 +57029,33 @@ bSp
 cPg
 lOp
 eYx
+cPg
+rFS
+rDn
 bYP
-vVG
 cPg
-cPg
-cPg
-cPg
+rDn
 kMt
-cPg
+rDn
 nbu
 cPg
-cPg
-vVG
-xLV
+rDn
+rFS
+uVk
 bYP
 cPg
-cPg
-vVG
+rDn
+rFS
 cPg
 cPg
 lOp
 rUF
-mnb
-sjY
-vIv
-cqY
-fAy
-mqK
+vmD
+vmD
+vmD
+vmD
+vmD
+ezY
 uKH
 mka
 fEf
@@ -57444,25 +57252,25 @@ vou
 nIj
 mds
 vou
-jfb
-xQB
-wrW
-xQB
-byk
-ekx
+mXm
+mXm
+mXm
+mXm
+mXm
+mXm
 vcJ
-ugL
-mXm
-hTV
 mXm
 mXm
 mXm
+mXm
+mXm
+mXm
 ekx
 ekx
 ekx
 ekx
 ekx
-ekx
+dWi
 ekx
 ekx
 uyy
@@ -57473,39 +57281,39 @@ uyy
 eqQ
 vvz
 uyy
-fPM
+kbg
 cdu
 cPg
 lOp
 eYx
 cPg
-nQH
-xYh
+vVG
+rrh
 tis
 cPg
-xYh
-pWo
-xYh
+rrh
+ndA
+rrh
 cPg
 cPg
-xYh
-nQH
-qRu
+rrh
+vVG
+lTL
 cPg
 cPg
-xYh
-nQH
+rrh
+vVG
 cPg
 cPg
 lOp
 rUF
-iay
-iBL
-eWu
-cqY
-jOQ
-mqK
-lRc
+fUs
+vmD
+vmD
+vmD
+vmD
+ezY
+uKH
 dDg
 lcw
 vuX
@@ -57701,26 +57509,26 @@ vou
 vou
 vou
 vou
-ekx
-ekx
+xLu
+xLu
 fsp
-ekx
-ekx
-ekx
-ekx
-ekx
+xLu
+xLu
+xLu
+xLu
+xLu
 mpj
 tux
 xLu
 xLu
 xLu
 ekx
-uEg
-uEg
-uEg
-uEg
-uEg
-uEg
+eQW
+xSN
+xSN
+xSN
+kdC
+ekx
 uEg
 uyy
 sKv
@@ -57742,27 +57550,27 @@ bpK
 bpK
 kId
 fJI
-rDn
+eMz
 cPg
 cPg
-rDn
-rFS
-rDn
+eMz
+jlV
+eMz
 cPg
 cPg
-rDn
-rFS
+eMz
+jlV
 cPg
 tis
-ini
+lOp
 mBc
-rUF
 jTU
 rUF
-alq
-mBc
-mqK
-uKH
+rUF
+rUF
+eUy
+ncI
+lRc
 jWH
 plr
 guJ
@@ -57972,12 +57780,12 @@ vXQ
 vXQ
 sSW
 ekx
-uEg
-uEg
-uEg
-uEg
-uEg
-uEg
+fsZ
+fXX
+fXX
+fXX
+vmD
+ekx
 uEg
 uyy
 cSz
@@ -57994,29 +57802,29 @@ fee
 mEk
 cPg
 vVG
+rrh
 cPg
 cPg
+rrh
+xbv
+rrh
 cPg
 cPg
-kMt
+rrh
+vVG
+rrh
 cPg
 cPg
-cPg
-cPg
+rrh
 vVG
 cPg
 cPg
-cPg
-cPg
-vVG
-cPg
-cPg
-fee
-cey
-fee
-dIo
-fee
-gsd
+lOp
+rUF
+nAM
+pbh
+xkC
+krM
 bnq
 mqK
 uKH
@@ -58229,12 +58037,12 @@ eSw
 vXQ
 eZp
 ekx
-uEg
-uEg
-uEg
-uEg
-uEg
-uEg
+fpg
+fpg
+vmD
+vmD
+ikO
+ekx
 ekx
 uyy
 uyy
@@ -58249,15 +58057,15 @@ qjf
 mng
 eLs
 xmJ
-buS
+cPg
 esQ
 xYh
-cPg
+buS
 cPg
 xYh
 pWo
 xYh
-cMq
+cCg
 cPg
 xYh
 nQH
@@ -58268,13 +58076,13 @@ xYh
 nQH
 cPg
 cPg
+lOp
+rUF
 mxo
-mxo
-mxo
-wQH
-mxo
-cPg
-cPg
+vIv
+vIv
+vIv
+vIv
 mqK
 uKH
 eOT
@@ -58486,12 +58294,12 @@ vXQ
 vXQ
 uXw
 ekx
-uEg
-uEg
-uEg
-uEg
-uEg
-uEg
+ekx
+ekx
+vmD
+ekx
+ekx
+ekx
 ekx
 eJL
 hvM
@@ -58506,15 +58314,15 @@ hoq
 qlX
 tAO
 oJs
-nNV
+adk
 edj
 fLM
-cPg
+tJA
 cPg
 fLM
-uVk
+xBS
 fLM
-cPg
+tJA
 cPg
 fLM
 sqc
@@ -58522,16 +58330,16 @@ fLM
 tJA
 cPg
 fLM
-eBB
+baH
 cPg
 cPg
-osT
-hlO
-aat
-kuk
-sYd
-rHh
-gUo
+lOp
+rUF
+vIv
+ikM
+vIv
+iay
+xAr
 mqK
 uKH
 nse
@@ -58729,10 +58537,10 @@ nWT
 nWT
 nWT
 nWT
-nWT
-nWT
-nWT
-nWT
+qpC
+qpC
+qpC
+qpC
 nWT
 nWT
 esN
@@ -58743,12 +58551,12 @@ vXQ
 lqa
 rOV
 ekx
-uEg
-uEg
-uEg
-uEg
-uEg
-uEg
+jfb
+xQB
+wrW
+xQB
+byk
+ekx
 ekx
 rPd
 hZe
@@ -58763,15 +58571,15 @@ bSp
 lEz
 sXV
 nUc
-bYP
+cPg
 aJV
 cPg
-cPg
+bYP
 cPg
 cPg
 lgL
 cPg
-cPg
+bYP
 cPg
 cPg
 aJV
@@ -58784,11 +58592,11 @@ cPg
 cPg
 hlO
 lNe
-hlO
-hDh
-sYd
-cPg
-cPg
+vIv
+sMn
+xcf
+aat
+vIv
 mqK
 hVb
 fEf
@@ -58986,11 +58794,11 @@ qpC
 qpC
 qpC
 qpC
-qpC
-qpC
-qpC
-qpC
-nWT
+qVo
+mBZ
+mBZ
+qVo
+hRh
 nWT
 esN
 unX
@@ -59040,12 +58848,12 @@ bpK
 bpK
 bpK
 iZI
-voR
+rUF
 pnf
-pnf
-pnf
-cPg
-eUy
+iFI
+isK
+jDj
+vIv
 hRA
 iXQ
 iXQ
@@ -59297,12 +59105,12 @@ cPg
 cPg
 tis
 cPg
-cPg
-cPg
-cPg
-cPg
-tis
-dvX
+rUF
+pnf
+vIv
+sGk
+vIv
+vIv
 rKn
 sYv
 sBr
@@ -59553,12 +59361,12 @@ cPg
 cPg
 cPg
 cPg
-cPg
-cPg
-cPg
-pzU
+hlO
+lNe
+vIv
+iFI
 isK
-sPp
+jDj
 xAr
 rKn
 uzA
@@ -59811,7 +59619,7 @@ gaz
 cPg
 cPg
 cPg
-cPg
+rUF
 rKn
 rKn
 rKn

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -62,6 +62,15 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"ado" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "adr" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -233,16 +242,10 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "aqn" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/item/clothing/head/warning_cone,
-/obj/machinery/landinglight/tadpole{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/assault_crewman,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "aqp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -351,11 +354,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "aAu" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 2
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/mainship/floor,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "aAQ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -768,11 +772,6 @@
 /obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
-"aUw" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/squads/general)
 "aVn" = (
 /obj/structure/orbital_cannon,
 /obj/machinery/light/mainship/small{
@@ -794,11 +793,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aWF" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/marine_selector/clothes,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "aXc" = (
@@ -826,11 +825,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"aYR" = (
-/turf/open/floor/mainship/blue{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "aYW" = (
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -894,9 +888,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "baH" = (
-/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/sterile/side{
-	dir = 5
+	dir = 6
 	},
 /area/mainship/squads/general)
 "bbl" = (
@@ -919,11 +912,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "bby" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/air_alarm{
+	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/obj/structure/sign/prop1,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "bch" = (
 /obj/structure/bed/chair/comfy/black,
@@ -1106,16 +1099,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"brj" = (
-/obj/machinery/chem_dispenser,
+"brH" = (
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
 /area/mainship/medical/chemistry)
-"brH" = (
-/obj/item/grown/sunflower,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "brL" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -1233,6 +1222,11 @@
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"bzc" = (
+/obj/effect/landmark/corpsespawner/marine/burst,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "bzj" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -1247,10 +1241,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "bzT" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/aft_hallway)
+/obj/item/clothing/head/modular/marine/helljumper,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "bAT" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
@@ -1550,10 +1543,11 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/upper_medical)
 "bPC" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/corpsespawner/marine/burst,
-/turf/open/floor/mainship,
-/area/mainship/living/cryo_cells)
+/obj/machinery/holopad,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "bPG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -1659,13 +1653,6 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"bTv" = (
-/obj/machinery/air_alarm{
-	dir = 1
-	},
-/obj/structure/sign/prop1,
-/turf/open/floor/mainship/orange/full,
-/area/mainship/squads/general)
 "bTS" = (
 /obj/structure/mirror,
 /turf/open/floor/wood,
@@ -1802,13 +1789,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"cdr" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
 "cdu" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/yellow_cargo,
@@ -1870,10 +1850,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"cfQ" = (
-/obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/general)
 "chD" = (
 /obj/item/toy/plush/carp,
 /turf/open/space/basic,
@@ -1895,6 +1871,9 @@
 "ciN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "ciZ" = (
@@ -1902,19 +1881,10 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cjl" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/misc/earmuffs,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/clothing/gloves/marine/fingerless,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/clothing/head/tgmcberet/red,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/shipboard/firing_range)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/storage/backpack/marine/engineerpack,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "cjC" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
@@ -1928,6 +1898,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
+"cmb" = (
+/obj/machinery/marine_selector/gear/medic,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/squads/general)
 "cnd" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -1996,10 +1970,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "cqY" = (
-/obj/structure/flora/tree/dead,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "csh" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -2103,6 +2078,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "czH" = (
@@ -2156,6 +2132,9 @@
 /area/mainship/command/cic)
 "cCg" = (
 /obj/item/trash/cigbutt,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cCy" = (
@@ -2271,6 +2250,7 @@
 "cMr" = (
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
 /obj/item/paper/memorial,
+/obj/item/clothing/head/modular/marine/old/assault,
 /turf/open/floor/mainship/terragov/north,
 /area/mainship/hallways/starboard_hallway)
 "cNy" = (
@@ -2306,6 +2286,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"cPL" = (
+/turf/open/floor/mainship/blue/corner,
+/area/mainship/squads/general)
 "cQN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/mainship{
@@ -2337,10 +2320,11 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "cRX" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/storage/backpack/marine/engineerpack,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/obj/structure/curtain/temple{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "cSg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2481,6 +2465,10 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
+"cXY" = (
+/obj/machinery/marine_selector/clothes/medic,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/squads/general)
 "cYi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -2869,12 +2857,6 @@
 "dpY" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"dqD" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "drW" = (
 /obj/docking_port/stationary/ert/target{
 	id = "port_target";
@@ -2977,11 +2959,9 @@
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
 "dzr" = (
-/obj/structure/curtain/temple{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "dzT" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -3335,6 +3315,13 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"dWi" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 4;
+	name = "Bathroom"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "dWD" = (
 /obj/structure/closet/secure_closet/guncabinet/m41aMK1,
 /turf/open/floor/mainship/red/full,
@@ -3354,20 +3341,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
-"dXL" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "dXO" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
@@ -3678,10 +3651,10 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
 "esQ" = (
-/obj/machinery/vending/weapon,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/marine_selector/clothes,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "euc" = (
@@ -3924,6 +3897,7 @@
 /area/mainship/engineering/engineering_workshop)
 "eIM" = (
 /obj/machinery/camera/autoname/mainship,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "eJJ" = (
@@ -3945,6 +3919,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
+"eLc" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
@@ -4067,8 +4047,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "eSw" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship,
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "eSy" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -4210,6 +4192,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/computer/squad_selector,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "faM" = (
@@ -4352,14 +4335,15 @@
 	},
 /area/mainship/command/cic)
 "fhi" = (
-/obj/machinery/light/red{
-	dir = 1
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
-"fhP" = (
+"fhF" = (
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/side{
-	dir = 6
+	dir = 8
 	},
 /area/mainship/squads/general)
 "fku" = (
@@ -4560,11 +4544,15 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/upper_medical)
 "ftY" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/misc/table_lighting,
-/obj/item/paper,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/structure/bed/chair/office/dark,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "fuf" = (
 /obj/machinery/telecomms/server/presets/requisitions,
 /turf/open/floor/mainship/tcomms,
@@ -4787,7 +4775,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/weapon,
-/turf/open/floor/mainship/sterile/side{
+/turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/squads/general)
@@ -4912,7 +4900,7 @@
 /area/mainship/hallways/starboard_hallway)
 "fKK" = (
 /obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/orange{
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
 /area/mainship/squads/general)
@@ -5015,6 +5003,12 @@
 	dir = 4
 	},
 /area/mainship/medical/chemistry)
+"fTT" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/orange{
+	dir = 10
+	},
+/area/mainship/squads/general)
 "fTZ" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small{
@@ -5172,15 +5166,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"gaW" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "gbc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5217,17 +5202,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "gcd" = (
-/obj/structure/window/framed/mainship,
-/turf/open/floor/plating,
-/area/mainship/living/tankerbunks)
-"gcr" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/area/mainship/squads/general)
+"gcr" = (
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "gcM" = (
 /obj/structure/closet/crate,
 /obj/item/storage/briefcase/inflatable,
@@ -5572,7 +5553,7 @@
 /area/mainship/shipboard/brig)
 "gxL" = (
 /obj/machinery/marine_selector/clothes/engi,
-/turf/open/floor/mainship/orange,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "gze" = (
 /obj/effect/ai_node,
@@ -5606,11 +5587,11 @@
 	},
 /area/mainship/medical/lower_medical)
 "gBQ" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/area/mainship/squads/general)
 "gCk" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/orange{
@@ -5640,9 +5621,7 @@
 /area/mainship/squads/general)
 "gFW" = (
 /obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
+/turf/open/floor/mainship/orange,
 /area/mainship/squads/general)
 "gGb" = (
 /obj/structure/table/mainship/nometal,
@@ -5677,10 +5656,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"gLL" = (
-/obj/machinery/marine_selector/clothes/engi,
-/turf/open/floor/mainship/orange/full,
-/area/mainship/squads/general)
 "gLR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5970,10 +5945,10 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "hdY" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/vending/weapon,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "heh" = (
@@ -6225,8 +6200,14 @@
 /area/mainship/hallways/aft_hallway)
 "hsr" = (
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/item/grown/sunflower,
 /turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
+/area/mainship/hallways/starboard_hallway)
+"hts" = (
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "htZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -6244,6 +6225,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"hvp" = (
+/obj/structure/sign/restroom{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "hvL" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
@@ -6476,9 +6463,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "hPp" = (
-/obj/machinery/computer/dropship_picker,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "hPF" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -6502,10 +6490,6 @@
 /obj/vehicle/unmanned/droid,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/command/airoom)
-"hQU" = (
-/obj/machinery/marine_selector/gear/smartgun,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "hRh" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 1
@@ -6592,10 +6576,7 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "hUf" = (
@@ -6710,9 +6691,9 @@
 	},
 /area/mainship/squads/general)
 "iay" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "iaH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
@@ -6793,11 +6774,15 @@
 	},
 /area/mainship/engineering/ce_room)
 "ifT" = (
-/obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/transport_crewman,
-/obj/effect/landmark/start/job/assault_crewman,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "igh" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/stack/barbed_wire/half_stack,
@@ -6837,17 +6822,6 @@
 /obj/structure/supply_drop,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"iju" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
-"ijI" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/squads/general)
 "ijM" = (
 /obj/structure/bookcase,
 /obj/item/folder/white,
@@ -6862,6 +6836,15 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
+"ikO" = (
+/obj/structure/mirror{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "ilc" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -6939,6 +6922,17 @@
 	dir = 6
 	},
 /area/mainship/squads/general)
+"inD" = (
+/obj/structure/cable,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/chemistry{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "inU" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -7148,11 +7142,19 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "iFw" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/earmuffs,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/gloves/marine/fingerless,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/head/tgmcberet/red,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "iFI" = (
 /obj/machinery/marine_selector/clothes/smartgun,
 /turf/open/floor/mainship/black/full,
@@ -7432,6 +7434,11 @@
 	dir = 10
 	},
 /area/mainship/squads/req)
+"iYk" = (
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
+/area/mainship/squads/general)
 "iYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7548,12 +7555,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"jfW" = (
-/obj/machinery/vending/medical/shipside,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wirecutters,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+"jfZ" = (
+/obj/machinery/marine_selector/clothes/engi,
+/turf/open/floor/mainship/orange,
+/area/mainship/squads/general)
 "jhK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/floor,
@@ -7586,6 +7591,11 @@
 /obj/item/reagent_containers/cup/glass/flask/gold,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"jjY" = (
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/aft_hallway)
 "jkK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro,
@@ -7666,18 +7676,6 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"juX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/blue{
-	dir = 5
-	},
-/area/mainship/squads/general)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -7698,12 +7696,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
-"jwD" = (
-/obj/machinery/chem_master,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "jwH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/research/containment/floor2{
@@ -7771,6 +7763,11 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/mainship/command/self_destruct)
+"jBI" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "jBS" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -7804,6 +7801,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
+"jDj" = (
+/obj/machinery/marine_selector/gear/smartgun,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "jDG" = (
 /turf/open/floor/mainship/white,
 /area/mainship/living/pilotbunks)
@@ -7829,11 +7830,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"jGF" = (
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "jHd" = (
 /obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/orange{
@@ -7873,6 +7869,12 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/living/mechpilotquarters)
+"jII" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "jLn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -7971,6 +7973,12 @@
 /obj/structure/benchpress,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"jRA" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "jRQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -8018,12 +8026,28 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space)
+"jUu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
+/area/mainship/squads/general)
 "jUP" = (
-/obj/structure/sign/restroom{
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/upper_medical)
 "jUQ" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -8107,14 +8131,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "kdC" = (
-/obj/structure/sink{
-	dir = 8
-	},
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
-	},
-/obj/structure/mirror{
-	dir = 4
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -8220,6 +8238,12 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/black{
 	dir = 8
+	},
+/area/mainship/squads/general)
+"koX" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange{
+	dir = 1
 	},
 /area/mainship/squads/general)
 "kpI" = (
@@ -8434,11 +8458,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
-"kBc" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "kBk" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
@@ -8446,13 +8465,11 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "kCs" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
 	},
-/obj/machinery/tank_part_fabricator,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/area/mainship/squads/general)
 "kCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8470,10 +8487,11 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "kDL" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
-/turf/open/floor/wood,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "kDO" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/white,
@@ -8516,10 +8534,6 @@
 /obj/item/trash/cigbutt/cigarbutt,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
-"kFR" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "kGb" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
 /turf/open/floor/mainship/orange{
@@ -8559,12 +8573,6 @@
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"kHq" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "kHN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -8586,12 +8594,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "kId" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
+"kJM" = (
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/transport_crewman,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "kJX" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
@@ -8612,14 +8625,6 @@
 /obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"kLG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "kLK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -8986,11 +8991,6 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
-"lfn" = (
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -9221,6 +9221,12 @@
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
 /area/mainship/living/tankerbunks)
+"lqa" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "lqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9295,10 +9301,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "luk" = (
-/obj/structure/bed/chair/sofa,
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/turf/open/floor/wood,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/tank_part_fabricator,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "lun" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/mechpilot,
@@ -9410,11 +9415,6 @@
 "lAT" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"lBk" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "lBs" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -9478,10 +9478,6 @@
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
-"lEt" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "lEz" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 5
@@ -9511,17 +9507,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"lFD" = (
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "lGi" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -9573,16 +9558,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lHN" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/obj/structure/target_stake,
-/obj/item/target,
-/obj/item/clothing/suit/storage/faction/militia,
-/turf/open/floor/plating/mainship/striped{
-	dir = 4
-	},
-/area/mainship/shipboard/firing_range)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "lHS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9601,11 +9582,11 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "lIW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/vending/weapon,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "lJt" = (
@@ -9626,7 +9607,7 @@
 "lJV" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/general)
 "lJX" = (
@@ -9722,10 +9703,6 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"lOP" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/squads/general)
 "lPM" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/chair/office/dark{
@@ -9861,6 +9838,13 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"lTL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "lTQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -10527,7 +10511,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 8
 	},
 /area/mainship/squads/general)
 "mNV" = (
@@ -10781,10 +10765,7 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nbC" = (
 /obj/effect/ai_node,
@@ -10819,9 +10800,6 @@
 /area/mainship/living/mechpilotquarters)
 "ndA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/vending/weapon,
@@ -11072,18 +11050,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"num" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "nuX" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -11205,6 +11171,14 @@
 	dir = 8
 	},
 /area/mainship/medical/upper_medical)
+"nAq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "nAM" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -11312,15 +11286,11 @@
 	},
 /area/mainship/command/self_destruct)
 "nIF" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 1
-	},
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/upper_medical)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "nIG" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -11432,9 +11402,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "nQH" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "nRz" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
@@ -11500,12 +11473,6 @@
 	dir = 9
 	},
 /area/mainship/shipboard/weapon_room)
-"nVJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "nWd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -11825,23 +11792,6 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
-"orN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "osb" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -12082,7 +12032,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "oIT" = (
-/obj/machinery/marine_selector/gear/engi,
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
@@ -12162,6 +12111,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "oOX" = (
+/obj/effect/ai_node,
 /turf/open/floor/mainship/terragov{
 	dir = 1
 	},
@@ -12252,6 +12202,9 @@
 /obj/structure/prop/mainship/sensor_computer1/sd,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"oYn" = (
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/squads/general)
 "oYv" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -12353,10 +12306,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pbh" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/vending/weapon,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pbx" = (
@@ -12405,17 +12358,6 @@
 /obj/structure/largecrate/supply/ammo/standard_ammo,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
-"pef" = (
-/obj/structure/cable,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/structure/sign/chemistry{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "peg" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/yellow_cargo,
@@ -12433,14 +12375,16 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "pfi" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flipped{
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/squads/general)
 "pfH" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -12472,6 +12416,12 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"pgH" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "pha" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -12492,9 +12442,12 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
 "pii" = (
-/obj/machinery/marine_selector/gear/medic,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/squads/general)
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/table_lighting,
+/obj/item/paper,
+/obj/item/newspaper,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "pjB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12625,10 +12578,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"ppc" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "pqm" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship{
@@ -12748,7 +12697,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/orange{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/general)
 "pyV" = (
@@ -12791,6 +12740,10 @@
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
+/area/mainship/hallways/hangar)
+"pCc" = (
+/obj/machinery/computer/dropship_picker,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pCd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -13168,6 +13121,9 @@
 	dir = 4
 	},
 /obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pWs" = (
@@ -13465,10 +13421,9 @@
 	},
 /area/mainship/squads/req)
 "qtr" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/misc/cigarettes,
-/obj/effect/spawner/random/misc/cigar,
-/turf/open/floor/wood,
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "qtz" = (
 /obj/machinery/camera/autoname/mainship,
@@ -13692,8 +13647,10 @@
 /area/mainship/hallways/starboard_hallway)
 "qGH" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
+/area/mainship/hallways/starboard_hallway)
 "qHj" = (
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
 /turf/open/floor/plating,
@@ -14066,6 +14023,12 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"raA" = (
+/obj/machinery/light/red{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "rbd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14092,6 +14055,20 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
+"rcn" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "rcC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14101,6 +14078,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"rdZ" = (
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "rea" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -14303,12 +14286,6 @@
 /obj/item/toy/plush/lizard,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"rrv" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "rrw" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/red/full,
@@ -14491,6 +14468,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "rDn" = (
@@ -14499,16 +14477,6 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
-"rDX" = (
-/obj/structure/bed/chair/office/dark,
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "rEw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14627,8 +14595,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "rNX" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "rOr" = (
 /obj/machinery/holopad,
@@ -14701,6 +14670,15 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
+"rSr" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "rSA" = (
 /turf/closed/wall/mainship/white,
 /area/medical/morgue)
@@ -14771,11 +14749,8 @@
 /turf/open/floor/mainship/blue/full,
 /area/mainship/hallways/boxingring)
 "rXB" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/mainship/hexagon,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "rYr" = (
 /obj/structure/cable,
@@ -15258,16 +15233,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "sFM" = (
-/turf/open/floor/mainship/blue{
-	dir = 6
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "sGk" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 1
+/obj/machinery/door/poddoor/railing{
+	dir = 2;
+	id = "vehicle_elevator_railing"
 	},
-/area/mainship/medical/chemistry)
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "sGA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -15281,6 +15265,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"sHF" = (
+/obj/machinery/vending/weapon,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "sIN" = (
 /obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/mainship/sterile/dark,
@@ -15327,9 +15318,7 @@
 /area/mainship/engineering/port_atmos)
 "sMn" = (
 /obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "sMF" = (
 /obj/machinery/light/mainship{
@@ -15492,6 +15481,11 @@
 "sXV" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 4
+	},
+/area/mainship/squads/general)
+"sXX" = (
+/turf/open/floor/mainship/blue{
+	dir = 9
 	},
 /area/mainship/squads/general)
 "sYd" = (
@@ -15667,22 +15661,9 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"tkH" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/rifle/m412,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/turf/open/floor/mainship/red,
-/area/mainship/shipboard/firing_range)
 "tkS" = (
-/obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "tkW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15708,6 +15689,20 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
+"tni" = (
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/hand_labeler,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "tnR" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/keycard_auth{
@@ -15813,6 +15808,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"tux" = (
+/obj/machinery/door/airlock/mainship/generic,
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "tuM" = (
 /obj/structure/window/reinforced/extratoughened{
 	dir = 8
@@ -16116,9 +16115,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"tJr" = (
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/squads/general)
 "tJA" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16146,12 +16142,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"tLO" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "tMy" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -16272,10 +16262,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
-"tTQ" = (
-/obj/machinery/marine_selector/clothes/medic,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/squads/general)
 "tTR" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
@@ -16508,16 +16494,34 @@
 "ufq" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/mechpilotquarters)
+"ufM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "ugv" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
 "ugL" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigar,
-/obj/effect/spawner/random/food_or_drink/donut,
-/turf/open/floor/wood,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "uhj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16630,6 +16634,16 @@
 "uqg" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engine_core)
+"uqh" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/obj/item/clothing/head/modular/marine/helljumper,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "uqj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16877,9 +16891,9 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "uEg" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/structure/foamedmetal,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "uFV" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
@@ -17075,6 +17089,18 @@
 "uQQ" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"uQU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "uSe" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/hull/lower_hull)
@@ -17083,6 +17109,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"uSO" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "uTs" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -17151,7 +17183,8 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "uWK" = (
-/turf/open/floor/mainship/orange{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
 /area/mainship/squads/general)
@@ -17195,11 +17228,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "uZR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/obj/machinery/vending/medical/shipside,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "vab" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17251,13 +17284,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "vcJ" = (
-/obj/structure/bed/chair/sofa,
-/obj/effect/landmark/start/job/shiptech,
 /obj/machinery/light/blue{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "vcN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17562,12 +17593,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
-"vwM" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "vxx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17593,11 +17618,12 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "vyG" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/orange{
-	dir = 8
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/area/mainship/squads/general)
+/obj/effect/ai_node,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "vyJ" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
@@ -17652,6 +17678,17 @@
 /obj/machinery/keycard_auth,
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
+"vBA" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/obj/structure/table/mainship/nometal,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/turf/open/floor/mainship/red,
+/area/mainship/shipboard/firing_range)
 "vBY" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/side,
@@ -17895,7 +17932,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "vXR" = (
-/turf/open/floor/mainship/orange/full,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "vXY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18319,18 +18357,6 @@
 	},
 /turf/open/floor/mainship/orange/corner,
 /area/mainship/engineering/ce_room)
-"wxV" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "wyz" = (
 /obj/machinery/landinglight/alamo{
 	dir = 1;
@@ -18342,6 +18368,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"wyY" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "wAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18870,13 +18902,17 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
 "xbP" = (
-/obj/machinery/marine_selector/gear/engi,
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
+/area/mainship/squads/general)
+"xcf" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "xdy" = (
 /obj/effect/landmark/start/job/ai,
@@ -18918,9 +18954,6 @@
 /mob/living/simple_animal/cat/martin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"xfw" = (
-/turf/open/floor/mainship/blue/corner,
-/area/mainship/squads/general)
 "xgv" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/camera/autoname/mainship,
@@ -18998,16 +19031,10 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "xkC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/mainship/sterile/side{
 	dir = 10
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 4
-	},
-/area/mainship/medical/chemistry)
+/area/mainship/squads/general)
 "xkD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
@@ -19110,6 +19137,12 @@
 /obj/structure/sign/safety/cryogenic,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"xpT" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "xqb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19203,6 +19236,13 @@
 	dir = 1
 	},
 /area/mainship/engineering/engineering_workshop)
+"xwC" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "xxI" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -19454,9 +19494,8 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
-"xHo" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/sterile/side{
+"xHU" = (
+/turf/open/floor/mainship/orange{
 	dir = 4
 	},
 /area/mainship/squads/general)
@@ -19494,20 +19533,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"xKw" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/dropper,
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "xKE" = (
 /obj/machinery/door/poddoor/railing{
 	id = "supply_elevator_railing"
@@ -19549,16 +19574,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"xMh" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 1
-	},
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
 "xNw" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -19682,6 +19697,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/brig)
+"xUY" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "xVg" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -19913,12 +19939,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"ych" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "ycp" = (
 /obj/machinery/computer/camera_advanced/overwatch/military/bravo,
 /turf/open/floor/mainship/orange{
@@ -41332,7 +41352,7 @@ nWT
 nWT
 nWT
 nWT
-nWT
+wSP
 qVo
 mBZ
 mBZ
@@ -45644,7 +45664,7 @@ lTH
 duU
 lGi
 iwj
-nIF
+jUP
 osh
 wnJ
 wnJ
@@ -45901,7 +45921,7 @@ lTu
 mvs
 xAX
 lAT
-nIF
+jUP
 fZP
 gaD
 xXt
@@ -46405,13 +46425,13 @@ tyN
 tyN
 tyN
 mvs
-sGk
-tLO
-brj
-rDX
-jwD
-xKw
-kHq
+rdZ
+brH
+eLc
+ftY
+jII
+tni
+jRA
 dLo
 kSC
 yjx
@@ -46663,16 +46683,16 @@ yfw
 kuc
 mvs
 oca
-cdr
-xKw
+xwC
+tni
 vwL
-jfW
+uZR
 sIN
 aSw
 dLo
 hiV
 yjx
-nIF
+jUP
 ryp
 mSh
 wNn
@@ -46922,7 +46942,7 @@ mvs
 vTy
 fTy
 iuw
-xkC
+xUY
 mHi
 wkJ
 nJd
@@ -47179,7 +47199,7 @@ mvs
 kVD
 kVD
 kVD
-xMh
+ifT
 kVD
 eGM
 kVD
@@ -47438,9 +47458,9 @@ gBJ
 ePj
 fEb
 fEb
-dXL
+rcn
 orC
-pef
+inD
 fuy
 yjx
 mvs
@@ -47695,7 +47715,7 @@ iwj
 lAT
 lAT
 lAT
-num
+uQU
 mgw
 mgw
 nMm
@@ -47952,10 +47972,10 @@ lSQ
 mNf
 qFX
 iMF
-wxV
-iju
-iju
-pfi
+sFM
+nIF
+nIF
+ado
 mzF
 mvs
 nku
@@ -48215,7 +48235,7 @@ lAT
 cxv
 mqY
 mwj
-nkC
+uqh
 nuX
 nuX
 spJ
@@ -48992,7 +49012,7 @@ xGl
 qPq
 pgq
 tRG
-xhP
+bzT
 uCC
 yjj
 kHT
@@ -49243,7 +49263,7 @@ lAT
 nMm
 kMt
 mvs
-mbQ
+nku
 rrj
 xGl
 tpo
@@ -51045,7 +51065,7 @@ vAn
 swv
 vAn
 vAn
-bzT
+jjY
 vAn
 vAn
 vAn
@@ -52305,17 +52325,17 @@ nyF
 nyF
 kfB
 gup
+dpY
 fFw
 jMP
 pke
-aqn
+xJe
 xJe
 xJe
 xJe
 xJe
 tTW
 sVI
-pfU
 qNE
 lBs
 kWc
@@ -52559,9 +52579,10 @@ kDx
 kDx
 kDx
 kDx
-kDx
 hFZ
+kDx
 qPc
+dpY
 nwX
 tHk
 nzB
@@ -52572,7 +52593,6 @@ kDx
 kDx
 cxw
 vPk
-aHp
 ubU
 gMb
 gMb
@@ -52819,6 +52839,7 @@ csW
 csW
 lGv
 qPc
+dpY
 nwX
 cfw
 kDx
@@ -52829,7 +52850,6 @@ kDx
 kDx
 cxw
 vPk
-igh
 ubU
 gMb
 gMb
@@ -53076,6 +53096,7 @@ kDx
 kDx
 cxw
 qPc
+dpY
 nwX
 cfw
 kDx
@@ -53086,7 +53107,6 @@ kDx
 kDx
 cxw
 vPk
-cRX
 uzm
 gMb
 gMb
@@ -53333,6 +53353,7 @@ kDx
 kDx
 kwo
 qPc
+dpY
 nwX
 cfw
 kDx
@@ -53343,7 +53364,6 @@ kDx
 kDx
 cxw
 vPk
-kDx
 ubU
 gMb
 gMb
@@ -53590,6 +53610,7 @@ kDx
 kDx
 cxw
 qPc
+dpY
 nwX
 nbW
 qWy
@@ -53600,7 +53621,6 @@ kDx
 kDx
 cxw
 vPk
-kDx
 ubU
 gMb
 gMb
@@ -53847,6 +53867,7 @@ kDx
 kDx
 kwo
 qPc
+dpY
 qfG
 jrk
 sAI
@@ -53857,7 +53878,6 @@ xyS
 xyS
 yki
 hdc
-hPp
 qNE
 dmm
 lht
@@ -54105,16 +54125,16 @@ kDx
 cxw
 mxq
 dpY
+pfU
+dpY
+igh
+pCc
 dpY
 dpY
 dpY
-dpY
-dpY
-dpY
+gpx
 yfw
 kuc
-gpx
-dpY
 fXg
 eFA
 cHE
@@ -54362,7 +54382,9 @@ kDx
 kwo
 qPc
 dpY
+aHp
 dpY
+cjl
 dpY
 dpY
 dpY
@@ -54370,8 +54392,6 @@ dpY
 dpY
 qwO
 gjA
-dpY
-dpY
 faF
 cHE
 cHE
@@ -54626,7 +54646,7 @@ vmD
 vmD
 vmD
 vmD
-nQH
+vmD
 vmD
 rWD
 aHG
@@ -54660,19 +54680,19 @@ jDL
 rUF
 swY
 wsR
-fEq
-lJV
-sMn
-lFD
+rSr
+kCs
+fhF
+mNM
 swY
 rUF
-gFW
-jGF
-gaW
+uSO
+rNX
+fEq
 oIT
-vyG
-pyS
-gFW
+fTT
+nAq
+uSO
 rUF
 kMi
 dBu
@@ -54882,7 +54902,7 @@ ykH
 pVB
 vzN
 ykH
-pVB
+ykH
 rCU
 uMj
 uNt
@@ -54917,19 +54937,19 @@ tVF
 rUF
 dtI
 kUU
-lOP
-ijI
-kBc
+vXR
+gcd
+hPp
 tVr
 xXT
 rUF
 tKs
 krM
 rOr
-vXR
+gcr
 pGb
 fYB
-bTv
+bby
 mBc
 vmD
 nmm
@@ -55151,7 +55171,7 @@ vmD
 vmD
 vmD
 vmD
-vmD
+dlz
 vmD
 vmD
 rKm
@@ -55174,19 +55194,19 @@ vmD
 hme
 qhf
 tkW
-ijI
-dqD
-aUw
-kBc
-tTQ
+gcd
+kDL
+xkC
+hPp
+cXY
 hme
-gLL
+gxL
 pGb
 oAz
 kHp
 pGb
 syR
-gxL
+jfZ
 hme
 rUF
 jTU
@@ -55396,14 +55416,14 @@ vmD
 vmD
 vmD
 vmD
-vmD
-vmD
-vmD
-vmD
-hWt
-vmD
-vmD
-vmD
+mXm
+fbp
+oGN
+oGN
+oGN
+ezY
+oGN
+mOo
 omW
 lVR
 kGc
@@ -55431,24 +55451,24 @@ rUF
 mBc
 lRs
 tkW
-tJr
+oYn
+gBQ
 baH
-fhP
-lBk
-pii
+jBI
+cmb
 rUF
-tkS
+koX
+pGb
 pGb
 pGb
 kHp
-pGb
 syR
-cfQ
+gFW
 rUF
-kFR
+sMn
 iBL
 uVF
-uZR
+cqY
 acl
 mqK
 hPb
@@ -55653,28 +55673,28 @@ vmD
 rug
 vmD
 vmD
-vmD
-vmD
-rug
-vmD
-hWt
-vmD
-rug
-vmD
+mXm
+sGk
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
 tpi
 tFb
 kGc
 uej
 lhT
 eQb
-eQb
+miU
 rUF
 vVG
-aYR
+sXX
 mRy
 xWS
 hvS
-ppc
+tkS
 rUF
 wDi
 ngh
@@ -55690,21 +55710,21 @@ aLA
 rbd
 hPG
 tgi
-nVJ
+uWK
 hPG
 aMp
 rUF
 tED
 krM
 pGb
-vXR
+gcr
 pGb
 fYB
 elQ
 rUF
 eIM
 sjY
-rNX
+xcf
 wDN
 wfO
 mqK
@@ -55909,15 +55929,15 @@ vmD
 vmD
 vmD
 vmD
-vmD
-vmD
-vmD
-vmD
-vmD
-hWt
-vmD
-vmD
-vmD
+hvp
+mXm
+sGk
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
 eel
 pgh
 vDH
@@ -55944,25 +55964,25 @@ eMz
 eMz
 rUF
 oNs
-orN
+ufM
 yhG
-vwM
-xHo
-mNM
+lJV
+fKK
+pfi
 ukJ
 rUF
 pqm
-uWK
-ych
+xHU
+pgH
 xbP
-fKK
-kLG
+xpT
+pyS
 hGE
 rUF
 xuy
 sjY
 vIv
-uZR
+cqY
 fAy
 mqK
 ukb
@@ -56165,16 +56185,16 @@ ekx
 ekx
 ekx
 ekx
+dWi
 ekx
-ekx
-vmD
-vmD
-vmD
-vmD
-hWt
-vmD
-vmD
-vmD
+mXm
+sGk
+eFo
+eFo
+lpt
+eFo
+eFo
+pqQ
 miU
 eQb
 fqj
@@ -56219,7 +56239,7 @@ ekL
 ikM
 sjY
 ikM
-uZR
+cqY
 cef
 mqK
 lys
@@ -56424,14 +56444,14 @@ xSN
 xSN
 kdC
 ekx
-jUP
-vmD
-vmD
-vmD
-hWt
-vmD
-vmD
-vmD
+mXm
+sGk
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
 tpi
 eQb
 kGc
@@ -56680,29 +56700,29 @@ fXX
 njf
 fXX
 vmD
-xQB
-dlz
-vmD
-rug
-vmD
-hWt
-vmD
-rug
-vmD
+ekx
+mXm
+sGk
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
 eel
-iay
+vyj
 ciN
-tpi
-eel
-brH
+kGc
+lHN
+eQb
 tpi
 rUF
 nIn
 vfL
-xfw
-rrv
-lfn
-sFM
+cPL
+bPC
+hts
+iYk
 ryY
 xVU
 bSp
@@ -56733,7 +56753,7 @@ rUF
 ekh
 sjY
 cPg
-uZR
+cqY
 wfO
 mqK
 uKH
@@ -56936,30 +56956,30 @@ fpg
 fpg
 vmD
 vmD
-vmD
+ikO
 ekx
 dzr
-dzr
-vmD
-vmD
-hWt
-vmD
-vmD
-vmD
+wyY
+eXp
+tXl
+eXp
+eXp
+eXp
+qtr
 miU
-cRE
-miU
-tpi
-miU
-cqY
+fqj
+eQb
+kGc
+vyG
+eQb
 cRE
 rUF
 dPp
-juX
-sFM
+jUu
+iYk
 xWS
 fPK
-ppc
+tkS
 rUF
 lSq
 bSp
@@ -56982,15 +57002,15 @@ xLV
 rFS
 rDn
 tJA
-rDn
-oGT
+cPg
+cPg
 cPg
 lOp
 rUF
 kdD
 sjY
-hQU
-uZR
+jDj
+cqY
 cef
 mqK
 uKH
@@ -57196,18 +57216,18 @@ ekx
 ekx
 ekx
 luk
-kDL
-ekx
-mOo
-oGN
-oGN
-oGN
-ezY
-oGN
-fbp
 bLP
+hTV
 mXm
-qGH
+mXm
+mXm
+mXm
+mXm
+tpi
+tpi
+miU
+tpi
+tpi
 qGH
 hsr
 hEc
@@ -57224,30 +57244,30 @@ cPg
 lOp
 eYx
 cPg
-esQ
-xYh
+vVG
+cPg
 bYP
-xYh
+cPg
 ndA
 gMl
-esQ
+vVG
 nbu
 bYP
-xYh
-pbh
+cPg
+nNV
 xLV
-esQ
-xYh
+vVG
+cPg
 bYP
-xYh
-pbh
+cPg
+cPg
 cPg
 lOp
 rUF
 mnb
 sjY
 vIv
-uZR
+cqY
 fAy
 mqK
 uKH
@@ -57454,19 +57474,19 @@ byk
 ekx
 vcJ
 ugL
+mXm
+hTV
+mXm
+mXm
+mXm
 ekx
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-kCs
-bLP
-xLu
-xLu
-gcd
-xLu
+ekx
+ekx
+ekx
+ekx
+ekx
+ekx
+ekx
 uyy
 uNy
 bTj
@@ -57481,30 +57501,30 @@ cPg
 lOp
 eYx
 cPg
-rFS
-rDn
+nQH
+xYh
 tis
-eMz
+xYh
 pWo
 gMl
-jlV
-eMz
+nQH
+xYh
 rHh
-eMz
-ciZ
+xYh
+aAu
 rHh
-jlV
-eMz
+nQH
+xYh
 cPg
-eMz
-ciZ
+cPg
+cPg
 cPg
 lOp
 rUF
-lEt
+iay
 iBL
 eWu
-uZR
+cqY
 jOQ
 mqK
 lRc
@@ -57712,18 +57732,18 @@ ekx
 ekx
 ekx
 mpj
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-pqQ
-bLP
+tux
 xLu
-uXw
-eZp
-sSW
+xLu
+xLu
+ekx
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
 uyy
 sKv
 qVH
@@ -57741,20 +57761,20 @@ bpK
 aWF
 kId
 bpK
-bby
+kId
 lIW
 fJI
-esQ
-xYh
+lTL
+rDn
 cPg
-xYh
+rDn
 pbh
 cPg
 hdY
-xYh
+rDn
 cPg
-xYh
-pbh
+cPg
+cPg
 tis
 ini
 mBc
@@ -57970,17 +57990,17 @@ hUz
 pQt
 ycz
 rXB
-eFo
-eFo
-lpt
-eFo
-eFo
-gcr
-hTV
-xLu
-rOV
 vXQ
-qtr
+vXQ
+sSW
+ekx
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
 uyy
 cSz
 bHF
@@ -57995,23 +58015,23 @@ fee
 fee
 mEk
 cPg
-rFS
-eMz
+vVG
 cPg
-eMz
-pWo
+cPg
+cPg
+nNV
 gMl
-jlV
-eMz
+vVG
 cPg
-eMz
+cPg
+cPg
 ciZ
 cPg
 jlV
-eMz
 cPg
-eMz
-ciZ
+cPg
+cPg
+cPg
 cPg
 fee
 cey
@@ -58226,18 +58246,18 @@ cuG
 esN
 unX
 rKn
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-pqQ
-xLu
-xLu
-uEg
-vXQ
+pii
 eSw
+vXQ
+eZp
+ekx
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
+ekx
 uyy
 uyy
 uyy
@@ -58253,22 +58273,22 @@ eLs
 xmJ
 cPg
 esQ
-eMz
+xYh
 buS
-eMz
-nNV
+xYh
+aAu
 gMl
-vVG
+esQ
 cCg
 buS
-eMz
-nNV
+xYh
+sHF
 cPg
 vVG
 eMz
 buS
-eMz
-nNV
+cPg
+cPg
 cPg
 mxo
 mxo
@@ -58483,18 +58503,18 @@ nWT
 esN
 unX
 rKn
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-pqQ
-aAu
+aqn
 vXQ
-gBQ
 vXQ
-xLu
+uXw
+ekx
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
+ekx
 eJL
 hvM
 ibO
@@ -58524,8 +58544,8 @@ cPg
 eWM
 fLM
 tJA
-qRu
-sqc
+cPg
+cPg
 cPg
 osT
 hlO
@@ -58740,18 +58760,18 @@ nWT
 esN
 unX
 rKn
-mOo
-eXp
-tXl
-eXp
-eXp
-eXp
-mOo
-xLu
-iFw
-ftY
-ifT
-xLu
+kJM
+vXQ
+lqa
+rOV
+ekx
+uEg
+uEg
+uEg
+uEg
+uEg
+uEg
+ekx
 rPd
 hZe
 mmh
@@ -58768,21 +58788,21 @@ nUc
 cPg
 aJV
 cPg
-cPg
+bYP
 cPg
 lgL
 gMl
 aJV
 cPg
-cPg
-cPg
-aJV
+bYP
 cPg
 aJV
 cPg
-cPg
-cPg
 aJV
+cPg
+bYP
+cPg
+cPg
 cPg
 hlO
 lNe
@@ -59270,7 +59290,7 @@ bDv
 bDv
 cEe
 bDv
-cjl
+iFw
 fmP
 nhn
 nbh
@@ -60038,7 +60058,7 @@ esN
 unX
 nJG
 nZI
-lHN
+nZI
 nZI
 nZI
 wtq
@@ -60067,10 +60087,10 @@ heh
 vmB
 fpB
 aSJ
-umU
-umU
-umU
-umU
+cRX
+cRX
+cRX
+cRX
 rKn
 vAb
 gUW
@@ -60301,7 +60321,7 @@ wJe
 nJG
 qxw
 jiE
-tkH
+vBA
 nJG
 cwD
 uJT
@@ -60582,8 +60602,8 @@ ucj
 ktb
 aSJ
 umU
-umU
-umU
+aKE
+bzc
 umU
 rKn
 iWR
@@ -61096,8 +61116,8 @@ rqX
 ktb
 aSJ
 fhi
-aKE
-bPC
+raA
+umU
 aSJ
 rKn
 vSJ
@@ -62132,25 +62152,25 @@ nWT
 nWT
 nWT
 nWT
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-aiT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+wSP
 qVo
 mBZ
 mBZ
@@ -62389,25 +62409,25 @@ qpC
 qpC
 qpC
 qpC
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+aiT
 qVo
 mBZ
 mBZ

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2714,6 +2714,17 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/living/chapel)
+"djj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/plasticflaps/sturdy,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "dkD" = (
 /obj/machinery/door/airlock/mainship/medical/glass/chemistry{
 	dir = 1
@@ -3697,14 +3708,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/mechpilotquarters)
 "exV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/obj/item/tool/weldpack,
+/obj/structure/table/mainship/nometal,
+/obj/item/stack/barbed_wire/half_stack,
+/obj/item/tool/crowbar,
 /turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/area/mainship/hallways/hangar)
 "eye" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -3855,25 +3863,10 @@
 	},
 /area/mainship/living/commandbunks)
 "eGl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/plasticflaps/sturdy,
+/turf/open/floor/mainship/green{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/stack/conveyor,
-/obj/item/stack/conveyor,
-/obj/item/stack/conveyor,
-/obj/item/stack/conveyor,
-/obj/item/stack/conveyor,
-/obj/item/stack/conveyor,
-/obj/item/tool/screwdriver,
-/obj/item/tool/crowbar,
-/obj/item/tool/wrench,
-/obj/item/conveyor_switch_construct,
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "eGs" = (
 /obj/structure/target_stake,
@@ -3955,17 +3948,6 @@
 /obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"eLx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "eLM" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/white{
@@ -5630,17 +5612,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"gDg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/plasticflaps/sturdy,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
 "gES" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -6821,11 +6792,16 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "igh" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/barbed_wire/half_stack,
-/obj/item/tool/crowbar,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/squads/req)
 "igO" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/wood,
@@ -8747,6 +8723,27 @@
 /obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"kPn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/tool/screwdriver,
+/obj/item/tool/crowbar,
+/obj/item/tool/wrench,
+/obj/item/conveyor_switch_construct,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "kQn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11656,10 +11653,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "ocK" = (
-/obj/structure/plasticflaps/sturdy,
-/turf/open/floor/mainship/green{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldpack,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oda" = (
 /obj/structure/sink{
@@ -14520,9 +14520,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /obj/item/clothing/head/warning_cone,
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "rEM" = (
@@ -51085,7 +51082,7 @@ tzk
 aWk
 dpY
 eiU
-vAn
+tWD
 vAn
 vAn
 vAn
@@ -52380,11 +52377,11 @@ xkF
 hhf
 doG
 rpv
-eLx
+igh
 iYf
 iYf
 iYf
-exV
+ocK
 osF
 hXJ
 cCZ
@@ -52636,7 +52633,7 @@ gMb
 nAM
 xHi
 iiU
-gDg
+djj
 uIy
 syt
 syt
@@ -52892,8 +52889,8 @@ gMb
 gMb
 nAM
 xbi
-ocK
 eGl
+kPn
 xjF
 gUa
 gUa
@@ -54419,7 +54416,7 @@ dpY
 dpY
 aHp
 dpY
-igh
+exV
 cjl
 dpY
 dpY

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -356,6 +356,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/tankerbunks)
+"aAQ" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "aBm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -1019,6 +1025,9 @@
 /area/mainship/shipboard/brig)
 "bld" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "blX" = (
@@ -1400,6 +1409,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/mob/living/simple_animal/cat/Runtime,
 /turf/open/floor/carpet/side{
 	dir = 6
 	},
@@ -1766,6 +1776,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"cdu" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "cef" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/food_or_drink/sugary_snack,
@@ -2321,6 +2335,17 @@
 "cSz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship,
+/obj/structure/closet/cabinet,
+/obj/item/binoculars,
+/obj/item/storage/briefcase,
+/obj/item/clothing/head/bowlerhat{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/weapon/cane{
+	pixel_x = 5
+	},
+/obj/item/book/codebook,
 /turf/open/floor/carpet/side{
 	dir = 5
 	},
@@ -2519,6 +2544,13 @@
 "dcY" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engineering_workshop)
+"dda" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/crew_quarters/toilet)
 "der" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3544,6 +3576,15 @@
 /obj/machinery/vending/security,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
+"eqQ" = (
+/obj/machinery/door/window,
+/obj/effect/spawner/random/misc/soap/deluxeweighted,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/living/numbertwobunks)
 "ess" = (
 /obj/structure/safe,
 /obj/item/moneybag,
@@ -3736,8 +3777,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "eEZ" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/security/marinemainship_network,
+/obj/structure/displaycase/destroyed,
+/obj/item/toy/plush/rouny,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "eFh" = (
@@ -4081,17 +4122,7 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/ce_room)
 "faC" = (
-/obj/structure/closet/cabinet,
-/obj/item/storage/briefcase,
-/obj/item/clothing/head/bowlerhat{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/weapon/cane{
-	pixel_x = 5
-	},
-/obj/item/binoculars,
-/turf/open/floor/wood,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "faF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4242,6 +4273,12 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
+"fhi" = (
+/obj/machinery/light/red{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "fku" = (
 /obj/effect/ai_node,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -4861,6 +4898,12 @@
 	},
 /obj/machinery/marine_selector/clothes/leader,
 /turf/open/floor/mainship,
+/area/mainship/squads/general)
+"fPM" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "fQp" = (
 /obj/structure/prop/mainship/name_stencil/C,
@@ -5988,6 +6031,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"hnu" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced/toughened{
+	dir = 8
+	},
+/obj/structure/window/reinforced/toughened{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "hnV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -9433,6 +9486,16 @@
 /obj/machinery/faxmachine,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"lMC" = (
+/obj/effect/landmark/start/latejoin,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "lMV" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -9609,7 +9672,6 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "lUS" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -12204,6 +12266,19 @@
 	},
 /turf/open/shuttle/escapepod/two,
 /area/mainship/command/self_destruct)
+"plb" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/landinglight/cas{
+	dir = 4;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/secure{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "plr" = (
 /turf/open/floor/mainship/black{
 	dir = 4
@@ -12555,6 +12630,15 @@
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
+"pIL" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced/toughened{
+	dir = 8
+	},
+/obj/structure/window/reinforced/toughened,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pJi" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -12771,9 +12855,7 @@
 "pVb" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pVr" = (
 /obj/item/trash/cigbutt,
@@ -13201,6 +13283,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/computer/marine_card,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "qyE" = (
@@ -13589,6 +13673,7 @@
 	},
 /area/space)
 "qUr" = (
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/cargo,
 /area/mainship/command/cic)
 "qUT" = (
@@ -14210,6 +14295,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
@@ -14923,6 +15009,7 @@
 /obj/structure/table/wood/fancy,
 /obj/item/megaphone,
 /obj/item/clothing/head/ornamented_cap,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/side{
 	dir = 1
 	},
@@ -15454,14 +15541,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "tzF" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/obj/structure/mirror{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
@@ -16466,13 +16550,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"uDB" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/floor,
-/area/crew_quarters/toilet)
 "uEg" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/wood,
@@ -16481,6 +16558,12 @@
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"uGl" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black{
+	dir = 5
+	},
+/area/mainship/squads/general)
 "uGq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16506,6 +16589,11 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"uJT" = (
+/obj/effect/landmark/start/latejoin,
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "uKk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16762,6 +16850,11 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/weapon_room)
+"uXR" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced/toughened,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "uYe" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -17106,9 +17199,10 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "vvz" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/computer/marine_card,
-/turf/open/floor/wood,
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "vvE" = (
 /obj/structure/bed/chair/nometal{
@@ -17271,12 +17365,10 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "vFb" = (
-/obj/structure/table/wood/fancy,
-/obj/item/book/codebook,
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
+/obj/machinery/door/airlock/mainship/generic/bathroom{
+	dir = 2
 	},
-/turf/open/floor/wood,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "vFi" = (
 /obj/structure/table/mainship/nometal,
@@ -17452,16 +17544,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"vVf" = (
-/obj/effect/landmark/start/latejoin,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/living/cryo_cells)
 "vVy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -18126,6 +18208,15 @@
 /obj/machinery/atmospherics/components/binary/valve/digital/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"wKS" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/structure/mirror{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/living/numbertwobunks)
 "wKY" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -18750,11 +18841,6 @@
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
-"xvO" = (
-/obj/effect/landmark/start/latejoin,
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/living/cryo_cells)
 "xwg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -45662,7 +45748,7 @@ wPV
 iet
 nJP
 dmx
-uDB
+dda
 tNQ
 iTM
 kRZ
@@ -51309,8 +51395,8 @@ gek
 ycD
 dpY
 dpY
-dpY
-dpY
+hnu
+pIL
 dpY
 uKp
 gmQ
@@ -51564,11 +51650,11 @@ dpY
 dpY
 dpY
 dpY
-bld
+dpY
 sBh
 bld
-bld
-bld
+uXR
+dpY
 lUS
 dpY
 dpY
@@ -51823,8 +51909,8 @@ nyF
 bRC
 nyF
 nyF
-nyF
-nyF
+plb
+plb
 nyF
 dTH
 nyF
@@ -53695,7 +53781,7 @@ vfH
 vfH
 vfH
 vfH
-vfH
+pQG
 vfH
 aCd
 ukg
@@ -56742,8 +56828,8 @@ cBw
 uyy
 uyy
 uyy
-rUF
-mBc
+uyy
+hEc
 ncg
 bSp
 cPg
@@ -56997,12 +57083,12 @@ uyy
 uNy
 bTj
 eEZ
+uyy
+eqQ
 vvz
 uyy
-aJV
-eMz
-eYx
-bSp
+fPM
+cdu
 cPg
 lOp
 eYx
@@ -57254,11 +57340,11 @@ uyy
 sKv
 qVH
 qyx
+uyy
+faC
 faC
 uyy
-aJV
-eMz
-mvQ
+uGl
 pVb
 lkH
 xvA
@@ -57512,11 +57598,11 @@ cSz
 bHF
 tzF
 vFb
+wKS
+aAQ
 uyy
-aJV
-eMz
 rIt
-isJ
+cdu
 fee
 fee
 mEk
@@ -57770,8 +57856,8 @@ uyy
 uyy
 uyy
 uyy
-nJG
-nJG
+uyy
+uyy
 nJG
 qjf
 mng
@@ -59316,7 +59402,7 @@ jCY
 vWG
 nJG
 cwD
-xvO
+uJT
 cwD
 wJh
 cwD
@@ -59573,7 +59659,7 @@ jCY
 eTN
 nJG
 cwD
-xvO
+uJT
 cwD
 wJh
 xpw
@@ -59830,7 +59916,7 @@ jiE
 ylc
 nJG
 cwD
-xvO
+uJT
 cwD
 wJh
 cwD
@@ -60087,7 +60173,7 @@ aws
 mQq
 nJG
 cwD
-xvO
+uJT
 cwD
 wJh
 cwD
@@ -60344,7 +60430,7 @@ uTv
 wAZ
 lYQ
 rzd
-xvO
+uJT
 cwD
 wJh
 cwD
@@ -60601,7 +60687,7 @@ ksb
 ltX
 nJG
 cwD
-vVf
+lMC
 cwD
 lWc
 cwD
@@ -60621,7 +60707,7 @@ rqX
 rqX
 ktb
 aSJ
-umU
+fhi
 aKE
 bPC
 aSJ

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -142,12 +142,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"akL" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "akW" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -184,14 +178,6 @@
 "amG" = (
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hull/lower_hull)
-"amQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "anb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -422,11 +408,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/living/briefing)
-"aDK" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "aDU" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -668,10 +649,6 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
-"aPv" = (
-/obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship/orange,
-/area/mainship/squads/general)
 "aPM" = (
 /obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
@@ -791,6 +768,11 @@
 /obj/effect/landmark/start/job/squadleader,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"aUw" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
+	},
+/area/mainship/squads/general)
 "aVn" = (
 /obj/structure/orbital_cannon,
 /obj/machinery/light/mainship/small{
@@ -844,6 +826,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"aYR" = (
+/turf/open/floor/mainship/blue{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "aYW" = (
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -907,9 +894,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "baH" = (
-/obj/machinery/vending/MarineMed,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/sterile/side{
-	dir = 8
+	dir = 5
 	},
 /area/mainship/squads/general)
 "bbl" = (
@@ -1119,6 +1106,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"brj" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "brH" = (
 /obj/item/grown/sunflower,
 /turf/open/floor/grass,
@@ -1254,11 +1247,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "bzT" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
 	},
-/area/mainship/squads/general)
+/area/mainship/hallways/aft_hallway)
 "bAT" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
@@ -1508,12 +1500,6 @@
 	},
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
-"bNf" = (
-/obj/machinery/chem_master,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "bNh" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1673,6 +1659,13 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"bTv" = (
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/obj/structure/sign/prop1,
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "bTS" = (
 /obj/structure/mirror,
 /turf/open/floor/wood,
@@ -1809,6 +1802,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"cdr" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "cdu" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/yellow_cargo,
@@ -1870,9 +1870,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"cfP" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black/full,
+"cfQ" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange,
 /area/mainship/squads/general)
 "chD" = (
 /obj/item/toy/plush/carp,
@@ -1902,10 +1902,19 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cjl" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/squads/general)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/earmuffs,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/gloves/marine/fingerless,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/head/tgmcberet/red,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "cjC" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
@@ -2582,11 +2591,6 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"dcT" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 8
-	},
-/area/mainship/hallways/aft_hallway)
 "dcY" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -2865,6 +2869,12 @@
 "dpY" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dqD" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "drW" = (
 /obj/docking_port/stationary/ert/target{
 	id = "port_target";
@@ -2977,15 +2987,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
-"dAf" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 4
-	},
-/area/mainship/medical/chemistry)
 "dBm" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck/kotahi,
@@ -3220,12 +3221,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"dOT" = (
-/obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "dPp" = (
 /obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/mainship,
@@ -3359,6 +3354,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
+"dXL" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "dXO" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 9
@@ -3749,10 +3758,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
-"ezf" = (
-/obj/machinery/marine_selector/clothes/leader,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "ezh" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -4346,17 +4351,17 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
-"fhe" = (
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "fhi" = (
 /obj/machinery/light/red{
 	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"fhP" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
+/area/mainship/squads/general)
 "fku" = (
 /obj/effect/ai_node,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -4384,12 +4389,6 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"fld" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "flk" = (
 /obj/machinery/door_control/ai/exterior{
 	dir = 4
@@ -4502,20 +4501,6 @@
 /obj/structure/sign/prop4,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
-"fpZ" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/misc/earmuffs,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/clothing/gloves/marine/fingerless,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/clothing/head/tgmcberet/red,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/shipboard/firing_range)
 "fqj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/bed/stool{
@@ -4802,7 +4787,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/weapon,
-/turf/open/floor/mainship/orange{
+/turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/mainship/squads/general)
@@ -4960,17 +4945,6 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"fMB" = (
-/obj/structure/cable,
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/structure/sign/chemistry{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
 "fNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5041,12 +5015,6 @@
 	dir = 4
 	},
 /area/mainship/medical/chemistry)
-"fTH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "fTZ" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small{
@@ -5204,6 +5172,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"gaW" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "gbc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5664,7 +5641,7 @@
 "gFW" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship/orange{
-	dir = 1
+	dir = 8
 	},
 /area/mainship/squads/general)
 "gGb" = (
@@ -5700,6 +5677,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"gLL" = (
+/obj/machinery/marine_selector/clothes/engi,
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "gLR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6521,6 +6502,10 @@
 /obj/vehicle/unmanned/droid,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/command/airoom)
+"hQU" = (
+/obj/machinery/marine_selector/gear/smartgun,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "hRh" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 1
@@ -6819,12 +6804,6 @@
 /obj/item/tool/crowbar,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"igL" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "igO" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/wood,
@@ -6858,6 +6837,17 @@
 /obj/structure/supply_drop,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"iju" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"ijI" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "ijM" = (
 /obj/structure/bookcase,
 /obj/item/folder/white,
@@ -6924,11 +6914,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"imE" = (
-/turf/open/floor/mainship/blue{
-	dir = 6
-	},
-/area/mainship/squads/general)
 "imJ" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -7563,6 +7548,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"jfW" = (
+/obj/machinery/vending/medical/shipside,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "jhK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/mainship/floor,
@@ -7675,6 +7666,18 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"juX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
+/area/mainship/squads/general)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -7695,6 +7698,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
+"jwD" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "jwH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/research/containment/floor2{
@@ -7820,6 +7829,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"jGF" = (
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "jHd" = (
 /obj/structure/dropship_equipment/shuttle/sentry_holder,
 /turf/open/floor/mainship/orange{
@@ -8420,6 +8434,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
+"kBc" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "kBk" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
@@ -8497,6 +8516,10 @@
 /obj/item/trash/cigbutt/cigarbutt,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"kFR" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "kGb" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
 /turf/open/floor/mainship/orange{
@@ -8532,21 +8555,16 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
-"kHb" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/rifle/m412,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/turf/open/floor/mainship/red,
-/area/mainship/shipboard/firing_range)
 "kHp" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
+"kHq" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "kHN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -8594,6 +8612,14 @@
 /obj/machinery/computer/camera_advanced/remote_fob,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"kLG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "kLK" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -8960,6 +8986,11 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
+"lfn" = (
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -9060,11 +9091,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"lki" = (
-/turf/open/floor/mainship/blue{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "lkD" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/mainship/mono,
@@ -9195,12 +9221,6 @@
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
 /area/mainship/living/tankerbunks)
-"lpB" = (
-/obj/machinery/marine_selector/clothes/medic,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/squads/general)
 "lqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9390,6 +9410,11 @@
 "lAT" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"lBk" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "lBs" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
@@ -9453,6 +9478,10 @@
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"lEt" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "lEz" = (
 /turf/open/floor/mainship/terragov/north{
 	dir = 5
@@ -9482,12 +9511,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"lFM" = (
-/obj/machinery/vending/medical/shipside,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wirecutters,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+"lFD" = (
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "lGi" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -9688,6 +9722,10 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"lOP" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/squads/general)
 "lPM" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/chair/office/dark{
@@ -10311,15 +10349,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"mBE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flipped{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "mBZ" = (
 /turf/open/space,
 /area/space)
@@ -10386,9 +10415,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
@@ -10493,8 +10520,14 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
 "mNM" = (
-/turf/open/floor/mainship/orange{
+/obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
 /area/mainship/squads/general)
 "mNV" = (
@@ -10680,9 +10713,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"mXe" = (
-/turf/open/floor/mainship/blue/corner,
-/area/mainship/squads/general)
 "mXf" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
@@ -10999,10 +11029,6 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"noR" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/squads/general)
 "npN" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
@@ -11041,6 +11067,18 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
+"num" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11462,6 +11500,12 @@
 	dir = 9
 	},
 /area/mainship/shipboard/weapon_room)
+"nVJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "nWd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -11624,15 +11668,6 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
-"oeI" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/squads/general)
 "ogF" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/mainship,
@@ -11790,6 +11825,23 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
+"orN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "osb" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -12184,16 +12236,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
-"oUY" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 1
-	},
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
 "oWP" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -12363,6 +12405,17 @@
 /obj/structure/largecrate/supply/ammo/standard_ammo,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"pef" = (
+/obj/structure/cable,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/chemistry{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "peg" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/yellow_cargo,
@@ -12380,22 +12433,14 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "pfi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "pfH" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -12447,11 +12492,9 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
 "pii" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/marine_selector/gear/medic,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/squads/general)
 "pjB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12582,6 +12625,10 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"ppc" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "pqm" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship{
@@ -12656,10 +12703,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"pvz" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
 "pvW" = (
 /obj/item/toy/deck,
 /obj/structure/table/wood,
@@ -12686,12 +12729,6 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
-"pxw" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "pya" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -13004,12 +13041,6 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
-"pPG" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "pPR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13278,7 +13309,9 @@
 /area/mainship/hallways/boxingring)
 "qhf" = (
 /obj/machinery/marine_selector/clothes/medic,
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "qiy" = (
 /obj/structure/cable,
@@ -13457,18 +13490,6 @@
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
 /area/mainship/engineering/port_atmos)
-"qtX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "qvJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
@@ -13579,12 +13600,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"qzM" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
 "qAE" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -13683,12 +13698,6 @@
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
-"qHm" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "qHv" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/glass/glass{
@@ -13761,18 +13770,6 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
-"qME" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "qMG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -14306,6 +14303,12 @@
 /obj/item/toy/plush/lizard,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
+"rrv" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "rrw" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/red/full,
@@ -14496,6 +14499,16 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
+"rDX" = (
+/obj/structure/bed/chair/office/dark,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "rEw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14873,10 +14886,6 @@
 	dir = 8
 	},
 /area/mainship/engineering/ce_room)
-"sdS" = (
-/obj/machinery/marine_selector/clothes/engi,
-/turf/open/floor/mainship/orange/full,
-/area/mainship/squads/general)
 "seg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -14937,9 +14946,10 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
 "sjY" = (
-/turf/open/floor/mainship/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "skU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -15248,16 +15258,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "sFM" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
+/turf/open/floor/mainship/blue{
+	dir = 6
 	},
 /area/mainship/squads/general)
 "sGk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/black/full,
-/area/mainship/squads/general)
+/area/mainship/medical/chemistry)
 "sGA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1443;
@@ -15267,13 +15277,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"sGL" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
 "sGU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
@@ -15324,7 +15327,7 @@
 /area/mainship/engineering/port_atmos)
 "sMn" = (
 /obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/orange{
+/turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/mainship/squads/general)
@@ -15591,9 +15594,7 @@
 /area/mainship/command/cic)
 "tgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
+/turf/open/floor/mainship/sterile/corner,
 /area/mainship/squads/general)
 "tgl" = (
 /obj/structure/cable,
@@ -15666,16 +15667,21 @@
 /obj/machinery/chem_dispenser/soda,
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"tkS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+"tkH" = (
+/obj/machinery/firealarm{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/blue{
-	dir = 5
+/obj/structure/table/mainship/nometal,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/turf/open/floor/mainship/red,
+/area/mainship/shipboard/firing_range)
+"tkS" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange{
+	dir = 1
 	},
 /area/mainship/squads/general)
 "tkW" = (
@@ -15832,16 +15838,6 @@
 	dir = 1
 	},
 /area/space)
-"twv" = (
-/obj/structure/bed/chair/office/dark,
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "txW" = (
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
@@ -16120,6 +16116,9 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"tJr" = (
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/squads/general)
 "tJA" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16147,6 +16146,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"tLO" = (
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "tMy" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
@@ -16267,6 +16272,10 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
+"tTQ" = (
+/obj/machinery/marine_selector/clothes/medic,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/squads/general)
 "tTR" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
@@ -17142,11 +17151,9 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "uWK" = (
-/obj/machinery/air_alarm{
-	dir = 1
+/turf/open/floor/mainship/orange{
+	dir = 4
 	},
-/obj/structure/sign/prop1,
-/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "uXb" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
@@ -17188,9 +17195,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "uZR" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "vab" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
@@ -17260,12 +17268,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"vdy" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "vdN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -17331,9 +17333,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"vgs" = (
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/squads/general)
 "vha" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17563,6 +17562,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
+"vwM" = (
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vxx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17588,7 +17593,10 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "vyG" = (
-/turf/open/floor/mainship/orange/full,
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "vyJ" = (
 /turf/open/floor/mainship/hexagon,
@@ -17767,12 +17775,6 @@
 "vMr" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/brig)
-"vMv" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "vMM" = (
 /obj/effect/soundplayer/deltaplayer,
 /obj/structure/sign/evac,
@@ -17824,17 +17826,6 @@
 /obj/effect/urban/decal/trash/ten,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"vSf" = (
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/squads/general)
 "vSo" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -17904,8 +17895,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "vXR" = (
-/obj/machinery/marine_selector/gear/smartgun,
-/turf/open/floor/mainship/black/full,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "vXY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18223,20 +18213,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
-"wsd" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "wsG" = (
 /obj/structure/bed/chair/nometal{
 	dir = 4
@@ -18257,7 +18233,7 @@
 	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 4
+	dir = 8
 	},
 /area/mainship/squads/general)
 "wsX" = (
@@ -18289,11 +18265,6 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"wtX" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/squads/general)
 "wup" = (
 /turf/closed/wall/mainship/research/containment/wall/corner,
 /area/mainship/medical/medical_science)
@@ -18348,6 +18319,18 @@
 	},
 /turf/open/floor/mainship/orange/corner,
 /area/mainship/engineering/ce_room)
+"wxV" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "wyz" = (
 /obj/machinery/landinglight/alamo{
 	dir = 1;
@@ -18514,20 +18497,6 @@
 /obj/machinery/telecomms/server/presets/delta,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"wIn" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/dropper,
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
 "wII" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -18949,6 +18918,9 @@
 /mob/living/simple_animal/cat/martin,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"xfw" = (
+/turf/open/floor/mainship/blue/corner,
+/area/mainship/squads/general)
 "xgv" = (
 /obj/structure/bed/chair/sofa,
 /obj/machinery/camera/autoname/mainship,
@@ -19026,16 +18998,16 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "xkC" = (
-/obj/effect/turf_decal/warning_stripes/box/small{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/warning_stripes/box/arrow{
-	dir = 8
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/squads/general)
+/area/mainship/medical/chemistry)
 "xkD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
@@ -19101,10 +19073,6 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
-"xop" = (
-/obj/machinery/marine_selector/gear/medic,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/squads/general)
 "xoE" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
@@ -19486,6 +19454,12 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
+"xHo" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "xIb" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -19520,6 +19494,20 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"xKw" = (
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/hand_labeler,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "xKE" = (
 /obj/machinery/door/poddoor/railing{
 	id = "supply_elevator_railing"
@@ -19561,6 +19549,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"xMh" = (
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "xNw" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -19915,6 +19913,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"ych" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "ycp" = (
 /obj/machinery/computer/camera_advanced/overwatch/military/bravo,
 /turf/open/floor/mainship/orange{
@@ -20057,10 +20061,6 @@
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
-"ykL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/squads/general)
 "ylc" = (
 /turf/open/floor/mainship/red{
 	dir = 8
@@ -46405,13 +46405,13 @@ tyN
 tyN
 tyN
 mvs
-qzM
-igL
-akL
-twv
-bNf
-wIn
-vdy
+sGk
+tLO
+brj
+rDX
+jwD
+xKw
+kHq
 dLo
 kSC
 yjx
@@ -46663,10 +46663,10 @@ yfw
 kuc
 mvs
 oca
-sGL
-wIn
+cdr
+xKw
 vwL
-lFM
+jfW
 sIN
 aSw
 dLo
@@ -46922,8 +46922,8 @@ mvs
 vTy
 fTy
 iuw
+xkC
 mHi
-dAf
 wkJ
 nJd
 dLo
@@ -47179,7 +47179,7 @@ mvs
 kVD
 kVD
 kVD
-oUY
+xMh
 kVD
 eGM
 kVD
@@ -47438,9 +47438,9 @@ gBJ
 ePj
 fEb
 fEb
-wsd
+dXL
 orC
-fMB
+pef
 fuy
 yjx
 mvs
@@ -47695,7 +47695,7 @@ iwj
 lAT
 lAT
 lAT
-qtX
+num
 mgw
 mgw
 nMm
@@ -47952,10 +47952,10 @@ lSQ
 mNf
 qFX
 iMF
-qME
-pii
-pii
-mBE
+wxV
+iju
+iju
+pfi
 mzF
 mvs
 nku
@@ -49000,7 +49000,7 @@ roN
 nIG
 mrK
 xvv
-pZE
+vAn
 iHy
 vgo
 qKw
@@ -50285,7 +50285,7 @@ xvv
 xvv
 xvv
 xvv
-pZE
+vAn
 pbe
 vAn
 dhv
@@ -51045,7 +51045,7 @@ vAn
 swv
 vAn
 vAn
-dcT
+bzT
 vAn
 vAn
 vAn
@@ -54659,20 +54659,20 @@ uqV
 jDL
 rUF
 swY
-pfi
-oeI
+wsR
+fEq
 lJV
-baH
-xkC
+sMn
+lFD
 swY
 rUF
-dOT
-mNM
-fEq
+gFW
+jGF
+gaW
 oIT
-sMn
+vyG
 pyS
-dOT
+gFW
 rUF
 kMi
 dBu
@@ -54917,19 +54917,19 @@ tVF
 rUF
 dtI
 kUU
-noR
-uZR
-aDK
+lOP
+ijI
+kBc
 tVr
 xXT
 rUF
 tKs
 krM
 rOr
-vyG
+vXR
 pGb
 fYB
-uWK
+bTv
 mBc
 vmD
 nmm
@@ -55172,15 +55172,15 @@ kTI
 jQT
 vmD
 hme
-lpB
-tkW
-uZR
-pPG
-wtX
-aDK
 qhf
+tkW
+ijI
+dqD
+aUw
+kBc
+tTQ
 hme
-sdS
+gLL
 pGb
 oAz
 kHp
@@ -55431,24 +55431,24 @@ rUF
 mBc
 lRs
 tkW
-vgs
-bzT
-cjl
-sFM
-xop
+tJr
+baH
+fhP
+lBk
+pii
 rUF
-gFW
+tkS
 pGb
 pGb
 kHp
 pGb
 syR
-aPv
+cfQ
 rUF
-pvz
+kFR
 iBL
 uVF
-fTH
+uZR
 acl
 mqK
 hPb
@@ -55670,11 +55670,11 @@ eQb
 eQb
 rUF
 vVG
-lki
+aYR
 mRy
 xWS
 hvS
-ezf
+ppc
 rUF
 wDi
 ngh
@@ -55689,21 +55689,21 @@ rUF
 aLA
 rbd
 hPG
-ykL
 tgi
+nVJ
 hPG
 aMp
 rUF
 tED
 krM
 pGb
-vyG
+vXR
 pGb
 fYB
 elQ
 rUF
 eIM
-sGk
+sjY
 rNX
 wDN
 wfO
@@ -55944,25 +55944,25 @@ eMz
 eMz
 rUF
 oNs
-wsR
+orN
 yhG
-vMv
-pxw
-vSf
+vwM
+xHo
+mNM
 ukJ
 rUF
 pqm
-fhe
-fld
+uWK
+ych
 xbP
 fKK
-amQ
+kLG
 hGE
 rUF
 xuy
-sGk
+sjY
 vIv
-fTH
+uZR
 fAy
 mqK
 ukb
@@ -56217,9 +56217,9 @@ oXs
 rUF
 ekL
 ikM
-sGk
+sjY
 ikM
-fTH
+uZR
 cef
 mqK
 lys
@@ -56474,7 +56474,7 @@ jqy
 iae
 mBc
 tXJ
-sGk
+sjY
 iFI
 nsl
 jOQ
@@ -56699,10 +56699,10 @@ tpi
 rUF
 nIn
 vfL
-mXe
-qHm
-sjY
-imE
+xfw
+rrv
+lfn
+sFM
 ryY
 xVU
 bSp
@@ -56731,9 +56731,9 @@ cPg
 llW
 rUF
 ekh
-sGk
+sjY
 cPg
-fTH
+uZR
 wfO
 mqK
 uKH
@@ -56955,11 +56955,11 @@ cqY
 cRE
 rUF
 dPp
-tkS
-imE
+juX
+sFM
 xWS
 fPK
-ezf
+ppc
 rUF
 lSq
 bSp
@@ -56988,9 +56988,9 @@ cPg
 lOp
 rUF
 kdD
-sGk
-vXR
-fTH
+sjY
+hQU
+uZR
 cef
 mqK
 uKH
@@ -57245,9 +57245,9 @@ cPg
 lOp
 rUF
 mnb
-sGk
+sjY
 vIv
-fTH
+uZR
 fAy
 mqK
 uKH
@@ -57501,10 +57501,10 @@ ciZ
 cPg
 lOp
 rUF
-cfP
+lEt
 iBL
 eWu
-fTH
+uZR
 jOQ
 mqK
 lRc
@@ -59270,7 +59270,7 @@ bDv
 bDv
 cEe
 bDv
-fpZ
+cjl
 fmP
 nhn
 nbh
@@ -60301,7 +60301,7 @@ wJe
 nJG
 qxw
 jiE
-kHb
+tkH
 nJG
 cwD
 uJT

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -127,14 +127,12 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "aiP" = (
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
+/obj/effect/turf_decal/medical_decals/triage/top{
+	dir = 8
 	},
-/obj/machinery/bodyscanner{
-	dir = 1
+/turf/open/floor/whitecyanthree{
+	dir = 8
 	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare,
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "aiT" = (
 /turf/open/floor/mainship_hull/dir{
@@ -394,9 +392,13 @@
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
 "aCM" = (
-/obj/structure/bed/roller,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/turf/open/floor/whitecyanthree{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "aDc" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small,
@@ -1373,15 +1375,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "bFG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/medical_decals/triage/bottom,
 /obj/effect/ai_node,
+/obj/effect/turf_decal/medical_decals/cryo/cell/two,
 /turf/open/floor/whitecyanthree{
 	dir = 1
 	},
@@ -1755,17 +1751,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "bYJ" = (
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
-	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/whitecyanthree{
-	dir = 8
+/obj/effect/turf_decal/medical_decals/doc{
+	dir = 4
 	},
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "bYP" = (
 /turf/open/floor/mainship/ntlogo/nt3,
@@ -2557,9 +2548,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "dcz" = (
 /obj/structure/cable,
@@ -3052,7 +3041,6 @@
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "dIk" = (
-/obj/item/medevac_beacon,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3186,14 +3174,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "dNQ" = (
+/obj/machinery/door/poddoor/shutters/opened/medbay,
 /obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
+	id = "or1privacyshutter";
 	name = "\improper Privacy Shutters"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/bioprinter/stocked,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "dNR" = (
@@ -3538,22 +3526,19 @@
 /turf/open/floor/plating,
 /area/mainship/engineering/upper_engineering)
 "ejJ" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/computer/cloning_console/vats,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "ekh" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship,
@@ -3778,11 +3763,9 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
 "eBB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/effect/soundplayer/deltaplayer,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "eCc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4454,9 +4437,6 @@
 /area/mainship/hallways/hangar)
 "foU" = (
 /obj/structure/cable,
-/obj/machinery/computer/sleep_console{
-	dir = 8
-	},
 /obj/effect/turf_decal/medical_decals/triage{
 	dir = 8
 	},
@@ -5430,22 +5410,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "gpC" = (
-/obj/structure/cable,
 /obj/structure/table/mainship/nometal,
-/obj/machinery/light/mainship{
+/obj/item/healthanalyzer{
+	pixel_x = -11
+	},
+/obj/item/healthanalyzer{
+	pixel_x = -11
+	},
+/obj/item/storage/firstaid/adv,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/machinery/recharger,
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = -10;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = 10;
-	pixel_y = 13
-	},
-/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "gpU" = (
 /obj/structure/toilet{
@@ -5732,16 +5712,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gQY" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
@@ -6183,6 +6160,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "hsr" = (
@@ -6201,7 +6179,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/corner{
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
@@ -6331,17 +6313,16 @@
 /turf/open/floor/mainship/orange,
 /area/mainship/squads/general)
 "hGO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/medical_decals/triage/edge{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/whitecyanthree{
 	dir = 1
 	},
-/turf/open/floor/whitecyanfour,
 /area/mainship/medical/lower_medical)
 "hGT" = (
 /obj/machinery/camera/autoname{
@@ -6585,6 +6566,10 @@
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 4
 	},
+/obj/structure/table/mainship/nometal,
+/obj/item/reagent_containers/glass/beaker/biomass{
+	name = "biomass beaker"
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "hVb" = (
@@ -6741,13 +6726,8 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "ieX" = (
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/whitecyanthree{
-	dir = 8
-	},
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "iff" = (
 /obj/machinery/power/apc/mainship,
@@ -6796,16 +6776,6 @@
 "iiC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/medical_decals/triage,
-/obj/structure/table/black,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/storage/firstaid/adv,
-/obj/machinery/recharger,
-/obj/item/healthanalyzer{
-	pixel_x = -11
-	},
 /turf/open/floor/whitecyanthree{
 	dir = 4
 	},
@@ -7876,6 +7846,7 @@
 /area/mainship/living/mechpilotquarters)
 "jII" = (
 /obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
@@ -8672,11 +8643,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "kMt" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/glass/beaker/biomass{
-	name = "biomass beaker"
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "kML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8918,6 +8888,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
 "kYM" = (
+/obj/machinery/light/floor,
 /obj/effect/turf_decal/medical_decals/cryo,
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/side{
@@ -9208,14 +9179,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/holosign/surgery{
-	id = "or2sign"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+	id = "or1sign"
 	},
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -9223,8 +9187,15 @@
 /obj/machinery/door/window/secure/medical{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/operating_room_one)
 "lon" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9254,17 +9225,15 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "lqS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 8
+	},
+/turf/open/floor/whitecyanfour{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lrn" = (
 /obj/structure/cable,
@@ -9386,16 +9355,14 @@
 /area/mainship/command/telecomms)
 "lxg" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/obj/effect/turf_decal/medical_decals/cryo/cell,
+/turf/open/floor/whitecyanfour,
 /area/mainship/medical/lower_medical)
 "lxK" = (
 /obj/effect/soundplayer/deltaplayer,
@@ -9776,8 +9743,13 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "lQN" = (
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/side,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/sleep_console{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lRc" = (
 /obj/machinery/light/mainship/small{
@@ -9824,10 +9796,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "lSQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
 /area/mainship/medical/lower_medical)
 "lSY" = (
 /obj/structure/cable,
@@ -10180,13 +10154,14 @@
 	},
 /area/mainship/squads/general)
 "mnH" = (
-/obj/machinery/bot/cleanbot,
 /obj/machinery/light/floor{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/computer/body_scanconsole,
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mog" = (
 /obj/item/trash/candy,
@@ -10495,6 +10470,13 @@
 	dir = 5
 	},
 /area/mainship/squads/req)
+"mKk" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "mKE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10698,20 +10680,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "mUU" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/obj/machinery/vending/nanomed{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/light/floor{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
 	},
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "mVr" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
@@ -11460,18 +11442,24 @@
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
 "nRH" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or2sign"
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
+/obj/structure/bed/chair/comfy{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/door/window/secure/medical{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "nRP" = (
@@ -11767,35 +11755,17 @@
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "onC" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
+/obj/structure/sink{
+	dir = 4
 	},
-/obj/item/storage/box/gloves{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/structure/sign/nosmoking_2{
-	dir = 4;
-	pixel_y = -4
-	},
-/obj/machinery/power/apc/mainship{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = -5;
-	pixel_y = 10
+/obj/machinery/light/floor{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
@@ -11934,11 +11904,21 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oyZ" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
-/obj/machinery/camera/autoname/mainship{
+/obj/structure/table/mainship/nometal,
+/obj/machinery/light/floor,
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "ozU" = (
 /obj/structure/disposalpipe/segment,
@@ -12149,7 +12129,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oOM" = (
-/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
@@ -12581,15 +12560,11 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "plR" = (
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/turf/open/floor/whitecyanfour{
-	dir = 4
-	},
+/obj/effect/turf_decal/medical_decals/triage/top,
+/turf/open/floor/whitecyanthree,
 /area/mainship/medical/lower_medical)
 "pmY" = (
 /obj/structure/table/mainship/nometal,
@@ -12802,19 +12777,14 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
 "pDg" = (
-/obj/machinery/computer/body_scanconsole,
-/obj/effect/turf_decal/medical_decals/triage/top{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/whitecyanthree{
-	dir = 8
-	},
+/obj/item/medevac_beacon,
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "pEF" = (
 /obj/structure/table/mainship/nometal,
@@ -13439,6 +13409,20 @@
 	dir = 4
 	},
 /area/space)
+"qqg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "qqh" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/red{
@@ -14198,9 +14182,11 @@
 /area/mainship/command/cic)
 "rkq" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/medical_decals/triage,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/medical_decals/triage/bottom{
+	dir = 8
+	},
 /turf/open/floor/whitecyanthree{
 	dir = 4
 	},
@@ -14321,13 +14307,13 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar/droppod)
 "rrp" = (
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
-	},
 /obj/machinery/autodoc{
 	dir = 1
 	},
 /obj/effect/turf_decal/warning_stripes/stripedsquare,
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 8
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "rrt" = (
@@ -14501,6 +14487,7 @@
 	dir = 1;
 	pixel_y = -4
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/mainship/yellow_cargo/arrow{
 	dir = 1
 	},
@@ -14571,12 +14558,40 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "rGl" = (
-/obj/machinery/robotic_cradle,
-/obj/effect/turf_decal/warning_stripes/stripedsquare,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
 	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/table/reinforced,
+/obj/structure/sign/nosmoking_2{
+	dir = 4;
+	pixel_y = -4
+	},
+/obj/item/storage/surgical_tray,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "rHh" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
@@ -14893,7 +14908,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/bed/roller,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sdR" = (
@@ -15285,7 +15299,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/mainship/sterile/dark,
+/obj/structure/rack,
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "sGk" = (
 /obj/machinery/door/poddoor/railing{
@@ -16086,25 +16118,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tGU" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/holosign/surgery{
-	id = "or1sign"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 4
-	},
-/obj/machinery/door/window/secure/medical{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_one)
 "tHk" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
@@ -16114,15 +16128,6 @@
 /area/mainship/hallways/hangar)
 "tHY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 4
-	},
 /turf/open/floor/whitecyanfour{
 	dir = 1
 	},
@@ -16344,16 +16349,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tWq" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "tWD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -16559,9 +16562,21 @@
 	dir = 4;
 	on = 1
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "uiG" = (
 /obj/effect/turf_decal/warning_stripes/thick,
@@ -16738,25 +16753,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uvB" = (
-/obj/structure/rack,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
+/obj/structure/table/mainship/nometal,
+/obj/item/clothing/head/welding,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/clothing/head/welding,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "uvK" = (
 /obj/structure/table/mainship/nometal,
@@ -16990,6 +17000,20 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/living/mechpilotquarters)
+"uKQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "uLb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired,
@@ -17190,8 +17214,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uVk" = (
-/obj/machinery/computer/cloning_console/vats,
-/turf/open/floor/mainship/sterile/side,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/effect/turf_decal/medical_decals/doc{
+	dir = 4
+	},
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "uVF" = (
 /obj/machinery/light/mainship{
@@ -17253,8 +17282,6 @@
 /area/mainship/command/telecomms)
 "uZR" = (
 /obj/machinery/vending/medical/shipside,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wirecutters,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "vab" = (
@@ -17715,8 +17742,14 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "vBY" = (
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile/side,
+/obj/machinery/bot/cleanbot,
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "vCB" = (
 /obj/structure/table/mainship,
@@ -17974,15 +18007,20 @@
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
 "vYo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19667,8 +19705,12 @@
 "xSi" = (
 /obj/effect/turf_decal/medical_decals/triage/edge,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /turf/open/floor/whitecyanfour{
 	dir = 8
 	},
@@ -19783,9 +19825,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
+/obj/machinery/robotic_cradle,
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "xVU" = (
 /obj/effect/turf_decal/warning_stripes/box/small,
@@ -19893,19 +19935,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "xZy" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -47731,10 +47764,10 @@ xBT
 cYZ
 kWu
 ouq
-iwj
-lAT
-lAT
-lAT
+mKk
+mNf
+qFX
+iMF
 uQU
 mgw
 mgw
@@ -47985,13 +48018,13 @@ jCW
 kDx
 brN
 uqj
-aCM
+dpY
 aoQ
 mmC
 lSQ
-mNf
-qFX
-iMF
+dXO
+ivW
+qRK
 sFM
 nIF
 nIF
@@ -48246,9 +48279,9 @@ sdK
 cWC
 tEV
 htZ
-dXO
-ivW
-qRK
+lYL
+rSg
+sDn
 uig
 lAT
 lAT
@@ -48503,9 +48536,9 @@ dpY
 kWu
 lAT
 dcg
-lYL
-rSg
-sDn
+cTx
+wTH
+oNh
 uvB
 lAT
 sZh
@@ -48759,15 +48792,15 @@ bOz
 xOg
 mvs
 xZy
-vYo
-cTx
-wTH
-oNh
+gnK
+xjD
+vBY
+bnL
 xVO
 lAT
 lAT
-nMm
-lQN
+qqg
+yjx
 mvs
 mbQ
 xGl
@@ -49015,16 +49048,16 @@ rCn
 lSk
 dpY
 nRz
-rGl
-gnK
-xjD
+usa
+mUU
+gNc
 mnH
-bnL
-eBB
+gNc
+rHK
+kMt
 lAT
-lAT
-nMm
-uVk
+ejJ
+yjx
 mvs
 mbQ
 xGl
@@ -49272,16 +49305,16 @@ hMB
 lCh
 fwq
 mvs
-usa
+jUl
 lxg
-gNc
+aCM
 aiP
-gNc
-rHK
+aiP
+lqS
 rrp
 lAT
 nMm
-kMt
+mpw
 mvs
 nku
 rrj
@@ -49529,7 +49562,7 @@ brN
 aWk
 aQX
 mvs
-jUl
+oyZ
 hGO
 bYJ
 pDg
@@ -49788,14 +49821,14 @@ cYZ
 mvs
 kYM
 bFG
-ksa
+uVk
 dIk
 ksa
 jWB
 dnQ
 lAT
-wNF
-mpw
+uKQ
+yjx
 mvs
 nla
 xGl
@@ -50042,7 +50075,7 @@ aqx
 brN
 aWk
 dpY
-pzq
+mvs
 gpC
 tHY
 iiC
@@ -50050,9 +50083,9 @@ pEN
 rkq
 xSi
 foU
-tEV
+lQN
 mam
-vBY
+yjx
 mvs
 mbQ
 xGl
@@ -50300,16 +50333,16 @@ vdN
 tGI
 tQW
 mvs
-oCo
+mvs
 tGU
-tWq
+oCo
 loc
 dNQ
 nRH
+vYo
 aDU
-lAT
 wNF
-oyZ
+lTH
 mvs
 mbQ
 xGl
@@ -50556,15 +50589,15 @@ ecW
 tzk
 aWk
 dpY
-mvs
+eiU
+uFV
+tGU
 qOa
 uCj
-mUU
-lXB
 onC
-ejJ
+lXB
+rGl
 mHW
-lAT
 fom
 oOM
 mvs
@@ -50813,7 +50846,8 @@ gcM
 tzk
 aWk
 dpY
-nRz
+eBB
+dpY
 mvs
 mvs
 mvs
@@ -50821,9 +50855,8 @@ mvs
 mvs
 mvs
 dTh
-lqS
 gQY
-dTh
+tWq
 nRz
 pdj
 pdj
@@ -51070,7 +51103,7 @@ cvV
 tzk
 aWk
 dpY
-eiU
+dpY
 tWD
 vAn
 vAn
@@ -51080,7 +51113,7 @@ fDJ
 vAn
 vAn
 vhl
-pZF
+vAn
 vAn
 swv
 vAn

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -456,14 +456,6 @@
 /obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"aGZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
 "aHp" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
@@ -3187,17 +3179,6 @@
 	dir = 4
 	},
 /area/mainship/living/pilotbunks)
-"dTH" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/cas{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "dTK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3320,14 +3301,13 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "ecb" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/landinglight/cas{
-	dir = 8;
-	pixel_x = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ecW" = (
@@ -4117,16 +4097,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
 "faF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/ai_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/squads/req)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "faM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -4280,21 +4266,8 @@
 	},
 /area/mainship/squads/general)
 "fku" = (
-/obj/effect/ai_node,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "fky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5359,11 +5332,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "gpx" = (
-/obj/machinery/light/floor{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/cargo/arrow,
+/area/mainship/squads/req)
 "gpB" = (
 /obj/item/tool/taperoll/engineering,
 /turf/open/floor/mainship/mono,
@@ -5668,11 +5642,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gRV" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 5
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "supply_elevator_railing"
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/squads/req)
 "gSr" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable,
@@ -6575,16 +6550,6 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
-"hYr" = (
-/obj/machinery/landinglight/cas{
-	dir = 1;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "hZe" = (
 /turf/open/floor/plating/mainship/striped{
 	dir = 8
@@ -8260,13 +8225,6 @@
 /obj/structure/prop/mainship/prop_sec,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/brig)
-"kwo" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "kxh" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/chapel)
@@ -8769,9 +8727,25 @@
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "kWG" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/cas{
+	dir = 1;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "kWM" = (
 /turf/open/floor/mainship/yellow_cargo,
@@ -9423,13 +9397,6 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
-"lGv" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 1
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "lGU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9772,11 +9739,24 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "lUS" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
+/obj/machinery/landinglight/cas{
+	dir = 1;
+	pixel_y = -4
 	},
-/turf/open/floor/mainship/mono,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "lVp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11306,21 +11286,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "nPF" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "nQH" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
@@ -11435,15 +11406,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"nYk" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/machinery/light/floor{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "nYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11463,26 +11425,15 @@
 	},
 /area/mainship/shipboard/firing_range)
 "nZU" = (
-/obj/machinery/landinglight/cas{
-	dir = 1;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "oac" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
@@ -12135,10 +12086,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oZN" = (
-/obj/machinery/landinglight/cas{
-	dir = 1;
-	pixel_y = -4
-	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -12153,7 +12100,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/hangar)
 "oZY" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -13329,22 +13276,6 @@
 /obj/docking_port/stationary/supply,
 /turf/open/floor/mainship/empty,
 /area/mainship/squads/req)
-"qvN" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
 "qwg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -16774,7 +16705,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "uKp" = (
-/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "uKG" = (
@@ -18831,16 +18765,21 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "xlo" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/hangar)
 "xlu" = (
 /obj/machinery/door/poddoor/mainship/mech{
 	dir = 1
@@ -19282,10 +19221,6 @@
 	name = "\improper Warehouse Shutters"
 	},
 /obj/structure/plasticflaps/sturdy,
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "xHU" = (
@@ -19649,10 +19584,6 @@
 	id = "qm_warehouse";
 	name = "\improper Warehouse Shutters"
 	},
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "supply_elevator_railing"
-	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/req)
 "xZt" = (
@@ -19700,14 +19631,15 @@
 /area/mainship/medical/upper_medical)
 "yaf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "yao" = (
 /obj/structure/dropship_equipment/cas/weapon/minirocket_pod,
 /turf/open/floor/mainship/floor,
@@ -51094,13 +51026,13 @@ eDF
 xGr
 qST
 rEw
-eks
-xlo
+yaf
 vgo
 vgo
 vgo
 vgo
 vgo
+nPF
 vgo
 hrA
 vgo
@@ -51335,11 +51267,10 @@ tyN
 tyN
 tyN
 tyN
-nYk
 fwq
 fwq
 qMR
-gRV
+uKp
 dpY
 dpY
 dpY
@@ -51352,11 +51283,12 @@ dpY
 dpY
 dpY
 dpY
-yaf
+ecb
 vAn
 wLx
 wLx
 wLx
+vAn
 vAn
 vAn
 bYG
@@ -51592,7 +51524,6 @@ tyN
 hnu
 pIL
 tyN
-uKp
 gmQ
 dpY
 icg
@@ -51607,13 +51538,14 @@ dpY
 dpY
 dpY
 dpY
-eAd
 dpY
+eAd
 ybP
 cHE
 wYz
 xfo
 wYz
+cHE
 cHE
 lxK
 fQO
@@ -51849,7 +51781,6 @@ tyN
 hnu
 hnu
 tyN
-lUS
 dpY
 dpY
 dpY
@@ -51871,6 +51802,7 @@ cHE
 wYz
 wYz
 wYz
+cHE
 cHE
 hhf
 prY
@@ -52106,7 +52038,6 @@ iyr
 nyF
 nyF
 plb
-dTH
 nyF
 nyF
 kfB
@@ -52129,6 +52060,7 @@ xKE
 xKE
 xKE
 xkF
+cHE
 hhf
 doG
 rpv
@@ -52366,7 +52298,6 @@ kDx
 kDx
 kDx
 hFZ
-kDx
 qPc
 dpY
 dpY
@@ -52386,6 +52317,7 @@ gMb
 gMb
 gMb
 gMb
+gRV
 xHi
 iiU
 djj
@@ -52623,7 +52555,6 @@ tHk
 csW
 csW
 csW
-lGv
 qPc
 dpY
 dpY
@@ -52643,6 +52574,7 @@ gMb
 gMb
 gMb
 gMb
+gpx
 xZo
 eGl
 kPn
@@ -52880,7 +52812,6 @@ nzB
 kDx
 kDx
 kDx
-cxw
 qPc
 dpY
 dpY
@@ -52900,6 +52831,7 @@ gMb
 qvM
 gMb
 gMb
+gpx
 xZo
 cim
 vcN
@@ -53137,7 +53069,6 @@ kDx
 kDx
 kDx
 kDx
-kwo
 qPc
 dpY
 dpY
@@ -53157,6 +53088,7 @@ gMb
 gMb
 gMb
 gMb
+gpx
 xZo
 qKL
 vcN
@@ -53394,7 +53326,6 @@ kDx
 kDx
 kDx
 kDx
-cxw
 qPc
 dpY
 dpY
@@ -53414,6 +53345,7 @@ gMb
 gMb
 gMb
 gMb
+gRV
 xZo
 qKL
 vcN
@@ -53651,7 +53583,6 @@ kDx
 kDx
 kDx
 kDx
-kwo
 qPc
 dpY
 dpY
@@ -53671,6 +53602,7 @@ eXm
 eXm
 eXm
 kdD
+cHE
 hhf
 iOD
 gbc
@@ -53908,8 +53840,8 @@ kDx
 kDx
 kDx
 kDx
-cxw
 mxq
+dpY
 dpY
 dpY
 dpY
@@ -53919,7 +53851,6 @@ pCc
 dpY
 dpY
 dpY
-gpx
 yfw
 kuc
 fXg
@@ -53927,6 +53858,7 @@ eFA
 cHE
 unN
 eFA
+cHE
 cHE
 hhf
 lgN
@@ -54165,8 +54097,8 @@ kDx
 kDx
 kDx
 kDx
-kwo
 qPc
+dpY
 dpY
 dpY
 dpY
@@ -54176,10 +54108,10 @@ exV
 cjl
 dpY
 dpY
-dpY
 qwO
 gjA
-faF
+nZU
+cHE
 cHE
 cHE
 cHE
@@ -54422,8 +54354,7 @@ qWy
 kDx
 kDx
 kDx
-cxw
-hYr
+qPc
 vmD
 vmD
 vmD
@@ -54434,9 +54365,10 @@ vmD
 vmD
 vmD
 vmD
+fku
 rWD
-vmD
 aHG
+vmD
 vmD
 vmD
 vmD
@@ -54680,7 +54612,7 @@ xDq
 xDq
 xDq
 kWG
-nZU
+bjC
 diD
 rWK
 xdE
@@ -54692,12 +54624,12 @@ ykH
 rCU
 uMj
 uNt
-uMj
 jOm
 niH
 niH
 kVt
 rWK
+bjC
 bjC
 niH
 qQf
@@ -54936,8 +54868,8 @@ kDx
 kDx
 kDx
 hFZ
-kDx
-oZN
+lUS
+vmD
 vmD
 hWt
 vmD
@@ -55190,11 +55122,11 @@ fmN
 fmN
 fmN
 izJ
-ecb
 fmN
 fmN
 lHG
-fku
+faF
+vmD
 vmD
 bLP
 mXm
@@ -55447,11 +55379,11 @@ dpY
 dpY
 dpY
 dpY
-uKp
 dpY
 dpY
 dpY
-qvN
+oZN
+vmD
 vmD
 bLP
 mXm
@@ -55704,11 +55636,11 @@ dFt
 xtU
 dii
 eFh
-aGZ
 eFh
 kHN
 eFh
-nPF
+xlo
+vmD
 vmD
 bLP
 mXm
@@ -57255,7 +57187,7 @@ vou
 mXm
 mXm
 mXm
-mXm
+vcJ
 mXm
 mXm
 vcJ
@@ -57263,7 +57195,7 @@ mXm
 mXm
 mXm
 mXm
-mXm
+vcJ
 mXm
 ekx
 ekx

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1032,9 +1032,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "bld" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/window/reinforced/toughened{
-	dir = 1
+/obj/machinery/computer/cryopod{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -3572,7 +3571,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ekx" = (
 /turf/closed/wall/mainship,
@@ -5127,19 +5126,6 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -5449,7 +5435,6 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/closet/walllocker/hydrant/extinguisher,
 /obj/item/reagent_containers/glass/beaker/cryomix{
 	name = "cryo beaker";
 	pixel_x = -10;
@@ -6121,12 +6106,6 @@
 /area/mainship/hallways/starboard_hallway)
 "hnu" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/structure/window/reinforced/toughened{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "hnV" = (
@@ -7071,7 +7050,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "iyr" = (
-/obj/machinery/computer/squad_selector,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/landinglight/cas{
+	dir = 4;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan,
+/obj/structure/rack,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "iyN" = (
@@ -8836,7 +8828,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "kTI" = (
 /obj/machinery/firealarm{
@@ -9757,6 +9749,25 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lQb" = (
@@ -9830,13 +9841,7 @@
 	dir = 4
 	},
 /obj/machinery/light/mainship,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/tool/hand_labeler,
-/obj/item/facepaint/green,
-/obj/structure/table/mainship/nometal,
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lTt" = (
@@ -10161,6 +10166,15 @@
 /turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "mng" = (
+/obj/item/trash/cigbutt{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/trash/cigbutt,
 /turf/open/floor/mainship/terragov/north{
 	dir = 9
 	},
@@ -10812,8 +10826,7 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ncg" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -11547,6 +11560,9 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 6
 	},
+/obj/machinery/light/floor{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "nYD" = (
@@ -11626,7 +11642,6 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/structure/closet/walllocker/hydrant/extinguisher,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 1
 	},
@@ -11865,6 +11880,8 @@
 /area/mainship/squads/req)
 "ouq" = (
 /obj/structure/cable,
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -12533,10 +12550,7 @@
 	dir = 4;
 	pixel_x = -4
 	},
-/obj/machinery/door/window/secure{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/hangar)
 "plr" = (
 /turf/open/floor/mainship/black{
@@ -12746,11 +12760,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "pzq" = (
-/obj/structure/prop/mainship/hangar_stencil,
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/closet/walllocker/hydrant/extinguisher,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "pzU" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -12897,10 +12909,6 @@
 "pIL" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/window/reinforced/toughened{
-	dir = 8
-	},
-/obj/structure/window/reinforced/toughened,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pJi" = (
@@ -13134,13 +13142,18 @@
 	},
 /area/mainship/squads/general)
 "pVB" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/boxingring)
 "pVY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -15178,13 +15191,10 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "sBh" = (
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/item/reagent_containers/jerrycan,
-/obj/structure/rack,
+/obj/machinery/vending/tool,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sBq" = (
@@ -15831,10 +15841,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"ttT" = (
-/obj/machinery/vending/marineFood,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "tur" = (
 /obj/structure/bed/chair/sofa{
 	dir = 8
@@ -15960,16 +15966,6 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
-"tBj" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
 "tBY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -16614,9 +16610,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "unO" = (
-/obj/structure/sign/prop1{
-	dir = 1
-	},
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
@@ -17230,10 +17225,12 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/weapon_room)
 "uXR" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/window/reinforced/toughened,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "uYe" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -17690,6 +17687,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vAb" = (
@@ -18433,9 +18431,8 @@
 /turf/open/floor/carpet/side,
 /area/mainship/living/commandbunks)
 "wBE" = (
-/obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/boxingring)
 "wBL" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/engineering/port_atmos)
@@ -18762,9 +18759,6 @@
 /area/mainship/living/grunt_rnr)
 "wTH" = (
 /obj/structure/table/mainship/nometal,
-/obj/machinery/faxmachine/cic{
-	pixel_y = 8
-	},
 /obj/item/toy/deck{
 	pixel_y = 12;
 	pixel_x = -15
@@ -18782,6 +18776,9 @@
 	pixel_x = -9
 	},
 /obj/item/tool/pen,
+/obj/machinery/faxmachine{
+	pixel_y = 7
+	},
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "wTX" = (
@@ -19747,6 +19744,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
 	},
+/obj/machinery/computer/squad_selector,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xVj" = (
@@ -20130,15 +20128,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
-"ylq" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/computer/cryopod{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 
 (1,1,1) = {"
 qVo
@@ -43862,26 +43851,26 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-hRh
+cTi
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+bhv
+nWT
 nWT
 esN
 jzI
@@ -44119,25 +44108,25 @@ qVo
 qVo
 qVo
 qVo
-cTi
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
-bhv
+hRh
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
 nWT
 nWT
 esN
@@ -44390,14 +44379,14 @@ nWT
 nWT
 nWT
 nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-esN
+iTM
+kJX
+kJX
+kJX
+kJX
+kJX
+kJX
+iTM
 fvY
 rSA
 oOn
@@ -44648,12 +44637,12 @@ nWT
 nWT
 nWT
 iTM
-kJX
-kJX
-kJX
-kJX
-kJX
-kJX
+wag
+lnT
+bGy
+bGy
+lnT
+wVL
 iTM
 jzI
 rSA
@@ -44905,12 +44894,12 @@ nWT
 nWT
 nWT
 iTM
-wag
-lnT
-bGy
-bGy
-lnT
-wVL
+vuM
+aGA
+jQH
+jQH
+dWI
+oUM
 iTM
 kEP
 rSA
@@ -45163,10 +45152,10 @@ nWT
 nWT
 iTM
 vuM
-aGA
 jQH
+goY
+gZg
 jQH
-dWI
 oUM
 iTM
 kEP
@@ -45419,10 +45408,10 @@ cCy
 cCy
 cCy
 iTM
-vuM
+fGe
 jQH
-goY
-gZg
+jQH
+jQH
 jQH
 oUM
 iTM
@@ -45675,13 +45664,13 @@ nhS
 fAJ
 lJX
 lJX
-iTM
-fGe
+qha
+vuM
+leW
 jQH
 jQH
-jQH
-jQH
-oUM
+rXy
+nLi
 qha
 uUU
 lzS
@@ -45932,15 +45921,15 @@ dSY
 fAJ
 uWB
 kCk
-iTM
-vuM
-leW
-jQH
-jQH
-rXy
-nLi
 qha
-ndI
+kRZ
+iBa
+dLg
+hSB
+wrP
+jea
+pTj
+pOn
 mvs
 dIf
 dvG
@@ -46189,15 +46178,15 @@ nJP
 dmx
 dda
 tNQ
-iTM
-kRZ
-iBa
-dLg
-hSB
-wrP
-jea
-pTj
-pOn
+qha
+qha
+qha
+wBE
+pVB
+qha
+qha
+qha
+rKn
 nRz
 mvs
 mvs
@@ -46447,14 +46436,14 @@ lWz
 tyN
 xBh
 tyN
-tyN
-tyN
+wpF
+sBh
 dpY
 kXy
-tyN
-tyN
-tyN
-tyN
+qwO
+gjA
+yfw
+kuc
 mvs
 rdZ
 brH
@@ -46701,18 +46690,18 @@ cfp
 pgp
 xIb
 eiU
-iyr
 dpY
-wpF
-wBE
-ylq
+dpY
+bld
+ahe
+ahe
 dpY
 kXy
-qwO
-gjA
-yfw
-kuc
-mvs
+mVM
+mVM
+mVM
+mVM
+pzq
 oca
 xwC
 tni
@@ -46960,15 +46949,15 @@ dpY
 dpY
 dpY
 dpY
-ahe
-ahe
+dpY
+dpY
 dpY
 lYg
 fqM
 eks
 eks
 kTv
-mVM
+uFV
 mvs
 vTy
 fTy
@@ -47482,7 +47471,7 @@ plN
 aql
 wyz
 xBT
-pzq
+aQX
 mvs
 hJw
 gBJ
@@ -48510,7 +48499,7 @@ rHw
 xDq
 rCn
 bOz
-ttT
+dpY
 kWu
 lAT
 dcg
@@ -49024,7 +49013,7 @@ rxx
 csW
 rCn
 lSk
-uFV
+dpY
 nRz
 rGl
 gnK
@@ -50053,7 +50042,7 @@ aqx
 brN
 aWk
 dpY
-mvs
+pzq
 gpC
 tHY
 iiC
@@ -50582,7 +50571,7 @@ mvs
 pyV
 xGl
 xGl
-tBj
+qPq
 xGl
 xGl
 gAS
@@ -51576,10 +51565,10 @@ tyN
 sMF
 mzs
 dpY
-dpY
-dpY
-gpx
-dpY
+tyN
+tyN
+tyN
+tyN
 nYk
 fwq
 fwq
@@ -51833,10 +51822,10 @@ llC
 gek
 ycD
 dpY
-dpY
+tyN
 hnu
 pIL
-dpY
+tyN
 uKp
 gmQ
 dpY
@@ -52090,10 +52079,10 @@ dpY
 dpY
 dpY
 dpY
-sBh
-bld
-uXR
-dpY
+tyN
+hnu
+hnu
+tyN
 lUS
 dpY
 dpY
@@ -52347,10 +52336,10 @@ nyF
 nyF
 bRC
 nyF
+iyr
+nyF
 nyF
 plb
-plb
-nyF
 dTH
 nyF
 nyF
@@ -54930,7 +54919,7 @@ diD
 rWK
 xdE
 ykH
-pVB
+ykH
 vzN
 ykH
 ykH
@@ -56730,7 +56719,7 @@ fsZ
 fXX
 njf
 fXX
-vmD
+dlz
 ekx
 mXm
 sGk
@@ -57257,7 +57246,7 @@ mXm
 tpi
 tpi
 miU
-tpi
+uXR
 tpi
 qGH
 hsr
@@ -58767,25 +58756,25 @@ qVo
 qVo
 qVo
 qVo
-dgj
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
+hRh
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
 nWT
 nWT
 esN
@@ -59024,26 +59013,26 @@ qVo
 qVo
 qVo
 qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-mBZ
-mBZ
-qVo
-hRh
+dgj
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+nWT
 nWT
 esN
 unX
@@ -59586,7 +59575,7 @@ pko
 vtk
 tXD
 lkH
-pzU
+lkH
 lkH
 vtk
 ksd

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -811,6 +811,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"aYx" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/hallways/starboard_hallway)
 "aYW" = (
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -1083,10 +1089,13 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "brH" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
+/obj/machinery/light/mainship/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "brL" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -1238,6 +1247,10 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
+"bBv" = (
+/obj/structure/prop/flag,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "bBG" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -1450,9 +1463,9 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -1666,9 +1679,10 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/command/self_destruct)
 "bWg" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/mainship/hallways/starboard_hallway)
 "bWq" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/icefloor/warnplate{
@@ -1933,10 +1947,6 @@
 /obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
-"cqV" = (
-/obj/item/grown/sunflower,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "csh" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -2333,6 +2343,11 @@
 	dir = 9
 	},
 /area/space)
+"cTl" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
+/area/mainship/hallways/starboard_hallway)
 "cTx" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -3598,11 +3613,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/mechpilotquarters)
-"exQ" = (
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/obj/item/paper/memorial,
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/hallways/starboard_hallway)
 "exV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3816,9 +3826,10 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/structure/flora/tree/dead,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
 /area/mainship/hallways/starboard_hallway)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -4867,10 +4878,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "fTZ" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 9
-	},
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "fUs" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -4967,11 +4977,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"gaq" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
-	},
-/area/mainship/hallways/starboard_hallway)
 "gaz" = (
 /obj/machinery/vending/marineFood,
 /obj/item/reagent_containers/food/snacks/protein_pack,
@@ -5466,13 +5471,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"gCL" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "gES" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -5652,6 +5650,11 @@
 /obj/effect/turf_decal/warning_stripes/thick/corner,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
+"gTf" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "gTg" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/folder/blue,
@@ -5739,10 +5742,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/obj/item/clothing/head/modular/marine,
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
+/obj/item/grown/sunflower,
+/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
@@ -6415,8 +6416,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "hUf" = (
 /turf/open/floor/mainship/mono,
@@ -8157,11 +8158,6 @@
 	},
 /turf/open/space,
 /area/space)
-"kxM" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "kxN" = (
 /obj/machinery/light/mainship,
 /obj/structure/filingcabinet,
@@ -8549,6 +8545,14 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
+"kSP" = (
+/obj/structure/cable,
+/obj/machinery/light/mainship/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "kTv" = (
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment/corner{
@@ -8752,11 +8756,6 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
-"lfc" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -9285,10 +9284,6 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"lGF" = (
-/obj/structure/prop/flag,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "lGU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9844,6 +9839,10 @@
 	dir = 9
 	},
 /area/mainship/command/self_destruct)
+"mkt" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "mle" = (
 /turf/closed/wall/mainship/research/containment/wall/east,
 /area/mainship/medical/medical_science)
@@ -13315,7 +13314,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "qGH" = (
-/turf/open/space/basic,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
 "qHj" = (
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
@@ -15048,6 +15048,11 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"sVz" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "sVI" = (
 /obj/machinery/landinglight/tadpole,
 /obj/machinery/landinglight/tadpole{
@@ -15158,6 +15163,12 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"tfi" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "tfG" = (
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
@@ -15388,6 +15399,11 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
+"ttG" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "ttT" = (
 /obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
@@ -16109,12 +16125,6 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
-"uix" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
-	},
-/area/mainship/hallways/starboard_hallway)
 "uiG" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
@@ -17495,6 +17505,13 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
+"vYj" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "vYo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17538,9 +17555,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/obj/item/paper/memorial,
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
@@ -54112,7 +54130,7 @@ vmD
 vmD
 vmD
 vmD
-bLP
+mkt
 vmD
 rWD
 aHG
@@ -54890,7 +54908,7 @@ hWt
 vmD
 vmD
 vmD
-lGF
+bBv
 lVR
 kGc
 bbl
@@ -55407,9 +55425,9 @@ vmD
 eel
 pgh
 vDH
-fTZ
+cTl
 xdN
-gYa
+eKC
 tqD
 rUF
 bJB
@@ -55664,9 +55682,9 @@ vmD
 miU
 eQb
 fqj
-kxM
+gTf
 oOX
-exQ
+waC
 miU
 rUF
 xWS
@@ -55921,9 +55939,9 @@ vmD
 tpi
 eQb
 kGc
-gaq
+bWg
 fGV
-uix
+aYx
 cKB
 rUF
 hWC
@@ -56180,7 +56198,7 @@ iay
 ciN
 tpi
 eel
-cqV
+gYa
 tpi
 rUF
 nIn
@@ -56437,7 +56455,7 @@ cRE
 miU
 tpi
 miU
-eKC
+sVz
 cRE
 rUF
 dPp
@@ -56690,12 +56708,12 @@ oGN
 oGN
 ezY
 oGN
-lfc
-bWg
-mXm
-waC
-waC
+ttG
 hTV
+mXm
+bLP
+bLP
+fTZ
 hEc
 uyy
 cBw
@@ -56948,7 +56966,7 @@ eFo
 eFo
 eFo
 kCs
-bWg
+hTV
 xLu
 xLu
 gcd
@@ -57205,7 +57223,7 @@ eFo
 eFo
 eFo
 pqQ
-bWg
+hTV
 xLu
 uXw
 eZp
@@ -57462,7 +57480,7 @@ lpt
 eFo
 eFo
 gcr
-gCL
+vYj
 xLu
 rOV
 vXQ
@@ -61074,31 +61092,31 @@ oxO
 oxO
 oxO
 oxO
+oxO
+oxO
+hUz
 brH
+hUz
+hUz
+hUz
+rCA
+tfi
 brH
-wPV
-mDY
-wPV
-wPV
-wPV
-sYv
-qFT
-mDY
-wPV
-wPV
-qFT
-sYv
-wPV
-mDY
-wPV
-sYv
-qFT
-wPV
-hME
-wPV
-wPV
-hME
-wPV
+hUz
+hUz
+tfi
+rCA
+hUz
+brH
+hUz
+rCA
+tfi
+hUz
+kSP
+hUz
+hUz
+kSP
+hUz
 hPF
 esN
 esN
@@ -61331,36 +61349,36 @@ esN
 esN
 esN
 esN
-brL
-brL
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
 esN
 esN
 qGH
 qGH
 qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+qGH
+esN
+esN
+nWT
+nWT
+nWT
 nWT
 nWT
 nWT

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -23,14 +23,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "acn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "acq" = (
 /obj/structure/rack,
@@ -122,7 +118,14 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "aiP" = (
-/turf/open/floor/mainship/sterile/corner,
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "aiT" = (
 /turf/open/floor/mainship_hull/dir{
@@ -203,15 +206,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"aoJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "aoQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -239,19 +233,24 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "aqn" = (
-/obj/structure/prop/mainship/ship_memorial,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "aqp" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 1
-	},
-/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
 "aqx" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -263,13 +262,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/grunt_rnr)
-"arI" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "atc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -343,15 +335,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
-"ayg" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
 "azw" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/glass/bucket/janibucket,
@@ -368,19 +351,17 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "aAu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/living/tankerbunks)
 "aBm" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "aBY" = (
 /obj/structure/flora/pottedplant/ten,
@@ -403,7 +384,7 @@
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
 "aCM" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/obj/structure/bed/roller,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aDc" = (
@@ -422,20 +403,19 @@
 /turf/open/floor/mainship/orange/full,
 /area/mainship/living/briefing)
 "aDU" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
+/obj/machinery/sleeper{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "aDZ" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/squad_changer,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"aEk" = (
-/obj/machinery/door_control/mainship/droppod,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "aEu" = (
 /obj/machinery/disposal,
 /obj/machinery/light/mainship{
@@ -494,7 +474,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/warning_stripes/thin,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aHp" = (
 /turf/open/floor/mainship/yellow_cargo,
@@ -508,7 +488,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "aHH" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -546,17 +526,13 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "aJH" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "aJV" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship,
@@ -601,9 +577,6 @@
 /area/mainship/hallways/hangar)
 "aLA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
-/obj/structure/sign/poster{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
@@ -622,7 +595,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/sign/poster,
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
 	},
@@ -731,23 +703,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "aSw" = (
-/obj/machinery/holosign/surgery{
-	id = "or1sign"
-	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/medical/or/or1,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/upper_medical)
 "aSJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
@@ -903,20 +864,19 @@
 /obj/effect/spawner/random/medical/firstaid/alwaysspawns,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"baH" = (
+/obj/structure/bed/chair/office/dark,
+/obj/item/paper/chemistry,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "bbl" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/barbed_wire/half_stack,
-/obj/item/tool/crowbar,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/item/spare_cord,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "bbr" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship{
@@ -1043,7 +1003,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "bjJ" = (
 /obj/structure/toilet{
 	dir = 8
@@ -1095,7 +1055,9 @@
 /area/mainship/engineering/lower_engineering)
 "bnL" = (
 /obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/lower_medical)
 "boV" = (
 /obj/machinery/door/firedoor/mainship{
@@ -1137,7 +1099,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bsg" = (
 /obj/structure/cable,
@@ -1199,6 +1161,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "bxv" = (
+/obj/machinery/light/mainship,
+/obj/machinery/holopad,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/upper_medical)
 "bxQ" = (
@@ -1219,13 +1184,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "byk" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/machinery/light/mainship/small,
+/obj/effect/spawner/random/misc/gnome/fiftyfifty,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "byY" = (
 /obj/structure/bed/chair/nometal,
 /obj/effect/landmark/start/job/shiptech,
@@ -1314,7 +1279,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
+/obj/machinery/door/firedoor/mainship,
+/turf/open/floor/mainship/stripesquare,
 /area/mainship/living/grunt_rnr)
 "bDg" = (
 /obj/machinery/light/mainship{
@@ -1384,15 +1350,19 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "bFG" = (
-/obj/effect/turf_decal/warning_stripes/thick{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/light/mainship{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/obj/structure/cable,
+/obj/effect/turf_decal/medical_decals/triage/bottom,
+/obj/effect/ai_node,
+/turf/open/floor/whitecyanthree{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "bFX" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -1416,14 +1386,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "bHF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
 /area/mainship/living/numbertwobunks)
 "bIO" = (
 /obj/structure/cable,
@@ -1470,11 +1442,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/obj/machinery/firealarm{
-	dir = 8
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
 	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/starboard_hallway)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -1537,6 +1508,10 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
+"bOC" = (
+/obj/item/toy/gun_ammo,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "bOX" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship,
@@ -1637,14 +1612,16 @@
 	},
 /area/mainship/command/cic)
 "bTj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
 /area/mainship/living/numbertwobunks)
 "bTo" = (
 /obj/structure/table/mainship,
@@ -1658,12 +1635,18 @@
 /turf/open/floor/wood,
 /area/mainship/living/mechpilotquarters)
 "bUW" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/bed/stool{
-	pixel_y = 8
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
 	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/structure/sign/safety/cryogenic{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/mainship/medical/lower_medical)
 "bVx" = (
 /obj/machinery/door/airlock/mainship/generic/mech_pilot/bunk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1682,12 +1665,11 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/command/self_destruct)
 "bWg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/storage/briefcase/inflatable,
-/obj/structure/closet/crate,
-/turf/open/floor/mainship/office,
-/area/mainship/hallways/hangar)
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
+/area/mainship/hallways/starboard_hallway)
 "bWq" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/icefloor/warnplate{
@@ -1751,14 +1733,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "bYJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/whitecyanthree{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "bYP" = (
 /turf/open/floor/mainship/ntlogo/nt3,
@@ -1857,8 +1842,9 @@
 	},
 /area/mainship/squads/req)
 "ciN" = (
+/obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/starboard_hallway)
 "ciZ" = (
 /obj/structure/prop/mainship/name_stencil,
 /obj/machinery/holopad,
@@ -1924,18 +1910,12 @@
 /turf/open/floor/tile/dark,
 /area/mainship/command/cic)
 "coF" = (
-/obj/structure/disposalpipe/segment/corner,
-/obj/structure/cable,
-/obj/machinery/firealarm,
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/crowbar,
-/obj/item/tool/wrench,
-/obj/item/tool/screwdriver,
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/electronics/spotlights,
+/turf/open/floor/mainship/orange{
+	dir = 9
 	},
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/area/mainship/hallways/hangar)
 "cpi" = (
 /obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship_hull,
@@ -1970,12 +1950,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"ctR" = (
-/obj/structure/dropship_equipment/shuttle/sentry_holder,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "cuG" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
@@ -1991,7 +1965,7 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "cvV" = (
-/obj/machinery/vending/marineFood,
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
 /turf/open/floor/mainship/orange{
 	dir = 6
 	},
@@ -2015,17 +1989,25 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "cwD" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
 "cxv" = (
-/obj/structure/largecrate/supply/supplies/flares,
-/turf/open/floor/mainship/orange{
-	dir = 9
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/mainship/hallways/hangar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "cxw" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -2098,6 +2080,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
@@ -2188,6 +2171,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"cKB" = (
+/obj/structure/prop/mainship/valmoric,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "cLc" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -2222,10 +2209,13 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "cNy" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/droppod)
 "cNR" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -2251,24 +2241,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"cPY" = (
-/obj/machinery/door/airlock/mainship/medical/or/or2,
-/obj/machinery/holosign/surgery{
-	id = "or2sign"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "cQN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/mainship{
@@ -2287,14 +2259,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "cRE" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "cRJ" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/squadengineer,
@@ -2305,15 +2272,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "cRX" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "vehicle_elevator_railing"
-	},
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/storage/backpack/marine/engineerpack,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "cSg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2331,7 +2293,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/vending/engivend,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -2375,14 +2337,16 @@
 	},
 /area/space)
 "cTx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
+/area/mainship/medical/lower_medical)
 "cTF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -2409,19 +2373,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "cVU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/obj/structure/bed/chair/wood/wings,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "cWu" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "cWC" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/multi_tile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "cXa" = (
@@ -2522,6 +2485,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"dcg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "dcz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -2621,13 +2596,8 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "dhv" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/upper_medical)
+/turf/closed/wall/mainship,
+/area/mainship/shipboard/weapon_room)
 "dhK" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/blue/full,
@@ -2641,7 +2611,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "dit" = (
 /obj/machinery/telecomms/server/presets/engineering,
@@ -2651,11 +2621,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/firing_range)
 "diD" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/starboard_hallway)
 "diF" = (
 /obj/structure/sign/prop1{
 	dir = 1
@@ -2712,9 +2686,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "dlz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "dlQ" = (
 /obj/machinery/status_display,
 /obj/structure/sign/prop4,
@@ -2787,7 +2761,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "dnQ" = (
-/obj/machinery/autodoc,
+/obj/effect/turf_decal/medical_decals/triage/top,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "doG" = (
@@ -2871,31 +2845,18 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"duy" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "duU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	dir = 2
 	},
-/obj/machinery/computer/camera_advanced/overwatch/medical,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "dvG" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/cryopod/right{
+	dir = 2
 	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 5
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "dvX" = (
@@ -2924,11 +2885,11 @@
 /turf/open/floor/mainship/red,
 /area/mainship/command/airoom)
 "dzr" = (
-/obj/machinery/air_alarm{
+/obj/structure/curtain/temple{
 	dir = 8
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "dzT" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/door/firedoor/mainship,
@@ -2981,7 +2942,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "dGh" = (
 /obj/machinery/self_destruct/rod,
@@ -3011,14 +2972,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "dIf" = (
-/obj/machinery/cryopod/right,
+/obj/machinery/cryopod/right{
+	dir = 2
+	},
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "dIk" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
+/obj/item/medevac_beacon,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "dIo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3063,11 +3030,11 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "dJS" = (
-/obj/structure/dropship_equipment/shuttle/tangle_emitter,
-/turf/open/floor/mainship/orange{
-	dir = 8
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "dKF" = (
 /obj/structure/bed/chair/wood/normal,
 /turf/open/floor/mainship/mono,
@@ -3107,6 +3074,14 @@
 	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"dMy" = (
+/obj/item/toy/crossbow,
+/obj/item/toy/crossbow_ammo,
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "dMO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -3137,12 +3112,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "dNQ" = (
-/obj/structure/sink,
-/obj/structure/mirror,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters"
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "dNR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3155,8 +3134,18 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "dQG" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_one)
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/adv{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "dRR" = (
 /obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired,
 /obj/structure/benchpress,
@@ -3219,6 +3208,12 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"dUo" = (
+/obj/machinery/computer/cryopod{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "dUt" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -3268,13 +3263,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/cic)
 "dXO" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	name = "Bathroom"
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
+/area/mainship/medical/lower_medical)
 "dYv" = (
 /turf/open/floor/mainship/red{
 	dir = 1
@@ -3300,10 +3292,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"ebu" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
 "ebE" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/mainship/tcomms,
@@ -3358,16 +3346,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "eel" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "eeF" = (
 /obj/machinery/power/apc/mainship/hardened{
 	dir = 8
@@ -3448,49 +3429,40 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"eiY" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker"
-	},
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker"
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
 "ejw" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
 /area/mainship/engineering/upper_engineering)
 "ejJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/window/reinforced,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "ekh" = (
 /obj/machinery/marine_selector/gear/smartgun,
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "ekk" = (
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 1
+	},
+/area/mainship/hallways/hangar/droppod)
 "eks" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -3592,11 +3564,11 @@
 	},
 /area/mainship/squads/general)
 "euc" = (
-/obj/structure/closet/walllocker/hydrant/extinguisher,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 8
 	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "euA" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -3682,11 +3654,14 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "ezY" = (
-/obj/structure/flora/tree/dead,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
+	},
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "eAd" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/mainship/mono,
@@ -3704,14 +3679,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
 "eBB" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "eCc" = (
 /obj/structure/disposalpipe/segment{
@@ -3765,7 +3736,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "eFi" = (
 /obj/machinery/light/mainship,
@@ -3806,11 +3777,16 @@
 /turf/closed/wall/mainship,
 /area/mainship/hull/lower_hull)
 "eGM" = (
-/obj/structure/rack,
-/obj/item/stack/medical/heal_pack/advanced/bruise_pack,
-/obj/item/stack/medical/heal_pack/advanced/burn_pack,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 8;
+	name = "\improper Medical Storage Airlock"
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/upper_medical)
 "eHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3839,25 +3815,20 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
 	},
-/obj/item/clothing/head/warning_cone,
-/obj/structure/sign/pods{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/starboard_hallway)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "eLs" = (
-/obj/item/clothing/head/modular/marine,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "eLt" = (
 /obj/item/stool,
 /obj/effect/decal/cleanable/blood,
@@ -3873,7 +3844,7 @@
 "eMx" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "eMz" = (
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
@@ -3912,7 +3883,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "eOG" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/cell_charger,
@@ -3929,6 +3900,16 @@
 /obj/effect/turf_decal/warning_stripes/thin,
 /turf/open/shuttle/escapepod/eight,
 /area/mainship/command/self_destruct)
+"ePj" = (
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "ePE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3939,11 +3920,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "eQb" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "eQg" = (
 /obj/effect/turf_decal/warning_stripes/medical,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -3956,17 +3937,18 @@
 	},
 /area/mainship/squads/general)
 "eQW" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
+/obj/machinery/shower{
+	dir = 4
 	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/light/mainship/small{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "eSw" = (
-/obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	name = "Bathroom"
-	},
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/living/tankerbunks)
 "eSy" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -4015,11 +3997,6 @@
 	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
-"eVA" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/medical/lower_medical)
 "eWu" = (
 /obj/machinery/loadout_vendor,
 /obj/machinery/light/mainship{
@@ -4038,6 +4015,7 @@
 /area/mainship/hull/lower_hull)
 "eWM" = (
 /obj/item/trash/cigbutt,
+/obj/effect/urban/decal/trash/eight,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "eXm" = (
@@ -4081,8 +4059,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "eZp" = (
-/obj/machinery/door/airlock/mainship/generic,
-/turf/open/floor/mainship/floor,
+/obj/machinery/loadout_vendor,
+/turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "faw" = (
 /obj/structure/bed/chair/nometal{
@@ -4147,7 +4125,7 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
 "fcu" = (
-/obj/effect/landmark/corpsespawner/chef/regular,
+/obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "fdf" = (
@@ -4189,7 +4167,7 @@
 /area/mainship/engineering/engineering_workshop)
 "feK" = (
 /obj/item/toy/deck/kotahi,
-/obj/structure/table/wood/gambling,
+/obj/structure/table/wood/gambling/urban,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "feP" = (
@@ -4199,10 +4177,10 @@
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
 "ffi" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/upper_medical)
+/obj/structure/droppod,
+/obj/structure/drop_pod_launcher,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "ffo" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/black{
@@ -4254,8 +4232,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -4317,7 +4295,16 @@
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/command/corporateliaison)
 "fom" = (
-/obj/machinery/iv_drip,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -4331,13 +4318,17 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "foU" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/computer/sleep_console{
+	dir = 8
 	},
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "fpb" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 8
@@ -4356,20 +4347,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "fpg" = (
-/obj/effect/ai_node,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fpB" = (
 /obj/structure/sign/prop4,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
 "fqj" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/obj/machinery/disposal,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "fqs" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/machinery/keycard_auth,
@@ -4396,19 +4389,18 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/cic)
 "fsp" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_two)
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fsZ" = (
 /obj/machinery/light/mainship{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/door/poddoor/railing{
-	dir = 8;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "ftH" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/station_alert,
@@ -4423,16 +4415,31 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/chemistry)
 "ftY" = (
-/obj/machinery/camera/autoname/mainship,
-/obj/structure/bed/chair/wood/wings{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/table_lighting,
+/obj/item/paper,
 /turf/open/floor/wood,
-/area/mainship/medical/lower_medical)
+/area/mainship/living/tankerbunks)
 "fuf" = (
 /obj/machinery/telecomms/server/presets/requisitions,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"fuy" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/medical/lower_medical)
 "fuL" = (
 /obj/machinery/light/mainship/small{
 	dir = 1
@@ -4510,8 +4517,11 @@
 /area/mainship/living/commandbunks)
 "fyR" = (
 /obj/structure/cable,
-/turf/closed/wall/mainship,
-/area/mainship/living/starboard_garden)
+/obj/structure/sign/goldenplaque{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "fza" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -4613,29 +4623,13 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "fDJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/sign/safety/cryogenic{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "fEb" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -4658,23 +4652,30 @@
 /turf/open/floor/tile/dark,
 /area/mainship/command/cic)
 "fFo" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/bed/stool{
-	pixel_y = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "fFw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+/obj/machinery/landinglight/tadpole{
 	dir = 8;
-	on = 1
+	pixel_x = -4
 	},
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
+/obj/machinery/landinglight/tadpole{
+	dir = 1
 	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "fFD" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/job/researcher,
@@ -4687,27 +4688,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "fGV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/turf/open/floor/mainship/terragov/north{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	dir = 1;
-	id = "or1privacyshutter";
-	name = "Privacy Shutters";
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/operating_room_one)
+/area/mainship/hallways/starboard_hallway)
 "fGZ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -4838,6 +4822,7 @@
 	},
 /obj/structure/closet/bodybag,
 /obj/machinery/holopad,
+/obj/effect/ai_node,
 /turf/open/floor/cult,
 /area/medical/morgue)
 "fNR" = (
@@ -4851,9 +4836,12 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "fPi" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "fPH" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
@@ -4873,13 +4861,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/squads/req)
-"fQR" = (
-/obj/structure/sign/pods,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "fRw" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -4890,24 +4871,31 @@
 /turf/open/shuttle/escapepod/six,
 /area/mainship/command/self_destruct)
 "fTy" = (
-/obj/item/trash/cigbutt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/upper_medical)
 "fTZ" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/mainship/hallways/starboard_hallway)
 "fUs" = (
 /obj/machinery/light/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"fXg" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 9
+"fXd" = (
+/obj/item/toy/gun,
+/obj/structure/barricade/wooden{
+	dir = 8
 	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
+"fXg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -4915,7 +4903,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/floodlight/landing,
+/obj/machinery/light/floor{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "fXL" = (
@@ -4928,11 +4918,8 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/command/cic)
 "fXX" = (
-/obj/machinery/cryopod/right,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "fYa" = (
 /obj/structure/closet/secure_closet/shiptech,
 /obj/item/lightreplacer,
@@ -4961,24 +4948,6 @@
 	},
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/general)
-"fYT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/storage/box/gloves,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/operating_room_two)
 "fZH" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -5054,16 +5023,14 @@
 /turf/open/floor/mainship/orange/full,
 /area/mainship/command/cic)
 "gaD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
 	},
 /obj/effect/ai_node,
-/turf/open/floor/cult,
-/area/medical/morgue)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "gbc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5093,27 +5060,28 @@
 	},
 /area/mainship/living/commandbunks)
 "gbM" = (
-/turf/closed/wall/mainship,
-/area/mainship/living/starboard_garden)
-"gcd" = (
-/obj/structure/cable,
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
-/obj/structure/disposalpipe/segment,
-/obj/item/reagent_containers/blood/OMinus,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/structure/sign/pods{
+	dir = 1
 	},
-/area/mainship/medical/operating_room_one)
-"gcr" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
+"gcd" = (
+/obj/structure/window/framed/mainship,
+/turf/open/floor/plating,
+/area/mainship/living/tankerbunks)
+"gcr" = (
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "gcM" = (
-/obj/machinery/vending/MarineMed,
+/obj/structure/closet/crate,
+/obj/item/storage/briefcase/inflatable,
+/obj/item/storage/briefcase/inflatable,
 /turf/open/floor/mainship/orange,
 /area/mainship/hallways/hangar)
 "gdb" = (
@@ -5155,6 +5123,7 @@
 	pixel_y = 5
 	},
 /obj/item/storage/box/donkpockets,
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
 "gfi" = (
@@ -5192,7 +5161,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "giB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -5200,15 +5169,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"giN" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
 "giW" = (
 /obj/machinery/door/airlock/mainship/medical/glass/CMO{
 	dir = 1
@@ -5287,8 +5247,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "gnK" = (
-/obj/machinery/holopad,
-/obj/machinery/iv_drip,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "goh" = (
@@ -5343,14 +5308,23 @@
 /area/mainship/engineering/engineering_workshop)
 "gpC" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/mainship,
+/obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/closet/walllocker/hydrant/extinguisher,
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = 10;
+	pixel_y = 13
+	},
 /turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "gpU" = (
 /obj/structure/toilet{
 	dir = 1
@@ -5363,17 +5337,8 @@
 /obj/item/toy/katana,
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"gqB" = (
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/rack,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "gqI" = (
-/obj/machinery/vending/uniform_supply,
+/obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -5471,35 +5436,24 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gAS" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/clothing/head/modular/marine/helljumper,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
-"gBE" = (
-/obj/machinery/door/window{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
 	},
-/obj/item/tool/soap,
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/upper_medical)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "gBJ" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/machinery/holosign_switch{
-	id = "or1sign";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/structure/cable,
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/crowbar,
+/obj/item/tool/wrench,
+/obj/item/tool/screwdriver,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "gBQ" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -5555,26 +5509,6 @@
 /obj/structure/bed/chair/nometal,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"gIS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar)
-"gKv" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "gKG" = (
 /obj/machinery/door/airlock/mainship/generic/pilot/bunk{
 	dir = 1
@@ -5624,10 +5558,10 @@
 	},
 /area/mainship/command/cic)
 "gNc" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/side{
-	dir = 5
+/obj/effect/turf_decal/medical_decals/triage/top{
+	dir = 8
 	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gPi" = (
 /obj/machinery/door/airlock/multi_tile/mainship/maint{
@@ -5677,6 +5611,12 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "gRV" = (
@@ -5699,13 +5639,17 @@
 	},
 /area/mainship/living/pilotbunks)
 "gSN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "gTg" = (
 /obj/structure/table/mainship/nometal,
@@ -5794,11 +5738,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/side{
-	dir = 6
-	},
-/area/mainship/living/numbertwobunks)
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
 /area/mainship/squads/req)
@@ -5809,7 +5750,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/chapel)
 "gZf" = (
-/obj/structure/table/wood,
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/structure/sign/nosmoking_2{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "gZg" = (
@@ -5854,11 +5801,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "hdc" = (
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/landinglight/tadpole{
+	dir = 4;
+	pixel_x = -4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/starboard_garden)
+/obj/machinery/landinglight/tadpole,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "hdY" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/black{
@@ -5881,10 +5830,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "heL" = (
-/obj/machinery/vending/MarineMed,
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -5897,8 +5846,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "hgl" = (
-/obj/vehicle/ridden/motorbike,
-/turf/open/floor/mainship/mono,
+/obj/structure/dropship_equipment/shuttle/operatingtable,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/orange{
+	dir = 5
+	},
 /area/mainship/hallways/hangar)
 "hgP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5946,8 +5898,21 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "hiV" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 9
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "hjG" = (
@@ -5992,12 +5957,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "hnk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -6052,18 +6013,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "hoP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 8
+/obj/item/spare_cord,
+/obj/structure/dropship_equipment/shuttle/rappel_system,
+/turf/open/floor/mainship/orange{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
-"hpx" = (
-/obj/item/reagent_containers/food/snacks/popcorn,
-/obj/structure/table/mainship/nometal,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/hallways/hangar)
 "hpW" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/mainship/hexagon,
@@ -6085,22 +6040,24 @@
 /area/mainship/hull/lower_hull)
 "hrA" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
-"htZ" = (
+/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/aft_hallway)
+"htZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
 /area/mainship/medical/lower_medical)
 "hua" = (
 /obj/item/clothing/gloves/marine/som,
@@ -6143,9 +6100,9 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hwZ" = (
-/obj/structure/prop/mainship/valmoric,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "hxc" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/black{
@@ -6162,10 +6119,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "hzD" = (
-/obj/machinery/cic_maptable,
-/obj/machinery/vending/nanomed{
-	dir = 4
-	},
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -6197,6 +6151,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"hEc" = (
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/living/numbertwobunks)
 "hEy" = (
 /obj/machinery/light_switch{
 	pixel_x = 3;
@@ -6212,28 +6170,30 @@
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"hGq" = (
-/turf/open/floor/carpet/side{
-	dir = 10
-	},
-/area/mainship/living/numbertwobunks)
 "hGE" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hGO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 1
+	},
+/turf/open/floor/whitecyanfour,
 /area/mainship/medical/lower_medical)
 "hGT" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "hHg" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -6262,37 +6222,28 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "hJw" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or1privacyshutter";
-	name = "\improper Privacy Shutters"
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	pixel_x = 10
 	},
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/operating_room_one)
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/toolbox/electrical,
+/obj/item/cell/apc,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_x = -10
+	},
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "hKy" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
-"hLE" = (
-/obj/structure/rack,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "hMB" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -6315,14 +6266,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hNd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/obj/effect/urban/decal/trash/twelve,
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "hOe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6350,15 +6296,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "hPp" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/computer/dropship_picker,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "hPF" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -6406,10 +6346,11 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
 "hSb" = (
-/obj/structure/bed/chair/wood/normal,
-/obj/item/reagent_containers/jerrycan,
+/obj/structure/sign/poster{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "hSc" = (
 /obj/machinery/light/mainship/small,
 /turf/open/floor/mainship/research/containment/floor2,
@@ -6467,14 +6408,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/machinery/line_nexter{
-	dir = 2
-	},
-/obj/structure/barricade/solid{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tree/dead,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "hUf" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -6484,7 +6421,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "hUW" = (
-/obj/effect/turf_decal/medical_decals/cryo/cell/two,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "hVb" = (
@@ -6513,7 +6459,7 @@
 "hWt" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "hWy" = (
 /obj/effect/ai_node,
 /obj/structure/cable,
@@ -6542,6 +6488,16 @@
 	dir = 8
 	},
 /area/mainship/medical/chemistry)
+"hYr" = (
+/obj/machinery/landinglight/cas{
+	dir = 1;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "hZe" = (
 /turf/open/floor/plating/mainship/striped{
 	dir = 8
@@ -6563,15 +6519,9 @@
 	},
 /area/mainship/squads/general)
 "iay" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/machinery/landinglight/alamo{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "iaH" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/floor,
@@ -6632,11 +6582,13 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "ieX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/whitecyanthree{
 	dir = 8
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "iff" = (
 /obj/machinery/power/apc/mainship,
@@ -6652,13 +6604,15 @@
 "ifT" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/transport_crewman,
+/obj/effect/landmark/start/job/assault_crewman,
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "igh" = (
-/obj/machinery/holopad,
-/obj/machinery/door/airlock/mainship/medical/free_access,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/table/mainship/nometal,
+/obj/item/stack/barbed_wire/half_stack,
+/obj/item/tool/crowbar,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "igO" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship/black{
@@ -6675,7 +6629,18 @@
 /area/mainship/hull/lower_hull)
 "iiC" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
+/obj/effect/turf_decal/medical_decals/triage,
+/obj/structure/table/black,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/defibrillator,
+/obj/item/storage/firstaid/adv,
+/obj/machinery/recharger,
+/obj/item/healthanalyzer{
+	pixel_x = -11
+	},
+/turf/open/floor/whitecyanthree{
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
@@ -6690,11 +6655,9 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "iku" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/crew_quarters/toilet)
+/obj/item/toy/crossbow_ammo,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "ikM" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/floor,
@@ -6840,18 +6803,14 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "iuw" = (
-/obj/structure/sink{
-	dir = 1
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "iuG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6861,10 +6820,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "ivW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/body_scanconsole,
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "iwj" = (
 /obj/effect/ai_node,
@@ -6882,7 +6839,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "ixz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -6966,10 +6923,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"iDE" = (
-/obj/machinery/cic_maptable/droppod_maptable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "iDG" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -6992,8 +6945,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "iFw" = (
-/obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/assault_crewman,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "iFI" = (
@@ -7011,7 +6965,7 @@
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "iHY" = (
 /obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted,
 /turf/open/floor/mainship/orange{
@@ -7024,15 +6978,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"iIe" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/ai_node,
-/obj/machinery/door/poddoor/railing{
-	dir = 2;
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "iII" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -7170,11 +7115,13 @@
 	dir = 2
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "iRQ" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 8
 	},
+/obj/machinery/computer/autodoc_console,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "iSv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -7185,14 +7132,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"iSK" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
 "iTn" = (
-/obj/machinery/light/mainship,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/sterile/side,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/CMO,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/medical/upper_medical)
 "iTI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -7298,7 +7245,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "iZI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed/chair/wood/normal{
@@ -7331,11 +7278,6 @@
 	dir = 1
 	},
 /area/mainship/squads/general)
-"jbg" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
 "jcy" = (
 /obj/structure/table/wood,
 /obj/structure/mirror,
@@ -7378,14 +7320,16 @@
 	},
 /area/mainship/living/pilotbunks)
 "jfb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/toilet,
+/obj/effect/landmark/corpsespawner/marine/burst,
+/obj/effect/decal/cleanable/blood,
+/obj/item/organ/brain,
+/obj/item/weapon/gun/rifle/standard_autoshotgun,
+/obj/machinery/light/mainship/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "jfQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7427,6 +7371,7 @@
 "jjR" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/reagent_containers/cup/glass/flask/gold,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "jkK" = (
@@ -7487,11 +7432,12 @@
 	},
 /area/mainship/squads/general)
 "jrk" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
+/obj/machinery/landinglight/tadpole{
+	dir = 4;
+	pixel_x = -4
 	},
-/area/mainship/medical/operating_room_two)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "jrW" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7524,11 +7470,13 @@
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
 "jwA" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "jwH" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/research/containment/floor2{
@@ -7549,22 +7497,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "jxi" = (
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/droppod)
 "jzc" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/stern_hallway)
-"jzx" = (
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/defibrillator,
-/obj/item/defibrillator,
-/obj/structure/rack,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "jzI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7659,10 +7603,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "jHd" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "jHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7697,11 +7642,19 @@
 /turf/open/floor/plating,
 /area/mainship/living/mechpilotquarters)
 "jLn" = (
-/obj/structure/rack,
-/obj/item/toy/deck/kotahi,
-/obj/item/toy/deck,
-/obj/item/storage/belt/protein_pack,
-/turf/open/floor/mainship/sterile/dark,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/medical/lower_medical)
 "jLC" = (
 /obj/structure/cable,
@@ -7736,13 +7689,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "jMP" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "jOm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -7753,22 +7705,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "jOQ" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"jOS" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar/droppod)
 "jPt" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 8
@@ -7778,11 +7721,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
-"jPT" = (
-/obj/effect/ai_node,
-/obj/effect/turf_decal/medical_decals/cryo,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "jQH" = (
 /turf/open/floor/wood,
 /area/mainship/hallways/boxingring)
@@ -7839,11 +7777,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "jUl" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/medical_decals/cryo,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -7853,15 +7788,11 @@
 /turf/open/space,
 /area/space)
 "jUP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/sign/restroom{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/robotic_cradle,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "jUQ" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -7885,19 +7816,14 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "jWB" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/mainship/sterile/side{
-	dir = 9
-	},
+/obj/effect/turf_decal/medical_decals/triage/top,
+/turf/open/floor/whitecyanthree,
 /area/mainship/medical/lower_medical)
 "jWH" = (
 /turf/open/floor/mainship/black{
 	dir = 5
 	},
 /area/mainship/command/self_destruct)
-"jXN" = (
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/upper_medical)
 "jZZ" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/floor,
@@ -7950,11 +7876,17 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "kdC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/shuttle/weapon_holder/mortar_holder,
-/turf/open/floor/mainship/office,
-/area/mainship/hallways/hangar)
+/obj/structure/sink{
+	dir = 8
+	},
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/obj/structure/mirror{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "kdD" = (
 /obj/structure/sign/prop1{
 	dir = 1
@@ -8010,18 +7942,20 @@
 /obj/structure/cable,
 /obj/machinery/power/apc,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "klu" = (
 /obj/machinery/hydroponics,
 /obj/item/seeds/goldappleseed,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "kly" = (
-/obj/machinery/computer/cryopod,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/machinery/light/mainship{
+	dir = 1
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/bed/chair/sofa,
+/obj/machinery/firealarm,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "kmd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8033,12 +7967,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "kmh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "knx" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/camera/autoname/mainship{
@@ -8047,17 +7980,11 @@
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
 "koA" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/structure/window/reinforced{
+/obj/vehicle/ridden/motorbike,
+/turf/open/floor/mainship/orange{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/hallways/hangar)
 "koS" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/black{
@@ -8065,16 +7992,11 @@
 	},
 /area/mainship/squads/general)
 "kpI" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/door/poddoor/mainship/droppod{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar/droppod)
 "krn" = (
 /obj/machinery/disposal,
@@ -8091,13 +8013,10 @@
 	},
 /area/mainship/squads/general)
 "ksa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "ksb" = (
 /obj/machinery/firealarm{
@@ -8200,6 +8119,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
+"kwh" = (
+/obj/structure/prop/mainship/prop_sec,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/brig)
 "kwo" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -8207,29 +8130,9 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"kwS" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "kxh" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/chapel)
-"kxm" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/operating_room_two)
 "kxw" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/security/marinemainship{
@@ -8269,13 +8172,11 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "kyi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
 	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "kyt" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -8321,17 +8222,13 @@
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "kCs" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
+/obj/machinery/door/poddoor/railing{
+	dir = 1;
+	id = "vehicle_elevator_railing"
 	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/tank_part_fabricator,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "kCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8342,11 +8239,17 @@
 /obj/effect/turf_decal/tracks/wheels/bloody{
 	dir = 10
 	},
+/obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kDx" = (
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"kDL" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "kDO" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/mainship/white,
@@ -8396,9 +8299,12 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "kGc" = (
-/obj/structure/cable,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/starboard_hallway)
 "kGk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/loadout_vendor,
@@ -8425,7 +8331,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "kHT" = (
 /obj/machinery/vending/tool,
@@ -8502,16 +8408,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "kMo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
+"kMt" = (
+/obj/structure/table/mainship/nometal,
+/obj/item/reagent_containers/glass/beaker/biomass{
+	name = "biomass beaker"
 	},
-/obj/machinery/door/poddoor/mainship/droppod,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "kML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/camera/autoname/mainship{
@@ -8547,7 +8459,7 @@
 /area/mainship/hallways/hangar)
 "kOA" = (
 /obj/machinery/vending/lasgun,
-/turf/open/floor/mainship/office,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "kQn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8613,8 +8525,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "kSC" = (
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -8667,12 +8587,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "kVD" = (
-/obj/structure/cable,
-/obj/machinery/power/apc,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "kWc" = (
 /obj/machinery/door/poddoor/railing{
 	id = "supply_elevator_railing"
@@ -8719,14 +8644,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/ce_room)
 "kYM" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc/mainship,
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/toolbox/electrical,
-/obj/item/cell/apc,
+/obj/effect/turf_decal/medical_decals/cryo,
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -8867,32 +8786,23 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
 "lhT" = (
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/machinery/holosign_switch{
-	id = "or2sign"
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters"
-	},
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/operating_room_two)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "lhZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/donut_box,
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
-"liX" = (
-/mob/living/simple_animal/corgi/walten,
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/lower_medical)
 "ljb" = (
-/obj/machinery/vending/weapon,
 /obj/machinery/vending/nanomed{
 	dir = 8
 	},
+/obj/machinery/vending/engivend,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -8943,11 +8853,11 @@
 	},
 /area/mainship/squads/general)
 "llq" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/effect/ai_node,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/hangar/droppod)
 "llr" = (
 /obj/machinery/shower{
 	dir = 4
@@ -9022,13 +8932,25 @@
 /area/mainship/hallways/boxingring)
 "loc" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or2sign"
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/door/window/secure/medical{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "lon" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9052,11 +8974,17 @@
 /turf/open/floor/mainship/empty,
 /area/mainship/living/tankerbunks)
 "lqS" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/obj/structure/sign/safety/cryogenic,
-/turf/open/floor/plating/platebotc,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lrn" = (
 /obj/structure/cable,
@@ -9120,10 +9048,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "luk" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
-/area/mainship/hallways/hangar)
+/obj/structure/bed/chair/sofa,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "lun" = (
 /obj/structure/bed/bunkbed,
 /obj/effect/landmark/start/job/mechpilot,
@@ -9180,13 +9108,16 @@
 /area/mainship/command/telecomms)
 "lxg" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/side{
+/obj/effect/turf_decal/medical_decals/triage{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lxK" = (
 /obj/effect/soundplayer/deltaplayer,
@@ -9242,16 +9173,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "lCb" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/structure/sign/pods{
+	dir = 1
 	},
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/structure/dropship_equipment/shuttle/rappel_system,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "lCh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9263,18 +9189,20 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "lCL" = (
-/obj/structure/bed/chair/wood/wings{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_x = -9
 	},
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 10
 	},
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "lDR" = (
@@ -9331,12 +9259,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"lGg" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "lGi" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -9523,17 +9445,6 @@
 /obj/structure/bed/chair/sofa/left,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"lPc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "lPM" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/bed/chair/office/dark{
@@ -9557,7 +9468,7 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "lQN" = (
-/obj/machinery/bodyscanner,
+/obj/machinery/cloning/vats,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "lRc" = (
@@ -9575,17 +9486,20 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
-"lSb" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/machinery/tank_part_fabricator,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "lSk" = (
-/obj/effect/turf_decal/medical_decals/cryo/cell,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "lSq" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -9600,7 +9514,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "lSQ" = (
-/obj/machinery/sleeper,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "lSY" = (
@@ -9639,9 +9555,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "lTu" = (
-/obj/structure/sign/safety/cryogenic,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_one)
+/obj/machinery/cryopod/right{
+	dir = 2
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "lTw" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -9666,6 +9584,14 @@
 	dir = 4
 	},
 /area/mainship/engineering/engineering_workshop)
+"lUS" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "lVp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
@@ -9679,11 +9605,10 @@
 	},
 /area/mainship/command/airoom)
 "lVR" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/upper_medical)
+/obj/structure/prop/flag,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "lWc" = (
 /obj/effect/landmark/start/latejoin,
 /obj/machinery/light/mainship{
@@ -9715,19 +9640,28 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lXB" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/obj/machinery/holosign_switch{
+	id = "or2sign";
+	pixel_x = -18;
+	pixel_y = -12
 	},
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 4
+/obj/machinery/door_control{
+	dir = 8;
+	id = "or2privacyshutter";
+	name = "Privacy Shutters"
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "lXN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 1
+	},
 /area/mainship/hallways/hangar)
 "lXP" = (
 /obj/structure/window/framed/mainship,
@@ -9742,27 +9676,39 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "lYE" = (
-/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/door_control/old/medbay{
+	id = "Medbay";
+	name = "Medbay Lockdown";
+	pixel_x = 6;
+	pixel_y = -20
+	},
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
 /area/mainship/medical/upper_medical)
 "lYL" = (
-/obj/machinery/computer/body_scanconsole,
-/turf/open/floor/mainship/sterile/side,
+/obj/machinery/computer/camera_advanced/overwatch/medical,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/paper/overwatch,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "lYQ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "mam" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mbM" = (
@@ -9771,20 +9717,9 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
 "mbQ" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/adv,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "mcr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9832,6 +9767,7 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
 "mfH" = (
+/obj/item/paper/xenoresearch2,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/medical_science)
 "mgw" = (
@@ -9839,18 +9775,18 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mgE" = (
-/obj/machinery/vending/marineFood,
-/turf/open/floor/mainship/green{
-	dir = 4
-	},
-/area/mainship/squads/req)
+/obj/item/paper/arachnebrig,
+/turf/open/floor/mainship/floor,
+/area/mainship/shipboard/brig)
 "mgM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "mhJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -9860,7 +9796,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "mia" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -9874,11 +9810,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
 "miU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "mjl" = (
 /obj/machinery/vending,
 /turf/open/floor/mainship/floor,
@@ -9912,7 +9845,8 @@
 	},
 /area/mainship/shipboard/firing_range)
 "mmC" = (
-/obj/machinery/bodyscanner,
+/obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mnb" = (
@@ -9927,11 +9861,12 @@
 /turf/open/floor/plating,
 /area/mainship/squads/general)
 "mnH" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
+/obj/machinery/bot/cleanbot,
+/obj/machinery/light/floor{
+	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
-	dir = 1
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "mog" = (
@@ -9954,15 +9889,9 @@
 	},
 /area/mainship/squads/req)
 "mpj" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/hallways/starboard_hallway)
 "mps" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9974,20 +9903,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
+/turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "mpw" = (
-/obj/machinery/computer/crew,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "mqD" = (
 /obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/starboard_garden)
+/obj/machinery/power/apc/mainship,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "mqK" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
@@ -10001,15 +9927,12 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "mqY" = (
-/obj/machinery/vending/marineFood,
-/turf/open/floor/mainship/sterile/side,
+/turf/open/floor/mainship/yellow_cargo/arrow,
 /area/mainship/medical/lower_medical)
 "mrK" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/vending/marineFood,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "mto" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms,
 /obj/machinery/door/poddoor/mainship/open/cic,
@@ -10058,9 +9981,11 @@
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
 "mwj" = (
-/obj/effect/turf_decal/medical_decals/cryo/mid,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/door/poddoor/mainship/droppod{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "mxg" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/light/mainship{
@@ -10112,13 +10037,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "mzF" = (
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/door_control/mainship/droppod{
 	dir = 1
 	},
-/area/mainship/medical/upper_medical)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "mBc" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
@@ -10147,17 +10073,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "mEd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/power/port_gen/pacman,
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 25
-	},
-/obj/item/stack/sheet/mineral/phoron{
-	amount = 25
-	},
-/turf/open/floor/mainship/office,
-/area/mainship/hallways/hangar)
+/obj/structure/disposalpipe/segment,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "mEj" = (
 /obj/structure/ship_ammo/cas/heavygun,
 /turf/open/floor/mainship/cargo,
@@ -10207,18 +10126,27 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "mHi" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "mHk" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/living/mechpilotquarters)
 "mHW" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
+/obj/structure/table/mainship/nometal,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/mop,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 6;
+	pixel_y = -2
 	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/lower_medical)
 "mJo" = (
 /obj/machinery/computer/telecomms/monitor/preset,
@@ -10230,27 +10158,16 @@
 /obj/effect/landmark/start/job/transportofficer,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
-"mJG" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
 "mJI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/dropship_part_fabricator/tadpole,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "mJL" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
-/obj/structure/dropship_equipment/electronics/spotlights,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "mJW" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/green{
@@ -10304,6 +10221,11 @@
 	dir = 8
 	},
 /area/mainship/shipboard/weapon_room)
+"mNf" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "mNK" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
@@ -10319,11 +10241,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "mOo" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/obj/structure/prop/mainship/gelida/lightstick,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "mOz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -10397,12 +10317,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
 "mRd" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
 /obj/machinery/light/mainship{
-	light_color = "#da2f1b"
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "mRp" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -10432,12 +10351,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "mSh" = (
-/obj/effect/turf_decal/warning_stripes/thick,
-/obj/machinery/light/mainship{
-	dir = 4
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/hand_labeler,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "mSo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10452,17 +10379,22 @@
 /area/mainship/engineering/port_atmos)
 "mUU" = (
 /obj/structure/sink{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
+/obj/machinery/vending/nanomed{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/light/floor{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/operating_room_two)
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/iv_drip,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "mVr" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/firing_range)
@@ -10495,37 +10427,29 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "mXf" = (
-/obj/machinery/cloning/vats,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
-/area/mainship/medical/lower_medical)
-"mXm" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"mXM" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 1;
-	name = "\improper Medical Storage Airlock"
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
+/obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
+"mXm" = (
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
+"mXw" = (
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/cryopod/right{
+	dir = 2
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
+	},
+/area/mainship/medical/lower_medical)
+"mXM" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "mXR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10563,6 +10487,10 @@
 	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
+"nbu" = (
+/obj/effect/urban/decal/trash/fifteen,
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "nbC" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -10585,33 +10513,19 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "ncI" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/tool/weldingtool/largetank,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/computer/cryopod{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/upper_medical)
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "ncO" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
 "ndA" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
+/obj/structure/flora/ausbushes/goldenbush,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "ndG" = (
 /obj/structure/bed/chair/sofa/right,
 /obj/item/bedsheet/ce{
@@ -10643,7 +10557,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "nei" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10666,7 +10580,7 @@
 	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "nfr" = (
 /obj/structure/flora/pottedplant/twentytwo,
 /turf/open/floor/mainship/mono,
@@ -10730,11 +10644,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "njf" = (
-/obj/structure/dropship_equipment/shuttle/tangle_emitter,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "njE" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -10757,95 +10669,42 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "nku" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/upper_medical)
+/area/mainship/hallways/hangar/droppod)
 "nkC" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 6
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/upper_medical)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "nkI" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "nkX" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/surgical_tray,
-/obj/item/storage/box/gloves,
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = -5;
-	pixel_y = 10
+/obj/structure/closet/walllocker/hydrant/extinguisher{
+	dir = 4
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/turf/open/floor/mainship/sterile/side{
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/chemistry)
 "nla" = (
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 4
 	},
-/obj/structure/table/mainship/nometal,
-/obj/item/storage/syringe_case/regular{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/syringe_case/regular{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/upper_medical)
+/area/mainship/hallways/hangar/droppod)
 "nld" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 10
@@ -10914,21 +10773,18 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "nuX" = (
-/obj/effect/ai_node,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "nuZ" = (
 /obj/structure/prop/mainship/sensor_computer3/sd,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
-"nvH" = (
-/obj/machinery/power/apc{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "nvN" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
@@ -10943,10 +10799,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"nwc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
 "nwy" = (
 /obj/item/weapon/telebaton,
 /obj/effect/decal/cleanable/blood,
@@ -10962,12 +10814,11 @@
 /turf/open/floor/plating,
 /area/mainship/squads/general)
 "nwX" = (
-/obj/machinery/camera/autoname/mainship{
+/obj/machinery/landinglight/tadpole{
 	dir = 1
 	},
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "nxC" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/security/marinemainship{
@@ -10987,12 +10838,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "nyh" = (
+/obj/structure/sign/pods{
+	dir = 1
+	},
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "nyw" = (
 /obj/structure/bed/chair/nometal{
 	dir = 1
@@ -11003,6 +10856,9 @@
 "nyy" = (
 /obj/effect/soundplayer/deltaplayer,
 /obj/structure/sign/science,
+/obj/structure/sign/nosmoking_2{
+	dir = 1
+	},
 /turf/closed/wall/mainship/white,
 /area/medical/morgue)
 "nyF" = (
@@ -11033,7 +10889,7 @@
 /turf/open/floor/plating,
 /area/mainship/squads/general)
 "nAb" = (
-/obj/structure/filingcabinet,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
@@ -11153,10 +11009,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "nJd" = (
-/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
-/obj/machinery/door/firedoor/mainship,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "nJG" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/firing_range)
@@ -11175,17 +11032,26 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "nMm" = (
-/obj/machinery/computer/cloning_console/vats,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "nMG" = (
-/obj/machinery/vending/tool,
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -11201,14 +11067,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "nNV" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/upper_medical)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/shipboard/firing_range)
 "nNY" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/ship_ammo/cas/heavygun,
@@ -11250,25 +11111,27 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "nRz" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_one)
-"nRH" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
+"nRH" = (
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "nRP" = (
 /obj/structure/sink{
 	dir = 8
@@ -11281,9 +11144,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "nTx" = (
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "nTT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11299,6 +11167,7 @@
 /area/mainship/engineering/upper_engineering)
 "nUc" = (
 /obj/item/clothing/mask/muzzle,
+/obj/structure/prop/flag/som,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "nVl" = (
@@ -11314,6 +11183,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_umbilical)
+"nWL" = (
+/obj/structure/dropship_equipment/shuttle/tangle_emitter,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/hallways/hangar)
 "nWM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11381,8 +11256,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "oac" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 6
@@ -11418,19 +11294,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "oca" = (
-/obj/structure/cable,
-/obj/structure/sign/nosmoking_2{
+/obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/adv,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_one)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "oco" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -11440,9 +11308,18 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "ocE" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/camera/autoname/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "ocK" = (
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
@@ -11526,38 +11403,42 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"omz" = (
-/obj/machinery/holopad,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
 "onk" = (
-/obj/machinery/light/mainship{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/upper_medical)
+/obj/effect/urban/decal/trash/eight,
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "onC" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/mop,
-/obj/structure/table/mainship/nometal,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
 	pixel_x = 6;
-	pixel_y = -2
+	pixel_y = 10
 	},
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/storage/surgical_tray,
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -5;
-	pixel_y = 3
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/lower_medical)
+/obj/structure/sign/nosmoking_2{
+	dir = 4;
+	pixel_y = -4
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "onZ" = (
 /obj/structure/window/framed/mainship/requisitions,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11582,9 +11463,10 @@
 	},
 /area/mainship/squads/req)
 "opd" = (
-/obj/structure/barricade/solid,
+/obj/structure/drop_pod_launcher,
+/obj/structure/droppod/leader,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/hangar/droppod)
 "ope" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
@@ -11595,22 +11477,20 @@
 	},
 /area/mainship/living/briefing)
 "orC" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/machinery/computer/dropship_picker,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"osb" = (
-/obj/structure/dropship_equipment/shuttle/sentry_holder,
-/turf/open/floor/mainship/orange{
+/obj/structure/cable,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/area/mainship/hallways/hangar)
+/area/mainship/medical/lower_medical)
+"osb" = (
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
+/obj/structure/sign/chemistry,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "osh" = (
 /obj/structure/closet/walllocker/hydrant/extinguisher,
 /obj/machinery/camera/autoname/mainship,
@@ -11643,9 +11523,6 @@
 /area/mainship/squads/req)
 "ouq" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -11698,8 +11575,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oyZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/obj/machinery/camera/autoname/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "ozU" = (
@@ -11707,20 +11586,15 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "oAb" = (
 /turf/closed/wall/mainship/research/containment/wall/north,
 /area/mainship/medical/medical_science)
 "oAz" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 1
-	},
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/floor,
+/area/mainship/squads/general)
 "oAD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -11735,17 +11609,17 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "oCo" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship,
-/obj/machinery/light/mainship{
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters"
+	},
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/operating_room_two)
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "oCN" = (
 /obj/item/facepaint/green,
 /obj/item/facepaint/green,
@@ -11774,20 +11648,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
-"oEm" = (
-/obj/structure/cable,
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
 "oGN" = (
-/obj/effect/turf_decal/warning_stripes/thin,
-/obj/machinery/landinglight/tadpole{
-	pixel_y = 4
+/obj/machinery/door/poddoor/railing{
+	id = "vehicle_elevator_railing"
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "oGO" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -11834,7 +11700,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "oHX" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 9
@@ -11889,9 +11755,12 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "oNh" = (
-/obj/effect/ai_node,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/mainship/sterile/side{
-	dir = 9
+	dir = 6
 	},
 /area/mainship/medical/lower_medical)
 "oNs" = (
@@ -11932,11 +11801,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oOM" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
@@ -11952,17 +11817,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "oOX" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
+/turf/open/floor/mainship/terragov{
+	dir = 1
 	},
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/starboard_hallway)
 "oQL" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -11989,13 +11847,6 @@
 "oSs" = (
 /obj/machinery/light/mainship{
 	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
 	},
 /turf/open/floor/mainship/green{
 	dir = 4
@@ -12104,8 +11955,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "oZY" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -12115,11 +11966,6 @@
 	dir = 9
 	},
 /area/mainship/squads/general)
-"paw" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/paper/memorial,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
 "pax" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor/glass{
 	dir = 1;
@@ -12162,7 +12008,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "pbh" = (
 /obj/effect/ai_node,
 /obj/structure/prop/mainship/name_stencil/C,
@@ -12214,12 +12060,12 @@
 /area/mainship/living/bridgebunks)
 "pdC" = (
 /obj/structure/largecrate/supply/ammo/standard_ammo,
-/turf/open/floor/mainship/office,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "peg" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar/droppod)
 "peH" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -12233,19 +12079,9 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "pfi" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/landmark/start/job/medicalofficer,
-/obj/item/tool/soap,
-/obj/item/attachable/bayonet,
-/obj/effect/decal/cleanable/blood,
-/obj/item/storage/pill_bottle/quickclot,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile,
-/area/mainship/medical/upper_medical)
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
 "pfH" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -12254,17 +12090,16 @@
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "pfU" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/yellow_cargo/arrow,
-/area/mainship/hallways/hangar/droppod)
+/obj/machinery/dropship_part_fabricator/tadpole,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "pgh" = (
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 4
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/area/mainship/medical/chemistry)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "pgp" = (
 /obj/structure/largecrate/guns/merc,
 /turf/open/floor/mainship/mono,
@@ -12278,13 +12113,6 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
-"pgL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
 "pha" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -12293,12 +12121,6 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/cargo/arrow,
-/area/mainship/hallways/hangar)
-"phr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
-/turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "pid" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12322,15 +12144,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pke" = (
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
 	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 1
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
 	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "pko" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -12376,21 +12198,20 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "plO" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/structure/mirror{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "plR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/side{
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/whitecyanfour{
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
@@ -12426,21 +12247,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "ppa" = (
-/obj/effect/turf_decal/tracks/wheels/bloody{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/medical/upper_medical)
-"ppG" = (
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 1;
-	name = "\improper Medical Storage Airlock"
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/turf/open/floor/wood,
+/area/mainship/living/grunt_rnr)
 "pqm" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship{
@@ -12454,17 +12266,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "pqC" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/living/pilotbunks)
 "pqQ" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 1;
@@ -12477,6 +12281,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/item/paper/overwatch,
 /turf/open/floor/mainship/green{
 	dir = 9
 	},
@@ -12513,7 +12318,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "pvy" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -12523,15 +12328,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"pvN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "pvW" = (
 /obj/item/toy/deck,
 /obj/structure/table/wood,
@@ -12550,10 +12346,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"pwj" = (
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "pwI" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -12585,14 +12377,12 @@
 	},
 /area/mainship/squads/general)
 "pyV" = (
+/obj/effect/turf_decal/warning_stripes/thick,
 /obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/sink{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/purple/corner,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "pzq" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/structure/table/mainship/nometal,
@@ -12619,10 +12409,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "pAM" = (
-/obj/machinery/loadout_vendor,
+/obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -12634,10 +12425,19 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
 "pDg" = (
-/obj/machinery/bodyscanner{
+/obj/machinery/computer/body_scanconsole,
+/obj/effect/turf_decal/medical_decals/triage/top{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/whitecyanthree{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "pEF" = (
 /obj/structure/table/mainship/nometal,
@@ -12654,20 +12454,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "pEN" = (
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/operating_room_two)
+/obj/effect/turf_decal/medical_decals/triage/bottom{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/whitecyanthree{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "pEQ" = (
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/mainship/marine/general/engi,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"pFn" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "pFs" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -12762,7 +12567,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "pKr" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -12785,17 +12590,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/cargo/arrow,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "pLB" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "pLD" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/structure/dropship_equipment/shuttle/nade_launcher,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "pLU" = (
 /obj/machinery/light/mainship{
@@ -12911,15 +12714,6 @@
 /obj/machinery/bot/cleanbot,
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
-"pSt" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
 "pSV" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/mechpilotquarters)
@@ -12969,11 +12763,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/railing{
-	id = "vehicle_elevator_railing"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "pVY" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -13012,10 +12804,12 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/command/airoom)
 "pXr" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/obj/effect/ai_node,
+/obj/machinery/light/mainship{
+	light_color = "#da2f1b"
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "pXw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13027,14 +12821,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "pZE" = (
-/obj/structure/sign/prop1{
-	dir = 1
-	},
 /obj/machinery/light/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "pZF" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -13115,17 +12906,24 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "qfF" = (
-/obj/structure/bed/chair/office/dark,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
-"qfG" = (
-/obj/structure/cable,
-/obj/structure/bed/stool{
-	pixel_y = 8
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/obj/machinery/power/apc,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 4
+	},
+/area/mainship/hallways/hangar/droppod)
+"qfG" = (
+/obj/machinery/landinglight/tadpole{
+	dir = 1
+	},
+/obj/machinery/landinglight/tadpole{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "qha" = (
 /turf/closed/wall/mainship,
 /area/mainship/hallways/boxingring)
@@ -13145,12 +12943,18 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "qjj" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/machinery/door/firedoor/mainship{
-	dir = 8
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/living/tankerbunks)
+/obj/item/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "qjw" = (
 /obj/structure/closet/bodybag,
 /obj/effect/decal/cleanable/blood,
@@ -13227,17 +13031,11 @@
 	},
 /area/mainship/command/cic)
 "qor" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/warning_stripes/thick{
+/obj/machinery/air_alarm{
 	dir = 8
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "qpf" = (
 /obj/machinery/light/mainship/small{
 	dir = 4
@@ -13286,11 +13084,11 @@
 	},
 /area/mainship/squads/req)
 "qtr" = (
-/obj/structure/dropship_equipment/shuttle/nade_launcher,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/cigarettes,
+/obj/effect/spawner/random/misc/cigar,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "qtz" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
@@ -13334,8 +13132,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "qwg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -13451,14 +13249,16 @@
 	},
 /area/mainship/living/commandbunks)
 "qBm" = (
-/obj/machinery/door/window{
-	dir = 8
-	},
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/structure/window,
 /obj/effect/landmark/start/job/cmo,
+/obj/machinery/door/window{
+	dir = 2
+	},
+/obj/structure/window{
+	dir = 8
+	},
 /turf/open/floor/mainship/floor,
 /area/mainship/medical/upper_medical)
 "qDh" = (
@@ -13583,7 +13383,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "qKz" = (
 /obj/machinery/firealarm{
 	dir = 8
@@ -13619,13 +13419,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qNE" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 1;
-	pixel_y = -4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -13639,24 +13432,42 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "qOa" = (
-/obj/machinery/door_control{
-	id = "or2privacyshutter";
-	name = "Privacy Shutters"
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
 	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 12
 	},
-/area/mainship/medical/operating_room_two)
+/obj/item/storage/surgical_tray,
+/obj/structure/sign/nosmoking_2{
+	dir = 4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "qOC" = (
 /obj/structure/closet/secure_closet/military_police,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/brig)
 "qOJ" = (
-/obj/structure/cable,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/machinery/door/poddoor/mainship/droppod,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "qPc" = (
 /obj/machinery/landinglight/cas{
 	dir = 1;
@@ -13668,9 +13479,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "qPq" = (
-/obj/structure/sign/chemistry,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/chemistry)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "qPD" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -13691,11 +13505,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "qQk" = (
 /obj/machinery/light/mainship/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -13737,18 +13549,16 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "qRK" = (
-/obj/structure/bed/chair/comfy{
-	dir = 1
+/mob/living/simple_animal/corgi/walten,
+/obj/item/reagent_containers/food/snacks/meatsteak,
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/lower_medical)
 "qRY" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/hallways/hangar/droppod)
 "qST" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13782,21 +13592,47 @@
 /turf/open/space/basic,
 /area/space)
 "qVu" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/syringe_case/regular{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/syringe_case/regular{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light/mainship{
+	dir = 8
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "qVH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
+/obj/item/plantable_flag,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
 /obj/effect/ai_node,
-/turf/open/floor/wood,
+/obj/structure/cable,
+/turf/open/floor/carpet/side,
 /area/mainship/living/numbertwobunks)
 "qWc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -13863,12 +13699,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"qZR" = (
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/lower_medical)
 "rag" = (
 /obj/machinery/door/airlock/mainship/command/CPTstudy{
 	dir = 1
@@ -13885,23 +13715,24 @@
 	},
 /area/mainship/squads/general)
 "rbo" = (
-/obj/machinery/light/mainship,
-/obj/effect/ai_node,
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
 	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "rbL" = (
 /obj/structure/sign/evac,
 /turf/closed/wall/mainship,
 /area/mainship/living/chapel)
 "rcm" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/ai_node,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "rcC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13922,6 +13753,7 @@
 /area/mainship/hull/lower_hull)
 "rer" = (
 /obj/structure/noticeboard,
+/obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/commandbunks)
 "reJ" = (
@@ -13952,7 +13784,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/weapon_room)
 "rio" = (
 /obj/structure/toilet{
 	dir = 4
@@ -13972,11 +13804,12 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "rkq" = (
-/obj/structure/closet/walllocker/hydrant/extinguisher,
-/obj/item/trash/cigbutt,
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/turf_decal/medical_decals/triage,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/whitecyanthree{
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "rky" = (
@@ -13995,6 +13828,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"rkO" = (
+/obj/structure/dropship_equipment/shuttle/weapon_holder/machinegun,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "rly" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -14091,11 +13930,15 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar/droppod)
 "rrp" = (
-/obj/structure/dropship_equipment/shuttle/nade_launcher,
-/turf/open/floor/mainship/orange{
+/obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
 	},
-/area/mainship/hallways/hangar)
+/obj/machinery/autodoc{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "rrt" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/lizard,
@@ -14149,6 +13992,12 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
+"rug" = (
+/obj/machinery/light/floor{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "ruM" = (
 /obj/machinery/air_alarm{
 	dir = 1
@@ -14172,16 +14021,13 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ryp" = (
-/obj/machinery/light/mainship{
-	dir = 8
+/obj/structure/sink{
+	dir = 4
 	},
-/obj/structure/sign/nosmoking_2{
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/chemistry)
 "ryB" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/hexagon,
@@ -14218,21 +14064,12 @@
 /area/mainship/living/briefing)
 "rzP" = (
 /obj/structure/largecrate/supply/supplies/water,
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "rzU" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/soundplayer/deltaplayer,
+/turf/closed/wall/mainship,
+/area/mainship/command/corporateliaison)
 "rAB" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -14253,9 +14090,11 @@
 	},
 /area/mainship/command/self_destruct)
 "rCb" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "rCl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
@@ -14282,22 +14121,30 @@
 "rCU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "rDn" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/reagent_containers/glass/beaker/biomass{
-	name = "biomass beaker"
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/weapon,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "rEw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14345,9 +14192,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "rGl" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/robotic_cradle,
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "rHh" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
@@ -14362,10 +14212,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
 	},
-/turf/open/floor/mainship/sterile,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "rIq" = (
 /obj/machinery/air_alarm,
@@ -14453,53 +14303,42 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "rPu" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "rPv" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "rQU" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 8
+/obj/structure/table/mainship/nometal,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/area/mainship/medical/chemistry)
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "rRa" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
 "rSg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/cic_maptable,
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
-"rSr" = (
-/obj/machinery/light/mainship{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/mirror{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/machinery/computer/crew,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "rSA" = (
 /turf/closed/wall/mainship/white,
 /area/medical/morgue)
-"rSW" = (
-/obj/item/plantable_flag,
-/turf/open/floor/carpet/side,
-/area/mainship/living/numbertwobunks)
 "rTr" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -14547,27 +14386,19 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "rWD" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/sign/restroom{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/area/mainship/hallways/starboard_hallway)
 "rWK" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "rWR" = (
 /obj/structure/rack,
 /obj/item/uav_turret/droid,
@@ -14578,7 +14409,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "rXy" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mainship/blue/full,
@@ -14614,6 +14445,7 @@
 	pixel_x = -8;
 	pixel_y = 3
 	},
+/obj/effect/urban/decal/trash/eight,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "rZh" = (
@@ -14639,15 +14471,6 @@
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"sbr" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/obj/structure/mirror{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
 "sbB" = (
 /turf/open/floor/mainship/black{
 	dir = 9
@@ -14663,7 +14486,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/weapon_room)
 "sbQ" = (
 /obj/machinery/chem_master,
 /obj/item/reagent_containers/glass/beaker/bluespace,
@@ -14688,11 +14511,14 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
 "sdK" = (
-/obj/structure/bed/roller,
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/bed/roller,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sdR" = (
@@ -14737,17 +14563,21 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "shx" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/structure/table/mainship/nometal,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/machinery/light/mainship{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "shB" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -14806,6 +14636,9 @@
 /obj/machinery/line_nexter{
 	dir = 4
 	},
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "soK" = (
@@ -14824,9 +14657,15 @@
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
 "spJ" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "spK" = (
 /obj/machinery/door/poddoor/mainship/umbilical/south{
 	dir = 2;
@@ -14857,17 +14696,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"ste" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 1;
-	name = "\improper Medical Storage Airlock"
-	},
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
 "stm" = (
 /obj/machinery/door/airlock/multi_tile/mainship/marine/general{
 	dir = 2
@@ -14918,10 +14746,15 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "swO" = (
-/obj/machinery/power/apc,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/mainship{
+	dir = 2
+	},
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/hallways/aft_hallway)
 "swY" = (
 /obj/machinery/marine_selector/gear/medic,
 /turf/open/floor/mainship/floor,
@@ -14967,23 +14800,16 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
-"sAl" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
+"sAI" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 4
 	},
 /obj/machinery/landinglight/tadpole{
-	dir = 8;
-	pixel_x = 4
+	dir = 4;
+	pixel_x = -4
 	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"sAI" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plating/plating_catwalk,
-/area/crew_quarters/toilet)
 "sBh" = (
 /obj/item/reagent_containers/jerrycan,
 /obj/item/reagent_containers/jerrycan,
@@ -15026,13 +14852,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "sDn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
+/obj/machinery/computer/camera_advanced/overwatch/medical,
+/obj/item/paper/overwatch,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "sEl" = (
 /turf/open/floor/mainship/terragov/north,
@@ -15099,9 +14924,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "sIN" = (
-/obj/item/trash/cigbutt,
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/upper_medical)
 "sJa" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/floor,
@@ -15146,17 +14972,18 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "sMF" = (
-/obj/vehicle/ridden/powerloader,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/cargo,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "sOJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/kitchenknife/butcherweighted,
 /obj/item/clothing/head/helmet/marine/som,
 /obj/effect/spawner/random/food_or_drink/burger,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/storage/chef/classic,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "sPc" = (
@@ -15171,9 +14998,6 @@
 	},
 /area/mainship/squads/general)
 "sPS" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -15181,7 +15005,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/floodlight/landing,
+/obj/machinery/light/floor{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "sQI" = (
@@ -15204,7 +15030,7 @@
 /area/mainship/engineering/port_atmos)
 "sSz" = (
 /turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/weapon_room)
 "sSN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -15220,10 +15046,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "sSW" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/machinery/vending/weapon,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "sUb" = (
 /obj/vehicle/ridden/powerloader,
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -15256,10 +15081,21 @@
 	},
 /obj/structure/table/mainship/nometal,
 /obj/item/folder/white,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 10
+	},
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
+"sVI" = (
+/obj/machinery/landinglight/tadpole,
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "sVR" = (
 /obj/structure/drop_pod_launcher/mech,
 /obj/structure/droppod/nonmob/mech_pod,
@@ -15312,17 +15148,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "sZh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/ai_node,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "sZP" = (
@@ -15341,12 +15168,6 @@
 /obj/effect/spawner/random/misc/gnome,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"taE" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "tbT" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/mono,
@@ -15361,9 +15182,17 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "teh" = (
-/obj/structure/window/framed/mainship/hull,
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 25
+	},
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/hallways/hangar)
 "tet" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -15507,10 +15336,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "tlT" = (
-/obj/machinery/door/poddoor/mainship/droppod,
-/obj/machinery/door/firedoor/mainship,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar/droppod)
+/obj/structure/prop/flag,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "tnR" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/keycard_auth{
@@ -15524,17 +15353,18 @@
 	},
 /area/mainship/engineering/ce_room)
 "tpi" = (
-/obj/machinery/light/mainship,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "tpo" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/upper_medical)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/hangar/droppod)
 "tpU" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 8
@@ -15551,14 +15381,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
 "tqD" = (
-/obj/machinery/door_control/old/medbay{
-	id = "Medbay";
-	name = "Medbay Lockdown";
-	pixel_x = 6;
-	pixel_y = -20
-	},
-/turf/open/floor/mainship/sterile/side,
-/area/mainship/medical/upper_medical)
+/obj/structure/prop/mainship/ship_memorial,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "tqR" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
@@ -15611,9 +15436,7 @@
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
 "ttT" = (
-/obj/structure/bed/roller,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "tur" = (
@@ -15634,7 +15457,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "tuW" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/weapon_room)
@@ -15661,6 +15484,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "tzF" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/structure/mirror{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "tzX" = (
@@ -15690,15 +15522,15 @@
 	},
 /area/mainship/living/commandbunks)
 "tAu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -15732,11 +15564,15 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
 "tBj" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/corner{
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/light/mainship{
 	dir = 4
 	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "tBY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -15793,12 +15629,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"tCO" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 4
-	},
-/turf/open/floor/mainship/floor,
-/area/mainship/hallways/hangar/droppod)
 "tDC" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/misc/earmuffs,
@@ -15825,9 +15655,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "tFb" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/starboard_hallway)
 "tFM" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -15865,14 +15698,25 @@
 /area/mainship/hallways/hangar)
 "tGU" = (
 /obj/structure/cable,
-/obj/machinery/optable,
-/obj/item/tank/anesthetic,
-/obj/structure/disposalpipe/segment,
-/obj/item/reagent_containers/blood/OMinus,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/door/firedoor/mainship,
+/obj/machinery/holosign/surgery{
+	id = "or1sign"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/area/mainship/medical/operating_room_two)
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/door/window/secure/medical{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "tHk" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 8
@@ -15881,9 +15725,17 @@
 /area/mainship/hallways/hangar)
 "tHY" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/medical_decals/triage/edge{
+	dir = 4
+	},
+/turf/open/floor/whitecyanfour{
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "tIn" = (
@@ -15984,18 +15836,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"tQa" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/ai_node,
-/obj/machinery/landinglight/tadpole{
-	dir = 8;
-	pixel_x = 4
-	},
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "tQO" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -16030,16 +15870,12 @@
 	},
 /area/mainship/medical/medical_science)
 "tRG" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
+/obj/machinery/cic_maptable/droppod_maptable,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "tTc" = (
 /obj/structure/disposalpipe/segment/corner,
 /obj/machinery/door_control/unmeltable{
@@ -16062,23 +15898,33 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/hangar)
 "tTR" = (
-/obj/docking_port/stationary/marine_dropship/minidropship,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "tTW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/bed/chair/comfy{
+/obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
 	},
-/area/mainship/medical/lower_medical)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "tUZ" = (
-/obj/machinery/firealarm,
-/turf/open/floor/mainship/mono,
-/area/mainship/living/grunt_rnr)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "tVd" = (
 /obj/structure/window/reinforced/extratoughened,
 /obj/structure/window/reinforced/windowstake{
@@ -16110,27 +15956,16 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tWq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/opened/medbay,
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or1privacyshutter";
+	name = "\improper Privacy Shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door_control{
-	dir = 1;
-	id = "or2privacyshutter";
-	name = "Privacy Shutters";
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/operating_room_two)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_one)
 "tWD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -16138,9 +15973,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "tXl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/door/poddoor/railing{
+	dir = 8;
+	id = "vehicle_elevator_railing"
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "tXB" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -16209,13 +16048,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/landinglight/tadpole{
-	dir = 1;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
-	},
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/req)
 "ubW" = (
@@ -16268,11 +16100,12 @@
 /turf/open/shuttle/escapepod/eleven,
 /area/mainship/command/self_destruct)
 "uej" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/defibrillator,
-/obj/machinery/recharger,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "uer" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship,
@@ -16299,17 +16132,16 @@
 "ufq" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/mechpilotquarters)
-"ufT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
 "ugv" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"ugL" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigar,
+/obj/effect/spawner/random/food_or_drink/donut,
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "uhj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16320,16 +16152,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "uig" = (
-/obj/machinery/door_control{
-	id = "or1privacyshutter";
-	name = "Privacy Shutters"
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
 	},
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/mainship/sterile/side{
-	dir = 1
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
 	},
-/area/mainship/medical/operating_room_one)
+/area/mainship/medical/lower_medical)
 "uiG" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
@@ -16424,7 +16254,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "uqd" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -16443,6 +16273,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "uqA" = (
@@ -16504,16 +16335,25 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uvB" = (
+/obj/structure/rack,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/storage/box/gloves{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 2;
+	pixel_y = -1
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/computer/autodoc_console,
-/turf/open/floor/mainship/sterile/side{
-	dir = 8
-	},
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "uvK" = (
 /obj/structure/table/mainship/nometal,
@@ -16560,14 +16400,6 @@
 "uyy" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/numbertwobunks)
-"uza" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/computer/body_scanconsole{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "uzm" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 2;
@@ -16579,13 +16411,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 1;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 1
 	},
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 1
@@ -16628,9 +16453,21 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "uCj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable,
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/obj/machinery/door_control{
+	dir = 8;
+	id = "or1privacyshutter";
+	name = "Privacy Shutters"
+	},
+/obj/machinery/holosign_switch{
+	id = "or1sign";
+	pixel_x = -18;
+	pixel_y = -12
+	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/operating_room_one)
 "uCk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16645,12 +16482,11 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
 "uCC" = (
-/obj/structure/sign/prop1,
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
+/obj/machinery/door/poddoor/mainship/droppod{
+	dir = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/hangar/droppod)
 "uCO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16662,38 +16498,24 @@
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/medical_science)
 "uDl" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
-	},
-/obj/structure/sign/prop1,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/machinery/door_control/mainship/droppod,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar/droppod)
 "uDq" = (
 /obj/machinery/light/mainship{
 	dir = 1
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"uDQ" = (
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/corner{
-	dir = 8
-	},
-/area/mainship/medical/operating_room_one)
 "uEg" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/structure/window/framed/mainship/white,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
+/obj/machinery/vending/tool,
+/turf/open/floor/wood,
+/area/mainship/living/tankerbunks)
 "uFV" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/faxmachine,
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/upper_medical)
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "uGq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16780,9 +16602,12 @@
 	},
 /area/mainship/command/airoom)
 "uMj" = (
-/obj/machinery/computer/sleep_console,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "uMG" = (
 /obj/structure/bed/nometal,
 /obj/item/bedsheet/green,
@@ -16795,12 +16620,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/starboard_hallway)
 "uNy" = (
 /obj/structure/bed/fancy,
 /obj/effect/landmark/start/job/fieldcommander,
@@ -16812,6 +16635,7 @@
 /area/mainship/living/numbertwobunks)
 "uOe" = (
 /obj/structure/closet/bodybag,
+/obj/item/clothing/mask/gas/icc,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uOf" = (
@@ -16830,12 +16654,11 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/hallways/aft_hallway)
 "uOQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/item/clothing/mask/gas/icc,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "uPn" = (
@@ -16869,7 +16692,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "uQQ" = (
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
@@ -16934,13 +16757,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uVk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/computer/cloning_console/vats,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/medical/lower_medical)
 "uVF" = (
 /obj/machinery/loadout_vendor,
 /obj/machinery/light/mainship{
@@ -16977,7 +16796,7 @@
 "uXy" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/outer,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/weapon_room)
 "uYe" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -16999,18 +16818,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "uZR" = (
-/obj/structure/table/mainship/nometal,
-/obj/effect/spawner/random/misc/paperbin{
-	pixel_y = 5
-	},
-/obj/item/tool/pen/blue,
-/obj/machinery/camera/autoname/mainship{
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/corner{
-	dir = 4
-	},
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "vab" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17061,6 +16872,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
+"vcJ" = (
+/obj/structure/bed/chair/sofa,
+/obj/effect/landmark/start/job/shiptech,
+/obj/machinery/light/blue{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/mainship/hallways/starboard_hallway)
 "vcN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17155,9 +16974,19 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
 "vhl" = (
-/obj/effect/landmark/start/job/medicalofficer,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "vhG" = (
 /obj/machinery/air_alarm{
 	dir = 4
@@ -17181,7 +17010,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
 "vkm" = (
-/obj/machinery/loadout_vendor,
+/obj/machinery/cryopod/right,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -17347,16 +17176,20 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vwL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/secure/medical{
+/obj/vehicle/ridden/wheelchair{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
 	},
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "vxx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17375,24 +17208,22 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "vyj" = (
-/obj/structure/sign/restroom{
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "vyG" = (
-/obj/machinery/light/mainship{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa,
-/turf/open/floor/wood,
-/area/mainship/living/grunt_rnr)
+/obj/structure/sign/chemistry,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "vyJ" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
 "vzd" = (
 /obj/structure/largecrate/guns,
-/turf/open/floor/mainship/office,
+/turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "vzt" = (
 /obj/structure/bed,
@@ -17420,6 +17251,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"vzN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "vAb" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -17434,8 +17273,8 @@
 /turf/closed/wall/mainship,
 /area/mainship/engineering/upper_engineering)
 "vBY" = (
-/obj/machinery/bot/cleanbot,
-/turf/open/floor/mainship/sterile,
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "vCB" = (
 /obj/structure/table/mainship,
@@ -17459,18 +17298,12 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "vDH" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/storage/backpack/marine/engineerpack,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/obj/machinery/landinglight/tadpole{
-	dir = 4;
-	pixel_x = -4
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "vFb" = (
 /obj/structure/table/wood/fancy,
 /obj/item/book/codebook,
@@ -17498,12 +17331,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "vGQ" = (
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/vehicle/ridden/powerloader,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/hallways/hangar)
 "vGX" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/structure/dropship_equipment/shuttle/sentry_holder,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/hallways/hangar)
 "vHw" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 8
@@ -17519,12 +17361,24 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
+"vIy" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/mainship/green{
+	dir = 4
+	},
+/area/mainship/squads/req)
 "vJq" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
 	},
 /turf/closed/wall/mainship,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/weapon_room)
 "vLD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -17578,10 +17432,9 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "vPk" = (
-/turf/open/floor/mainship/sterile/corner{
-	dir = 1
-	},
-/area/mainship/medical/lower_medical)
+/obj/machinery/landinglight/tadpole,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "vPH" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
@@ -17589,6 +17442,13 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"vRg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/paper/xenoresearch3,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/medical_science)
 "vSo" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -17638,7 +17498,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/area/mainship/hallways/aft_hallway)
 "vVG" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship,
@@ -17687,19 +17547,16 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"vYd" = (
-/obj/structure/morgue{
-	dir = 2
-	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/cult,
-/area/medical/morgue)
 "vYo" = (
-/obj/structure/dropship_equipment/shuttle/operatingtable,
-/turf/open/floor/mainship/orange{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/area/mainship/hallways/hangar)
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/lower_medical)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17729,15 +17586,16 @@
 "wag" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
+/obj/item/paper/memorial,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/starboard_hallway)
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
@@ -17874,16 +17732,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "wkJ" = (
-/obj/effect/turf_decal/medical_decals/cryo,
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/upper_medical)
 "wml" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
-"wmy" = (
-/obj/effect/turf_decal/warning_stripes/thick/corner,
-/turf/open/floor/plating,
-/area/mainship/hallways/hangar)
 "wmH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17950,12 +17804,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
-"wqZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/aft_hallway)
 "wrb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -17980,12 +17828,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/grunt_rnr)
 "wrW" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/misc/table_lighting,
-/obj/item/paper,
-/obj/item/paper,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "wsb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -18253,12 +18098,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"wHB" = (
-/obj/machinery/firealarm{
-	dir = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
 "wHI" = (
 /turf/open/floor/mainship/silver,
 /area/mainship/living/chapel)
@@ -18347,15 +18186,18 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "wNF" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/mainship{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/stripesquare,
-/area/mainship/hallways/aft_hallway)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "wNG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18381,9 +18223,15 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "wQo" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/port_hallway)
+/obj/effect/turf_decal/warning_stripes/thick/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "wQH" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
@@ -18457,6 +18305,18 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
+"wTH" = (
+/obj/structure/table/mainship/nometal,
+/obj/machinery/faxmachine/cic{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/popcorn{
+	pixel_x = -8
+	},
+/obj/item/toy/deck,
+/obj/item/toy/deck/kotahi,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "wTX" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -18475,9 +18335,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "wVG" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/obj/machinery/computer/squad_selector,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar/droppod)
 "wVL" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plating/plating_catwalk,
@@ -18488,14 +18351,8 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "wWG" = (
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/tadpole{
-	dir = 8;
-	pixel_x = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/docking_port/stationary/marine_dropship/minidropship,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "wWQ" = (
 /turf/closed/wall/mainship,
@@ -18507,14 +18364,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/area/mainship/hallways/starboard_hallway)
 "wXr" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light/mainship{
+/obj/structure/dropship_equipment/shuttle/tangle_emitter,
+/turf/open/floor/mainship/orange{
 	dir = 4
 	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/hangar)
 "wXN" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/mainship/orange{
@@ -18529,6 +18385,8 @@
 	pixel_y = 1
 	},
 /obj/item/tool/pen,
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen,
+/obj/item/paper/xenoresearch1,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
@@ -18572,7 +18430,7 @@
 "xar" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/shipboard/brig)
 "xbi" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
@@ -18617,35 +18475,17 @@
 "xdE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "xdN" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/mainship/living/starboard_garden)
-"xej" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/mainship/terragov/north{
 	dir = 8
 	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 4
-	},
-/area/mainship/medical/lower_medical)
+/area/mainship/hallways/starboard_hallway)
 "xeM" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -18690,11 +18530,8 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "xhP" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/ai_node,
-/obj/structure/cable,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/port_hallway)
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/hangar/droppod)
 "xiT" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -18728,9 +18565,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "xjD" = (
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar/droppod)
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/medical/lower_medical)
 "xjF" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -18738,8 +18574,18 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "xjG" = (
-/obj/structure/sign/safety/cryogenic,
-/turf/closed/wall/mainship/white,
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/tank/anesthetic,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
+"xkC" = (
+/obj/structure/cable,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/medical/lower_medical)
 "xkD" = (
 /obj/structure/closet/emcloset,
@@ -18890,7 +18736,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "xuy" = (
 /obj/machinery/firealarm,
@@ -18990,11 +18836,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
 "xyS" = (
-/obj/structure/window/framed/mainship/white,
-/obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/poddoor/shutters/opened/medbay,
-/turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/machinery/landinglight/tadpole{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "xzF" = (
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
@@ -19013,23 +18863,19 @@
 	dir = 4
 	},
 /area/mainship/squads/general)
-"xAG" = (
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
 "xAX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/bed/roller,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/structure/sign/safety/cryogenic{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "xBe" = (
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/vending/armor_supply,
+/obj/machinery/vending/tool,
 /turf/open/floor/mainship/green{
 	dir = 4
 	},
@@ -19100,6 +18946,7 @@
 	pixel_x = 5;
 	pixel_y = -8
 	},
+/obj/effect/urban/decal/trash/nine,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "xBT" = (
@@ -19207,14 +19054,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "xJe" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/warning_stripes/thick{
 	dir = 4
 	},
-/obj/machinery/light/mainship/small{
-	dir = 1
+/obj/machinery/landinglight/tadpole{
+	dir = 8;
+	pixel_x = -4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/crew_quarters/toilet)
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "xJh" = (
 /obj/machinery/power/fusion_engine/preset,
 /obj/structure/cable,
@@ -19291,11 +19139,12 @@
 /turf/open/floor/carpet/side,
 /area/mainship/living/commandbunks)
 "xQB" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/misc/cigar,
-/obj/effect/spawner/random/misc/cigarettes,
-/turf/open/floor/wood,
-/area/mainship/living/tankerbunks)
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1;
+	name = "Bathroom"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "xQT" = (
 /obj/machinery/door/window/secure/brig/cell_2{
 	dir = 8
@@ -19326,16 +19175,14 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "xSi" = (
-/obj/structure/toilet,
-/obj/effect/landmark/corpsespawner/marine/burst,
-/obj/effect/decal/cleanable/blood,
-/obj/item/organ/brain,
-/obj/item/weapon/gun/rifle/standard_autoshotgun,
-/obj/machinery/light/mainship/small{
-	dir = 1
+/obj/effect/turf_decal/medical_decals/triage/edge,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/whitecyanfour{
+	dir = 8
 	},
-/turf/open/floor/mainship/mono,
-/area/crew_quarters/toilet)
+/area/mainship/medical/lower_medical)
 "xSn" = (
 /obj/machinery/door_control/mainship/mech,
 /turf/open/floor/mainship/mono,
@@ -19344,12 +19191,11 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/evacuation)
 "xSN" = (
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/vehicle/ridden/powerloader,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "xSS" = (
 /obj/structure/morgue/crematorium,
 /turf/open/floor/cult,
@@ -19432,13 +19278,13 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/engineering/lower_engineering)
 "xVO" = (
-/obj/machinery/light/mainship,
-/obj/machinery/door/poddoor/railing{
-	dir = 1;
-	id = "vehicle_elevator_railing"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "xVU" = (
 /obj/effect/turf_decal/warning_stripes/box/small,
 /obj/effect/turf_decal/warning_stripes/box/small{
@@ -19485,14 +19331,6 @@
 /obj/structure/sign/prop1,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
-"xXW" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
-/area/mainship/medical/lower_medical)
 "xYg" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -19553,12 +19391,23 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "xZy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/aft_hallway)
+/obj/structure/table/mainship/nometal,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/tool/weldingtool/largetank,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/machinery/light/mainship{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "xZI" = (
 /obj/structure/janitorialcart,
 /obj/item/tool/mop,
@@ -19569,11 +19418,19 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/self_destruct)
 "xZP" = (
-/obj/effect/turf_decal/warning_stripes/thick{
-	dir = 8
+/obj/structure/table/mainship/nometal,
+/obj/machinery/faxmachine{
+	pixel_x = 5
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/effect/spawner/random/misc/paperbin{
+	pixel_y = 5;
+	pixel_x = -11
+	},
+/obj/item/tool/pen/blue,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/upper_medical)
 "yaf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19713,17 +19570,21 @@
 	},
 /area/mainship/medical/medical_science)
 "yjj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/warning_stripes/thin{
+/turf/open/floor/mainship/yellow_cargo/arrow{
 	dir = 1
 	},
-/obj/machinery/holopad,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hallways/hangar)
+/area/mainship/hallways/hangar/droppod)
 "yjx" = (
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
+"yki" = (
+/obj/effect/turf_decal/warning_stripes/thick/corner,
+/obj/machinery/landinglight/tadpole{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "ykn" = (
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/red/full,
@@ -19734,16 +19595,12 @@
 /turf/open/space,
 /area/space)
 "ykH" = (
-/obj/structure/sign/nosmoking_2{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/item/storage/firstaid/adv,
-/obj/structure/table/reinforced,
-/turf/open/floor/mainship/sterile/corner,
-/area/mainship/medical/operating_room_two)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/starboard_hallway)
 "ykK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/shiptech,
@@ -19762,8 +19619,11 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "ylp" = (
+/obj/machinery/light/mainship{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
-/area/mainship/living/starboard_garden)
+/area/mainship/hallways/hangar/droppod)
 "ylq" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -38893,9 +38753,9 @@ qVo
 qVo
 qVo
 qVo
-mBZ
-mBZ
-mBZ
+qVo
+qVo
+qVo
 mBZ
 mBZ
 mBZ
@@ -39150,9 +39010,9 @@ qVo
 qVo
 qVo
 qVo
-mBZ
-mBZ
-mBZ
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -42501,7 +42361,7 @@ esN
 kEP
 gmc
 cYW
-kQn
+vRg
 wYb
 sVq
 gmc
@@ -43785,7 +43645,7 @@ mGV
 gMu
 sXy
 rSA
-vPk
+lQb
 qFX
 iMF
 bOX
@@ -44042,16 +43902,16 @@ xSb
 xSb
 lcA
 rSA
-lGi
-lAT
+sJE
+xzF
 yjx
-bmo
+giW
 tMy
-wnJ
+vFi
 bxv
 ckd
 bck
-jXN
+pRb
 wcT
 tkA
 tfG
@@ -44299,16 +44159,16 @@ wFY
 xSb
 lsc
 rSA
-ftY
+lAq
 xzF
 yjx
 bmo
-mzF
-vTy
-tqD
+vrx
+npN
+rst
 wcT
-pRb
-ppa
+wcT
+vwh
 wcT
 tKd
 tfG
@@ -44559,13 +44419,13 @@ rSA
 gZf
 nbC
 yjx
-giW
-tMy
-vFi
+bmo
+rEY
+xZP
 iTn
 wcT
-wcT
-vwh
+mcR
+rpS
 wcT
 pKr
 tfG
@@ -44805,24 +44665,24 @@ oUM
 iTM
 kEP
 rSA
-vYd
-xSb
-oOn
-gaD
-wFY
-xSb
-wFY
 rSA
+rSA
+rSA
+gkY
+rSA
+rSA
+rSA
+ujw
 lCL
-nbC
-yjx
-bmo
-vrx
-npN
-rst
-wcT
-mcR
-rpS
+xzF
+pii
+dLo
+dLo
+dLo
+dLo
+pii
+qBm
+kuy
 wcT
 qvJ
 wrV
@@ -44831,14 +44691,14 @@ sXf
 sFo
 wwC
 xVr
-leu
+rzU
 vha
 leu
 leu
 leu
 leu
 leu
-leu
+rzU
 bpc
 tAe
 gbJ
@@ -45060,27 +44920,27 @@ gZg
 jQH
 oUM
 iTM
-kEP
-rSA
-rSA
-rSA
-rSA
-gkY
-rSA
-rSA
-rSA
-ujw
-lQb
+ndI
+mvs
+bcv
+euF
+hKy
+ntb
+euF
+hKy
+vkm
+mvs
+bUW
 xzF
-yjx
-bmo
-rEY
-uFV
+dLo
+bzT
+nkX
+hYl
 uZR
+dLo
 wcT
-qBm
-kuy
 wcT
+olX
 uOf
 jsE
 qJz
@@ -45317,29 +45177,29 @@ jQH
 jQH
 oUM
 qha
-ndI
-mvs
-bcv
-euF
-hKy
-ntb
-mXf
-rDn
-vkm
-mvs
-sJE
-xzF
-yjx
-olX
-wcT
-wcT
-wcT
-wcT
-wcT
-wcT
-olX
+uUU
+lzS
+tEV
+tEV
+tEV
+gze
+lAT
+lAT
+lTH
+duU
+lGi
+iwj
+dLo
+osh
+uWK
+wNn
+sFM
+dLo
+lkD
+qJz
+xiT
 mdp
-bLz
+mXM
 urT
 naV
 bLz
@@ -45574,27 +45434,27 @@ jQH
 rXy
 nLi
 qha
-uUU
-lzS
-tEV
-tEV
-tEV
-gze
-nMm
-iwj
-lTH
+ndI
 mvs
-lAq
-xzF
-eUN
-wcT
-wnJ
-wnJ
+dIf
+dvG
+dvG
+dvG
+dvG
+mXw
+lTu
+mvs
+xAX
+vyG
+dLo
+fZP
+gaD
+xXt
 pfi
-wcT
-lkD
-qJz
-xiT
+dLo
+poR
+jsE
+jsE
 bLz
 glL
 ogX
@@ -45794,7 +45654,7 @@ qVo
 qVo
 hRh
 esN
-uSh
+mJI
 wPV
 wPV
 wPV
@@ -45832,25 +45692,25 @@ wrP
 jea
 pTj
 pOn
+nRz
 mvs
-dIf
-fXX
-fXX
-fXX
-dvG
-lAT
-qZR
 mvs
-lGi
-iwj
-yjx
-mXM
-wnJ
-wnJ
-koA
-wcT
-poR
-jsE
+mvs
+mvs
+mvs
+mvs
+mvs
+nRz
+fFo
+aJH
+dkD
+qtB
+xqW
+nIF
+tkS
+dLo
+lkD
+qJz
 jsE
 bLz
 glL
@@ -46089,27 +45949,27 @@ tyN
 tyN
 tyN
 tyN
-dQG
-dQG
-dQG
-dQG
-lTu
 mvs
-igh
+dQG
+shx
+rQU
+qjj
+qVu
+mXf
 xjG
-mvs
+wcT
 kSC
-eVA
-iRQ
-wcT
-sbr
-wnJ
-gBE
-wcT
-lkD
-qJz
-jsE
-bLz
+yjx
+ftK
+tNW
+pJs
+baH
+pfi
+dLo
+kly
+tjp
+cVd
+cVd
 bLz
 iDs
 ghV
@@ -46346,29 +46206,29 @@ qwO
 gjA
 yfw
 kuc
-dQG
+mvs
 oca
-nkX
-uDQ
-dQG
-ryp
+wnJ
+wnJ
+vwL
+oBq
 sIN
-xXW
-qFX
+aSw
+wcT
 hiV
 eUN
-wcT
-wcT
-wcT
-sSW
-wcT
-wcT
-tUZ
-jsE
-jsE
-bLz
-jbg
+kVD
+ryp
+mSh
+wNn
+sFM
+dLo
+uob
+tur
+fDn
+dJS
 tdm
+mEd
 tNb
 tNb
 tdm
@@ -46603,29 +46463,29 @@ eks
 eks
 kTv
 mVM
-dQG
-uig
+mvs
+vTy
 fTy
 iuw
-dQG
+mHi
 mHi
 wkJ
-mwj
-lSk
-lAT
-lTH
+nJd
 wcT
-dhv
-vTy
-qRK
-lVR
-wcT
-upL
-cVd
+jLn
+osb
+pii
+dLo
+dLo
+dLo
+dLo
+pii
+qvJ
+qvJ
+gkL
+ppa
 bLz
-bLz
-bLz
-glL
+cVU
 lhZ
 dBm
 nHm
@@ -46860,28 +46720,28 @@ fCI
 xVg
 tVP
 lTe
-dQG
-gpC
-gcd
-fGV
-dQG
-eiY
-bnL
-eGM
-uej
-lAT
-iwj
-ppG
-fPi
-wnJ
-oBq
-ocE
+mvs
 wcT
-vyG
-tjp
+wcT
+wcT
+wcT
+wcT
+eGM
+wcT
+wcT
+jLn
+yjx
+mvs
+fPi
+xGl
+xGl
+ocE
+xGl
+xGl
+rcm
+pdj
+upL
 cVd
-cVd
-bLz
 glL
 rrt
 dST
@@ -47117,34 +46977,34 @@ aql
 wyz
 xBT
 pzq
-nRz
+mvs
 hJw
 gBJ
-aSw
-dQG
-mHi
-jPT
-mwj
-hUW
-iwj
+ePj
+fEb
+xkC
+mmC
+orC
+orC
+fuy
 yjx
-wcT
+mvs
 mbQ
-nuX
-qVu
-tpo
-wcT
-uob
-tur
-fDn
-aSq
-bLz
+xGl
+xGl
+qPq
+xGl
+xGl
+rPu
+pdj
+upL
+tjp
 bLz
 iDs
 iDs
 bLz
 cnA
-leu
+rzU
 leu
 hEy
 xzR
@@ -47374,29 +47234,29 @@ kDx
 brN
 xBT
 cYZ
-mvs
-duU
-tTW
-fEb
-qFX
-jWB
+kWu
+ouq
 iwj
 lAT
 lAT
 lAT
-eUN
-wcT
+lAT
+mgw
+mgw
+nMm
 ncI
-vhl
-qVu
-tpo
-wcT
-qvJ
-qvJ
-qvJ
-qvJ
+mvs
+mbQ
+xGl
+xGl
+qPq
+kKd
+xGl
+rPu
+pdj
 upL
 cVd
+mXM
 bLz
 bLz
 bLz
@@ -47631,32 +47491,32 @@ kDx
 brN
 uqj
 aCM
-mvs
-rSg
-hpx
-pvN
+aoQ
 mmC
-kyi
-dnQ
+lSQ
+mNf
+qFX
+iMF
 lAT
-hLE
 lAT
-mpw
-wcT
+lAT
+nMm
+mzF
+mvs
 nku
-nwc
-qVu
+xGl
+xGl
 tpo
-wcT
-hUf
+xGl
+xGl
 jxi
-hUf
-qvJ
-upL
-tjp
-cVd
-cVd
+pdj
+uob
+tur
+iWQ
+aSq
 bLz
+ohq
 jsE
 btW
 jsE
@@ -47889,34 +47749,34 @@ fGZ
 tAu
 sdK
 cWC
-lxg
-tXl
+tEV
 htZ
+dXO
 ivW
-sDn
-uvB
-iMF
-gqB
+qRK
+uig
 lAT
+lAT
+cxv
 mqY
-wcT
+mwj
 nkC
 nuX
-oEm
+nuX
 spJ
-ste
+ygV
 wQo
-rPu
-jwA
+mJL
+qRY
 qvJ
-uob
-tur
-iWQ
-aSq
-ohq
-jsE
+qvJ
+qvJ
+qvJ
+qvJ
+gkL
+are
 bCH
-jsE
+are
 leu
 dmE
 glN
@@ -48143,38 +48003,38 @@ kDx
 rHw
 xDq
 rCn
-gIS
+bOz
 ttT
-aAu
-ouq
+kWu
 lAT
+dcg
+lYL
+rSg
+sDn
+uvB
 lAT
-vPk
-oNh
-rHK
-eQW
-iMF
-lAT
-mRd
-wcT
+sZh
+hUW
+eUN
+mvs
 nla
 ffi
-nNV
-onk
-wcT
+ffi
+qfF
+opd
 ekk
 pXr
-ekk
-gkL
-qvJ
-qvJ
-qvJ
-qvJ
-gkL
-are
+pdj
+nyh
+xvv
+kyi
+hSb
+mRd
+xvv
+jsE
 mps
-are
-leu
+jsE
+rzU
 cfM
 cfM
 cfM
@@ -48402,50 +48262,50 @@ kDx
 rCn
 bOz
 xOg
-kWu
-usa
-gnK
-lSQ
-mnH
-vBY
-eBB
-liX
-yjx
-bnL
+mvs
+xZy
+vYo
+cTx
+wTH
+oNh
+xVO
+lAT
+lAT
+nMm
 lQN
-dLo
-dLo
-nJd
-dLo
+mvs
+mbQ
+xGl
+xGl
 qPq
-pii
-hUf
-nTx
-hUf
-gbM
-nyh
-mrK
-mrK
-nyh
-gbM
-hUf
+pgq
+wVG
+xhP
+kpI
+llq
+kWM
+kWM
+kWM
+kWM
+xvv
+vAn
 pAF
-hUf
-qej
-hUf
-hUf
-hUf
-hUf
+vAn
+swv
+vAn
+vAn
+vAn
+vAn
 vVy
-xpj
-omk
-xJd
-hUf
-hUf
+tWD
+pZF
+xeM
+vAn
+vAn
 pKl
-hUf
-hUf
-hUf
+vAn
+vAn
+vAn
 qej
 xpj
 hUf
@@ -48633,7 +48493,7 @@ ufq
 wEZ
 tyN
 nkm
-aDU
+dpY
 cPE
 kDx
 kDx
@@ -48657,52 +48517,52 @@ kDx
 rxx
 csW
 rCn
-gIS
-xAX
-aoQ
-loc
+lSk
+uFV
+nRz
+rGl
+gnK
+xjD
+mnH
+bnL
+eBB
 lAT
-uMj
-aiP
-gNc
-rHK
-eVA
-iRQ
 lAT
-lYL
-dLo
-bzT
-hYl
-hYl
-rQU
-uEg
-hUf
+nMm
+uVk
+mvs
+mbQ
+xGl
+xGl
+qPq
+pgq
+tRG
 xhP
 uCC
-gbM
-waC
-peg
-wVG
+yjj
+kHT
+roN
+nIG
 mrK
-gbM
+xvv
 pZE
 iHy
-ufT
+vgo
 qKw
-lOk
-lOk
+vGG
+vGG
 tuS
-lOk
+vGG
 ezT
-lOk
-lOk
-lOk
-lOk
-lOk
+vGG
+vGG
+vGG
+vGG
+vGG
 neZ
-lOk
+vGG
 puR
-lOk
+vGG
 ixz
 lOk
 jMO
@@ -48889,9 +48749,9 @@ sVR
 ufq
 uud
 tyN
-mJI
-luk
-iay
+ePE
+dpY
+cPE
 kDx
 kDx
 kDx
@@ -48915,51 +48775,51 @@ kDx
 kDx
 hMB
 lCh
-foU
-dlz
-jUl
-hGO
-bYJ
-uza
-mgM
-plR
-iRQ
-jzx
+fwq
+mvs
+usa
+lxg
+gNc
+aiP
+gNc
+rHK
+rrp
 lAT
-nwX
-dLo
-osh
-uWK
-wNn
-sFM
-hGT
-hUf
-nTx
-hUf
+nMm
+kMt
+mvs
+mbQ
+rrj
+xGl
+tpo
+pgq
+ekk
+tTR
+uCC
 llq
-fFo
-aqn
-eLs
-mrK
-llq
-hUf
+bbw
+uzy
+tbT
+hwZ
+dUo
+vAn
 pbe
-hUf
-qej
-hUf
-bem
-hUf
-hUf
-hUf
-hUf
-hUf
-bem
-hUf
-hUf
-qej
-hUf
+vAn
+swv
+vAn
+wII
+vAn
+vAn
+vAn
+vAn
+vAn
+wII
+vAn
+vAn
+swv
+vAn
 gim
-hUf
+vAn
 qej
 hUf
 bem
@@ -49132,7 +48992,7 @@ mBZ
 mBZ
 hRh
 esN
-uSh
+mJI
 wPV
 wPV
 uSh
@@ -49146,9 +49006,9 @@ sVR
 ufq
 wEZ
 tyN
-jfb
-luk
-iay
+ePE
+dpY
+cPE
 xDq
 xDq
 qWy
@@ -49174,49 +49034,49 @@ brN
 aWk
 aQX
 mvs
-kYM
-lAT
-ksa
+jUl
+hGO
+bYJ
 pDg
 ieX
-jUP
+plR
+iRQ
 lAT
-jLn
-lAT
-eUN
-dLo
-fZP
-uVk
-xXt
-tkS
-ftK
-hUf
+tUZ
+mqY
+mwj
+nkC
+ygV
+ygV
+gSN
+ygV
+jwA
 nTx
-hUf
-ylp
+pdj
+lCb
 peg
-ciN
-paw
-tFb
-ylp
-hUf
+kWM
+kWM
+kWM
+kWM
+vAn
 pbe
-wHB
-snn
-teh
-snn
-snn
+cwA
+tuW
+lev
+tuW
+tuW
 uXy
-teh
-snn
-ekx
-ekx
-ekx
-ekx
-ekx
-hUf
+lev
+tuW
+dhv
+dhv
+dhv
+dhv
+dhv
+vAn
 gim
-hUf
+vAn
 dla
 dla
 fXS
@@ -49403,8 +49263,8 @@ tyN
 tyN
 bDH
 tyN
-qor
-xZP
+ePE
+dpY
 cPE
 kDx
 kDx
@@ -49431,35 +49291,35 @@ brN
 aWk
 cYZ
 mvs
-coF
-tHY
-xej
-iiC
+kYM
+bFG
+ksa
 dIk
-sZh
-mam
-mam
-mam
-cVU
-dkD
-qtB
-xqW
-nIF
+ksa
+jWB
+dnQ
+lAT
+wNF
+mpw
+mvs
+nla
+xGl
+xGl
 qfF
-vwL
-hTV
+kKd
+xGl
 cNy
-hUf
+pdj
 ylp
-pgL
-ezY
-omz
-peg
-ylp
-hUf
+xvv
+xvv
+xvv
+xvv
+xvv
+vAn
 pbe
-hUf
-snn
+vAn
+tuW
 aNM
 aNM
 chD
@@ -49470,10 +49330,10 @@ gdb
 gdb
 gdb
 chO
-ekx
-hUf
+dhv
+vAn
 gim
-hUf
+vAn
 dla
 mBZ
 eyX
@@ -49687,36 +49547,36 @@ aqx
 brN
 aWk
 dpY
-fsp
-kxm
-lhT
-cPY
+mvs
+gpC
+tHY
+iiC
 pEN
 rkq
-nRH
-lAT
-lAT
-mgw
-oyZ
-dLo
-tNW
-pJs
-xXt
-tkS
-hGT
-opd
+xSi
+foU
+tEV
+mam
+vBY
+mvs
+mbQ
+xGl
+xGl
+qPq
+xGl
+xGl
 rPu
-wQo
+pdj
 mqD
-kGc
-rcm
-jHd
-ciN
-hdc
-rGl
+xvv
+rCb
+dMy
+iku
+xvv
+vAn
 pbe
 eMx
-snn
+tuW
 uUp
 uUp
 lev
@@ -49727,8 +49587,8 @@ bYx
 vyJ
 vyJ
 sUb
-ekx
-hUf
+dhv
+vAn
 gim
 eMx
 dla
@@ -49927,7 +49787,7 @@ pnF
 ubn
 pnF
 pnF
-pnF
+pQc
 pZX
 llR
 pnF
@@ -49944,36 +49804,36 @@ sSN
 vdN
 tGI
 tQW
-pEN
+mvs
 oCo
 tGU
 tWq
-pEN
+loc
 dNQ
 nRH
+aDU
 lAT
-lAT
-mgw
+wNF
 oyZ
-dLo
-euc
-uWK
-wNn
-sFM
-hGT
-opd
-nTx
-uDl
+mvs
+mbQ
+xGl
+xGl
+qPq
+xGl
+xGl
+aBm
+pdj
 fyR
-qfG
-hwZ
-gAS
-mrK
-gbM
+xvv
+xvv
+xvv
+xvv
+xvv
 pZE
-lPc
-hUf
-ekx
+pbe
+vAn
+dhv
 vyJ
 vyJ
 mFw
@@ -50182,18 +50042,18 @@ dpY
 dpY
 dpY
 dpY
-dpY
+dkX
 dpY
 eAd
 aHp
 aHp
-dpY
-dkX
-hgl
 acq
 fMh
-uKp
-cxv
+dpY
+coF
+jHd
+nWL
+wXN
 vZK
 wXN
 ttb
@@ -50201,36 +50061,36 @@ ecW
 tzk
 aWk
 dpY
-pEN
+mvs
 qOa
 uCj
 mUU
-pEN
+lXB
 onC
 ejJ
 mHW
-kly
+lAT
 fom
 oOM
-dLo
+mvs
 pyV
-pgh
-pgh
+xGl
+xGl
 tBj
-hGT
-hUf
-cNy
-hUf
-gbM
-wXr
-bUW
-ayg
-xdN
-gbM
-hUf
+xGl
+xGl
+gAS
+pdj
+uDl
+xvv
+bOC
+iku
+kmh
+xvv
+vAn
 pbe
-hUf
-ekx
+vAn
+dhv
 vyJ
 vyJ
 xSV
@@ -50241,7 +50101,7 @@ oHw
 sKH
 nVl
 mMA
-ekx
+dhv
 eLq
 dWU
 eLq
@@ -50438,18 +50298,18 @@ iXU
 kML
 iXU
 ktn
-nYk
-fwq
-fwq
-fwq
-fwq
-gRV
 dKF
 feK
-hSb
+dKF
+dpY
+dpY
+dpY
 kLu
 eaH
-uKp
+dpY
+teh
+pLD
+pLD
 rzP
 pdC
 vzd
@@ -50458,36 +50318,36 @@ gcM
 tzk
 aWk
 dpY
-pEN
-ykH
-fYT
-jrk
-pEN
+nRz
+mvs
+mvs
+mvs
+mvs
+mvs
+mvs
 dTh
-nRH
-gQY
 lqS
-mvs
-mvs
-dLo
-dLo
-xyS
-xyS
-qPq
-dLo
-ekk
-pXr
+gQY
+dTh
+nRz
+pdj
+pdj
+pdj
+qOJ
+pdj
+pdj
+pdj
 qRY
 gbM
-gbM
-gbM
-gbM
-gbM
-gbM
-ekk
-eel
-ekk
-ekx
+xvv
+kmh
+fXd
+xvv
+xvv
+vAn
+pbe
+vAn
+dhv
 vyJ
 vyJ
 xSV
@@ -50498,7 +50358,7 @@ rqz
 qTD
 ibZ
 wes
-ekx
+dhv
 tpU
 ngO
 tpU
@@ -50695,56 +50555,56 @@ iPQ
 tyN
 sMF
 pLk
-uKp
-mJL
-osb
-dJS
-rrp
-tzk
 dpY
 dEC
 eAd
+dpY
+dpY
+dpY
 hap
 uxC
-uKp
-lGg
-ndA
-taE
+dpY
+hgl
+vGX
+wXr
+hoP
+rkO
 pAM
+koA
 cvV
 tzk
 aWk
 dpY
-fsp
-pEN
-pEN
-pEN
-pEN
-pFn
+eiU
+vAn
+vAn
+vAn
+vAn
+vAn
 fDJ
+vAn
+vAn
+vhl
+pZF
 vAn
 swv
 vAn
-pZF
 vAn
 vAn
 vAn
 vAn
-pZF
 vAn
-vAn
+swv
 rZh
 vAn
 vAn
 vAn
 vAn
-swv
-vmD
-vmD
-vmD
-acn
-jDL
-ekx
+vAn
+vAn
+pbe
+hGT
+dhv
 vyJ
 vyJ
 xSV
@@ -50755,7 +50615,7 @@ xyG
 tfJ
 vDr
 aYW
-ekx
+dhv
 xEX
 bjo
 yaz
@@ -50952,19 +50812,19 @@ srb
 tyN
 iPO
 ovT
-diD
-phr
-kdC
-mEd
-bWg
-yjj
+uCO
+uCO
+uCO
+uCO
+uCO
+uCO
 uCO
 uCO
 lcE
 kNb
 uCO
 tjl
-jCb
+mgM
 jCb
 jCb
 jCb
@@ -50978,27 +50838,27 @@ vgo
 vgo
 vgo
 vgo
-shx
+vgo
+vgo
 vgo
 hrA
-kmh
 wvV
 vgo
-vgo
+swO
 fzt
 vGG
 vGG
 vGG
 vGG
-jMP
+psq
+kMo
+aqp
 vGG
 vGG
-vGG
-vGG
-wNF
-mxT
 iZb
-niH
+vGG
+iZb
+vgo
 mWu
 rXa
 sbN
@@ -51207,14 +51067,14 @@ dpY
 dpY
 trj
 tyN
-xSN
+sMF
 mzs
-uKp
-vYo
-ctR
-njf
-qtr
-duy
+dpY
+dpY
+dpY
+gpx
+dpY
+nYk
 fwq
 fwq
 qMR
@@ -51223,7 +51083,7 @@ dpY
 dpY
 dpY
 dpY
-gpx
+dpY
 dpY
 dpY
 dpY
@@ -51237,27 +51097,27 @@ wLx
 wLx
 vAn
 vAn
-swv
+vAn
 bYG
 mXR
 vAn
-vAn
+swv
 vAn
 wII
 vAn
 vAn
 wII
 vvV
+swv
+vAn
+vAn
 bYG
 vAn
-vAn
 wII
-swv
-jQT
-vmD
-vmD
+vAn
+vAn
 upQ
-vmD
+vAn
 sSz
 lcL
 xYJ
@@ -51466,12 +51326,12 @@ gek
 llC
 gek
 ycD
-lXN
-arI
-arI
-arI
-arI
-mpj
+dpY
+dpY
+dpY
+dpY
+dpY
+uKp
 gmQ
 dpY
 icg
@@ -51512,10 +51372,10 @@ hhf
 lxK
 hhf
 hhf
-vmD
+vAn
 upQ
-tVF
-ekx
+eMx
+vMr
 vMr
 vMr
 vMr
@@ -51526,7 +51386,7 @@ vMr
 vMr
 vMr
 vMr
-ekx
+vMr
 dNg
 cYi
 eUg
@@ -51723,27 +51583,27 @@ dpY
 dpY
 dpY
 dpY
-dpY
+bld
 sBh
 bld
-dpY
-dpY
-uKp
+bld
+bld
+lUS
 dpY
 dpY
 dpY
 lXb
 dpY
-nYk
-pqC
-kwS
-rzU
-tRG
-vDH
-lCb
-bbl
-orC
-mXm
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
 sPS
 cHE
 wYz
@@ -51769,21 +51629,21 @@ pJi
 ooM
 iYg
 fQO
-vmD
+vAn
 upQ
-vmD
-ekx
+vAn
+vMr
 wOa
 hwp
 pks
-wOa
+kwh
 xUi
 wOa
 wOa
 pks
 hwp
 wOa
-ekx
+vMr
 rtf
 uCk
 rtf
@@ -51990,17 +51850,17 @@ nyF
 nyF
 kfB
 gup
-dpY
-oGN
-kDx
-kDx
-tHk
-csW
-csW
-csW
-csW
-csW
-pLD
+fFw
+jMP
+pke
+aqn
+xJe
+xJe
+xJe
+xJe
+tTW
+sVI
+pfU
 qNE
 lBs
 kWc
@@ -52026,10 +51886,10 @@ iYf
 roD
 mzh
 wff
-vmD
+vAn
 upQ
-vmD
-ekx
+vAn
+vMr
 wOa
 wOa
 wOa
@@ -52040,7 +51900,7 @@ fnS
 wOa
 wOa
 wOa
-ekx
+vMr
 eLq
 iNk
 eLq
@@ -52247,9 +52107,7 @@ kDx
 kDx
 hFZ
 qPc
-dpY
-oGN
-pwj
+nwX
 tHk
 nzB
 kDx
@@ -52258,6 +52116,8 @@ kDx
 kDx
 kDx
 cxw
+vPk
+aHp
 ubU
 gMb
 gMb
@@ -52283,10 +52143,10 @@ svo
 xfu
 xvF
 wff
-vmD
+vAn
 upQ
-vmD
-ekx
+vAn
+vMr
 xQT
 lSr
 lSr
@@ -52297,7 +52157,7 @@ vMr
 xQT
 lSr
 lSr
-ekx
+vMr
 bfc
 lon
 bfc
@@ -52504,9 +52364,7 @@ csW
 csW
 lGv
 qPc
-dpY
-oGN
-kDx
+nwX
 cfw
 kDx
 kDx
@@ -52515,6 +52373,8 @@ kDx
 kDx
 kDx
 cxw
+vPk
+igh
 ubU
 gMb
 gMb
@@ -52542,10 +52402,10 @@ krn
 hhf
 kjA
 upQ
-vmD
-ekx
+vAn
+vMr
 cyn
-fvA
+mgE
 hqb
 vMr
 wOa
@@ -52554,7 +52414,7 @@ vMr
 cyn
 fvA
 hqb
-ekx
+vMr
 vmD
 vwk
 vmD
@@ -52761,17 +52621,17 @@ kDx
 kDx
 cxw
 qPc
-xOg
-oGN
-pwj
+nwX
 cfw
 kDx
 kDx
-tTR
+wWG
 kDx
 kDx
 kDx
 cxw
+vPk
+cRX
 uzm
 gMb
 gMb
@@ -52797,10 +52657,10 @@ buM
 buM
 hhf
 hhf
-fUs
+pZE
 upQ
-tVF
-ekx
+eMx
+vMr
 bjJ
 azH
 rsk
@@ -52811,7 +52671,7 @@ vMr
 bjJ
 azH
 dvZ
-ekx
+vMr
 fUs
 vwk
 vmD
@@ -53003,7 +52863,7 @@ uud
 tyN
 bxX
 aFJ
-kDx
+rbo
 kDx
 kDx
 kDx
@@ -53018,9 +52878,7 @@ kDx
 kDx
 kwo
 qPc
-dpY
-oGN
-kDx
+nwX
 cfw
 kDx
 kDx
@@ -53029,6 +52887,8 @@ kDx
 kDx
 kDx
 cxw
+vPk
+kDx
 ubU
 gMb
 gMb
@@ -53058,17 +52918,17 @@ uOz
 upQ
 cwA
 xar
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
-ekx
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
+vMr
 vmD
 vwk
 vmD
@@ -53275,9 +53135,7 @@ kDx
 kDx
 cxw
 qPc
-dpY
-oGN
-pwj
+nwX
 nbW
 qWy
 kDx
@@ -53286,6 +53144,8 @@ kDx
 kDx
 kDx
 cxw
+vPk
+kDx
 ubU
 gMb
 gMb
@@ -53532,17 +53392,17 @@ kDx
 kDx
 kwo
 qPc
-dpY
-oGN
-kDx
-kDx
-nbW
-xDq
-xDq
-xDq
-xDq
-xDq
-wmy
+qfG
+jrk
+sAI
+xyS
+xyS
+xyS
+xyS
+xyS
+yki
+hdc
+hPp
 qNE
 dmm
 lht
@@ -53774,7 +53634,7 @@ wEZ
 tFM
 axK
 aKX
-nbW
+plO
 xDq
 xDq
 xDq
@@ -53790,16 +53650,16 @@ kDx
 cxw
 mxq
 dpY
-lXN
-tQa
-wWG
-sAl
-wWG
-sAl
-wWG
-sAl
-wWG
-tQa
+dpY
+dpY
+dpY
+dpY
+dpY
+dpY
+yfw
+kuc
+gpx
+dpY
 fXg
 eFA
 cHE
@@ -53815,8 +53675,8 @@ ljb
 xBe
 gqI
 heL
-mgE
 apO
+vIy
 oSs
 xWh
 hhf
@@ -54052,9 +53912,9 @@ dpY
 dpY
 dpY
 dpY
-dpY
-dpY
-dpY
+iyr
+qwO
+gjA
 dpY
 dpY
 faF
@@ -54302,36 +54162,36 @@ kDx
 kDx
 kDx
 cxw
-qPc
-dpY
-dpY
-dpY
-dpY
-xAG
-dpY
-dpY
-dpY
-dpY
-dpY
-dkW
+hYr
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+rWD
 aHG
-vAn
-vAn
-vAn
-vAn
-vAn
-vAn
-vAn
-vAn
-vAn
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
 hWt
-swv
-xeM
-pZF
-vAn
-tWD
-vAn
-vAn
+rKm
+ezh
+pvX
+vmD
+acn
+vmD
+vmD
 rAB
 vmD
 vmD
@@ -54560,35 +54420,35 @@ xDq
 xDq
 kWG
 nZU
-kHN
-gcr
+diD
+rWK
 xdE
+ykH
 pVB
-pVB
-pVB
-pVB
+vzN
+ykH
 pVB
 rCU
-ozU
+uMj
 uNt
 jOm
-vgo
-vgo
+niH
+niH
 kVt
 rWK
 bjC
 wXm
-vgo
-xZy
+niH
+qQf
 ndN
 qQf
 iRM
-xZy
+qQf
 ixx
 eNP
-vgo
-xZy
-psq
+niH
+qQf
+lSY
 lHS
 mxT
 mxT
@@ -54817,35 +54677,35 @@ kDx
 kDx
 hFZ
 oZN
-tyN
-qOJ
-fFw
-eFo
-eFo
-eFo
-eFo
-eFo
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
 hmO
-gKv
-aoJ
-vAn
-nvH
-dzr
-hWt
-hNd
-vAn
-vAn
-vAn
-vAn
-vAn
-wqZ
-swv
-wII
-vAn
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+rKm
+jQT
+vmD
 mhJ
-vAn
-vAn
-vAn
+euc
+qor
+vmD
 rAB
 jQT
 vmD
@@ -54861,13 +54721,13 @@ qhf
 tkW
 pGb
 kHp
-pGb
+oAz
 pGb
 qhf
 hme
 gxL
 mNM
-pGb
+oAz
 kHp
 pGb
 pyS
@@ -55057,7 +54917,7 @@ lET
 tyN
 rYr
 tyN
-urD
+vGQ
 lXN
 skU
 fmN
@@ -55074,36 +54934,36 @@ fmN
 fmN
 lHG
 fku
-tyN
-swO
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-pqQ
-xLu
-fAJ
-fAJ
-fAJ
-fAJ
-kVD
-cTx
-xvv
-xjD
-xvv
-xvv
-xvv
-fQR
-rUF
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+lVR
+kGc
+bbl
+vyj
+eQb
+tlT
+mBc
 rUF
 rUF
 xZt
 rUF
 rUF
 rUF
-rUF
+mBc
 rUF
 rUF
 nDF
@@ -55331,28 +55191,28 @@ dpY
 dpY
 dpY
 qvN
-tyN
-lSb
-rXB
-eFo
-eFo
-lpt
-eFo
-eFo
-xVO
-xLu
-xJe
-iku
-plO
-fAJ
-rWD
-cTx
-xvv
-kWM
-kWM
-kWM
-xvv
-miU
+vmD
+vmD
+vmD
+vmD
+rug
+vmD
+vmD
+vmD
+vmD
+rug
+vmD
+vmD
+vmD
+rug
+vmD
+vmD
+hTV
+eQb
+uej
+lhT
+eQb
+eQb
 rUF
 vVG
 cPg
@@ -55588,28 +55448,28 @@ eFh
 kHN
 eFh
 nPF
-tyN
-vGQ
-rXB
-eFo
-eFo
-eFo
-eFo
-eFo
-pke
-xLu
-sAI
-sAI
-ebu
-dXO
-xvv
-cTx
-xvv
-kHT
-roN
-nIG
-xvv
-tpi
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+tqD
+bWg
+xdN
+fTZ
+tFb
+kGc
 rUF
 bJB
 bRc
@@ -55646,7 +55506,7 @@ hGE
 rUF
 xuy
 sjY
-pGb
+oAz
 syR
 fAy
 mqK
@@ -55845,28 +55705,28 @@ vou
 vou
 vou
 vou
-vou
-rCb
-iIe
-eFo
-eFo
-eFo
-eFo
-eFo
-rbo
-xLu
-fAJ
-fAJ
-ebu
-fAJ
-vyj
-cTx
-xvv
-bbw
-uzy
-tbT
-xvv
+pqC
+ekx
+ekx
+ekx
+ekx
+ekx
+ekx
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
 miU
+waC
+oOX
+gYa
+pgh
+vDH
 rUF
 xWS
 mRy
@@ -56103,24 +55963,24 @@ vou
 mds
 thc
 vou
-vGQ
-vGQ
-eXp
-fsZ
-eXp
-fsZ
-cRX
-vGQ
-xLu
-xSi
-eSw
-hoP
-fAJ
-aEk
-cTx
-xvv
+eQW
+xSN
+xSN
+xSN
+kdC
+ekx
+jUP
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+cKB
 eKC
-kWM
+fGV
 bLP
 eQb
 fqj
@@ -56360,27 +56220,27 @@ gKG
 shB
 mJw
 vou
-xLu
-eZp
-xLu
-xLu
-xLu
-xLu
-xLu
-eZp
-xLu
-fAJ
-fAJ
-fAJ
-fAJ
-tlT
-kMo
-tlT
-pdj
-pdj
-pdj
-pdj
-rUF
+fsZ
+fXX
+njf
+fXX
+vmD
+xQB
+dlz
+vmD
+rug
+vmD
+vmD
+vmD
+rug
+vmD
+vmD
+iay
+ciN
+ndA
+eel
+eQb
+tpi
 rUF
 nIn
 vfL
@@ -56617,27 +56477,27 @@ vou
 vou
 vou
 vou
-vXQ
 fpg
-rSr
-rOV
-vGX
-uXw
-rSr
 fpg
-xLu
-pSt
-tCO
-aJH
-hPp
-aqp
-gSN
-pfU
-bFG
-kpI
+vmD
+vmD
+vmD
+ekx
+dzr
+dzr
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
+vmD
 cRE
-giN
-rUF
+vmD
+vmD
+cRE
+vmD
+vmD
 rUF
 dPp
 vfL
@@ -56874,35 +56734,35 @@ gKG
 mvX
 fgN
 vou
-vXQ
-vXQ
-gBQ
-vXQ
-vXQ
-vXQ
-gBQ
-vXQ
-xLu
-xGl
-xGl
-xGl
-xGl
+ekx
+ekx
+vmD
+ekx
+ekx
+ekx
+luk
+kDL
+ekx
 mOo
-xvv
-iSK
-xGl
-xGl
-xGl
-xGl
-uyy
-uyy
+oGN
+oGN
+oGN
+ezY
+oGN
+mOo
+mXm
+mXm
+mXm
+mXm
+mXm
+hEc
 uyy
 cBw
 uyy
 uyy
 uyy
 rUF
-rUF
+mBc
 ncg
 bSp
 cPg
@@ -57131,29 +56991,29 @@ vou
 nIj
 mds
 vou
-vXQ
+jfb
 xQB
 wrW
-iFw
-mJG
-ifT
-wrW
 xQB
+byk
+ekx
+vcJ
+ugL
+ekx
+rXB
+eFo
+eFo
+eFo
+eFo
+eFo
+kCs
+mXm
 xLu
-xGl
-xGl
-xGl
-xGl
-mOo
-fTZ
-iSK
-xGl
-xGl
-xGl
-xGl
+xLu
+gcd
+xLu
 uyy
 uNy
-hGq
 bTj
 eEZ
 vvz
@@ -57167,7 +57027,7 @@ eMJ
 hxc
 cPg
 bYP
-xLV
+rDn
 eMz
 eMz
 pWo
@@ -57388,29 +57248,29 @@ vou
 vou
 vou
 vou
+ekx
+ekx
+fsp
+ekx
+ekx
+ekx
+ekx
+ekx
+mpj
+rXB
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
+mXm
 xLu
-xLu
-xLu
-qjj
-xLu
-qjj
-xLu
-xLu
-xLu
-kCs
-ygV
-ygV
-ygV
-jOS
-iDE
-lXB
-ygV
-ygV
-ygV
-oOX
+uXw
+eZp
+sSW
 uyy
 sKv
-rSW
 qVH
 qyx
 faC
@@ -57653,21 +57513,21 @@ hUz
 hUz
 hUz
 pQt
-rKn
-xGl
-xGl
-xGl
-xGl
-mOo
-pgq
-iSK
-xGl
-xGl
-xGl
-xGl
+ycz
+rXB
+eFo
+eFo
+lpt
+eFo
+eFo
+gcr
+mXm
+xLu
+rOV
+vXQ
+qtr
 uyy
 cSz
-gYa
 bHF
 tzF
 vFb
@@ -57911,18 +57771,18 @@ cuG
 esN
 unX
 rKn
-xGl
-xGl
-xGl
-kKd
-mOo
-pgq
-iSK
-xGl
-xGl
-xGl
-rrj
-uyy
+rXB
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
+xLu
+xLu
+uEg
+vXQ
+eSw
 uyy
 uyy
 uyy
@@ -57931,7 +57791,7 @@ uyy
 uyy
 nJG
 nJG
-nJG
+nNV
 bSp
 mng
 xmJ
@@ -58166,20 +58026,20 @@ nWT
 nWT
 nWT
 esN
-byk
-ycz
-ygV
-ygV
-ygV
-ygV
-aBm
-xvv
-lXB
-ygV
-ygV
-ygV
-oOX
-nJG
+unX
+rKn
+rXB
+eFo
+eFo
+eFo
+eFo
+eFo
+pqQ
+aAu
+vXQ
+gBQ
+vXQ
+xLu
 eJL
 hvM
 ibO
@@ -58425,18 +58285,18 @@ nWT
 esN
 unX
 rKn
-xGl
-xGl
-xGl
-kKd
-oAz
-pgq
-mSh
-xGl
-xGl
-xGl
-xGl
-nJG
+mOo
+eXp
+tXl
+eXp
+eXp
+eXp
+mOo
+xLu
+iFw
+ftY
+ifT
+xLu
 rPd
 hZe
 mmh
@@ -59731,7 +59591,7 @@ fmP
 jCY
 eTN
 nJG
-fRw
+eLs
 vAb
 gUW
 gXY
@@ -59743,7 +59603,7 @@ xBS
 qzp
 aSJ
 qzp
-mog
+hNd
 gfi
 cRJ
 aSJ
@@ -60001,7 +59861,7 @@ lEe
 aSJ
 dnw
 nMY
-ucj
+onk
 ktb
 aSJ
 qjf
@@ -60509,7 +60369,7 @@ fbC
 oUt
 aSJ
 bNl
-rqX
+nbu
 qqP
 ktb
 aSJ
@@ -61752,10 +61612,10 @@ qVo
 mBZ
 mBZ
 mBZ
-mBZ
-mBZ
-mBZ
-mBZ
+qVo
+qVo
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -62011,8 +61871,8 @@ mBZ
 qVo
 qVo
 qVo
-mBZ
-mBZ
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -62268,8 +62128,8 @@ mBZ
 qVo
 qVo
 qVo
-mBZ
-mBZ
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -62525,8 +62385,8 @@ mBZ
 qVo
 qVo
 qVo
-mBZ
-mBZ
+qVo
+qVo
 qVo
 qVo
 qVo
@@ -62782,8 +62642,8 @@ mBZ
 qVo
 qVo
 qVo
-mBZ
-mBZ
+qVo
+qVo
 qVo
 qVo
 qVo

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1232,6 +1232,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
 /area/mainship/living/briefing)
+"bAZ" = (
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/obj/item/paper/memorial,
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "bBk" = (
 /obj/structure/barricade/solid{
 	dir = 4
@@ -1450,8 +1455,10 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/obj/structure/prop/flag,
-/turf/open/floor/grass,
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
 /area/mainship/hallways/starboard_hallway)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
@@ -1667,7 +1674,7 @@
 /area/mainship/command/self_destruct)
 "bWg" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 5
+	dir = 9
 	},
 /area/mainship/hallways/starboard_hallway)
 "bWq" = (
@@ -2079,7 +2086,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "cBW" = (
@@ -2110,12 +2116,6 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
-"cDG" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
-	},
-/area/mainship/hallways/starboard_hallway)
 "cDN" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -2385,7 +2385,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "cXa" = (
@@ -3660,6 +3659,7 @@
 	id = "vehicle_elevator_railing"
 	},
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "eAd" = (
@@ -3815,9 +3815,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/prop/flag,
 /turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
+/area/mainship/hallways/starboard_hallway)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
@@ -3963,10 +3963,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
-"eTF" = (
-/obj/item/grown/sunflower,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "eTN" = (
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
@@ -4869,8 +4865,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "fTZ" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/mainship/terragov/north{
-	dir = 9
+	dir = 6
 	},
 /area/mainship/hallways/starboard_hallway)
 "fUs" = (
@@ -5729,9 +5726,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
@@ -6404,7 +6401,7 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/mainship/living/tankerbunks)
 "hUf" = (
@@ -6492,11 +6489,6 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
-"hYV" = (
-/obj/structure/flora/tree/dead,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "hZe" = (
 /turf/open/floor/plating/mainship/striped{
@@ -7454,6 +7446,10 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"jti" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -9679,6 +9675,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"lYk" = (
+/obj/item/grown/sunflower,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "lYE" = (
 /obj/machinery/door_control/old/medbay{
 	id = "Medbay";
@@ -11318,12 +11318,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"ocu" = (
-/obj/item/clothing/head/modular/marine,
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
-/area/mainship/hallways/starboard_hallway)
 "ocE" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -11658,6 +11652,7 @@
 /obj/machinery/door/poddoor/railing{
 	id = "vehicle_elevator_railing"
 	},
+/obj/structure/cable,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "oGO" = (
@@ -12350,6 +12345,11 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
+"pwX" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "pya" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -13636,6 +13636,11 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"qWG" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/mainship/hallways/starboard_hallway)
 "qXc" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 5;
@@ -15688,6 +15693,10 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"tIO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "tJA" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16004,6 +16013,11 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
+"ucK" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "udd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/mainship{
@@ -16435,6 +16449,10 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"uDG" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "uEg" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/wood,
@@ -16911,7 +16929,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
 "vhG" = (
@@ -17519,10 +17536,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/obj/item/paper/memorial,
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
@@ -53835,7 +53854,7 @@ dpY
 dpY
 dpY
 dpY
-iyr
+dpY
 qwO
 gjA
 dpY
@@ -54094,7 +54113,7 @@ vmD
 vmD
 vmD
 vmD
-vmD
+jti
 vmD
 rWD
 aHG
@@ -54611,7 +54630,7 @@ vmD
 hmO
 vmD
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
@@ -54868,11 +54887,11 @@ vmD
 vmD
 vmD
 vmD
+hWt
 vmD
 vmD
 vmD
-vmD
-bLP
+eKC
 lVR
 kGc
 bbl
@@ -55125,7 +55144,7 @@ vmD
 vmD
 rug
 vmD
-vmD
+hWt
 vmD
 rug
 vmD
@@ -55382,16 +55401,16 @@ vmD
 vmD
 vmD
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
 eel
 pgh
 vDH
-fTZ
+bWg
 xdN
-ocu
+bLP
 tqD
 rUF
 bJB
@@ -55639,16 +55658,16 @@ vmD
 vmD
 vmD
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
 miU
 eQb
 fqj
-gYa
+pwX
 oOX
-waC
+bAZ
 miU
 rUF
 xWS
@@ -55896,16 +55915,16 @@ jUP
 vmD
 vmD
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
 tpi
 eQb
 kGc
-bWg
+qWG
 fGV
-cDG
+fTZ
 cKB
 rUF
 hWC
@@ -56153,7 +56172,7 @@ dlz
 vmD
 rug
 vmD
-vmD
+hWt
 vmD
 rug
 vmD
@@ -56162,7 +56181,7 @@ iay
 ciN
 tpi
 eel
-eTF
+lYk
 tpi
 rUF
 nIn
@@ -56410,7 +56429,7 @@ dzr
 dzr
 vmD
 vmD
-vmD
+hWt
 vmD
 vmD
 vmD
@@ -56419,7 +56438,7 @@ cRE
 miU
 tpi
 miU
-hYV
+gYa
 cRE
 rUF
 dPp
@@ -56672,12 +56691,12 @@ oGN
 oGN
 ezY
 oGN
-mOo
+ucK
+uDG
 mXm
-mXm
-eKC
-eKC
 hTV
+hTV
+tIO
 hEc
 uyy
 cBw
@@ -56930,7 +56949,7 @@ eFo
 eFo
 eFo
 kCs
-mXm
+uDG
 xLu
 xLu
 gcd
@@ -57187,7 +57206,7 @@ eFo
 eFo
 eFo
 pqQ
-mXm
+uDG
 xLu
 uXw
 eZp
@@ -57444,7 +57463,7 @@ lpt
 eFo
 eFo
 gcr
-mXm
+waC
 xLu
 rOV
 vXQ

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -47,13 +47,13 @@
 /area/mainship/engineering/upper_engineering)
 "adg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/stack/conveyor/thirty,
 /obj/structure/rack,
 /obj/item/conveyor_switch_construct,
-/obj/item/tool/crowbar,
 /obj/item/paper/factoryhowto,
 /obj/item/tool/wrench,
+/obj/item/stack/conveyor/thirty,
 /obj/item/tool/screwdriver,
+/obj/item/tool/crowbar,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -2078,7 +2078,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "czH" = (
@@ -2342,7 +2341,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/vending/MarineMed,
+/obj/machinery/vending/weapon,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -2808,17 +2807,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "dmU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
 /area/mainship/squads/req)
 "dnw" = (
 /obj/structure/bed/bunkbed,
@@ -2837,7 +2830,6 @@
 /area/mainship/medical/lower_medical)
 "doG" = (
 /obj/structure/table/mainship/nometal,
-/obj/machinery/computer/supplydrop_console,
 /turf/open/floor/mainship/green{
 	dir = 1
 	},
@@ -3287,10 +3279,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "dUt" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/marine/requisitions{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
@@ -3399,9 +3401,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/machinery/quick_vendor/beginner,
 /turf/open/floor/mainship/black{
@@ -3698,14 +3697,12 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/mechpilotquarters)
 "exV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/tool/weldpack,
+/obj/item/tool/weldpack,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "eye" = (
@@ -3858,8 +3855,25 @@
 	},
 /area/mainship/living/commandbunks)
 "eGl" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/mainship,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/stack/conveyor,
+/obj/item/tool/screwdriver,
+/obj/item/tool/crowbar,
+/obj/item/tool/wrench,
+/obj/item/conveyor_switch_construct,
+/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "eGs" = (
 /obj/structure/target_stake,
@@ -3941,6 +3955,17 @@
 /obj/effect/landmark/corpsespawner/prisoner/regular,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"eLx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "eLM" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/white{
@@ -5500,6 +5525,8 @@
 /area/mainship/command/cic)
 "gsM" = (
 /obj/machinery/vending/cargo_supply,
+/obj/item/tool/wirecutters,
+/obj/item/tool/screwdriver,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -5603,6 +5630,17 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"gDg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/plasticflaps/sturdy,
+/turf/open/floor/mainship/mono,
+/area/mainship/squads/req)
 "gES" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -6285,7 +6323,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "hzD" = (
-/obj/machinery/vending/weapon,
+/obj/machinery/computer/camera_advanced/overwatch/req,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -6786,7 +6824,7 @@
 /obj/structure/table/mainship/nometal,
 /obj/item/stack/barbed_wire/half_stack,
 /obj/item/tool/crowbar,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "igO" = (
 /obj/item/trash/cigbutt,
@@ -11338,7 +11376,7 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/obj/machinery/vending/marineFood,
+/obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -11618,10 +11656,10 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
 "ocK" = (
-/obj/machinery/light/mainship{
-	light_color = "#da2f1b"
+/obj/structure/plasticflaps/sturdy,
+/turf/open/floor/mainship/green{
+	dir = 1
 	},
-/turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "oda" = (
 /obj/structure/sink{
@@ -12601,10 +12639,11 @@
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "prY" = (
-/obj/machinery/computer/camera_advanced/overwatch/req,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
+/obj/machinery/computer/supplydrop_console,
+/obj/structure/table/mainship/nometal,
 /turf/open/floor/mainship/green{
 	dir = 9
 	},
@@ -14212,13 +14251,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "rpv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
@@ -15969,13 +16006,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "tCJ" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/tool/weldpack,
-/obj/item/tool/weldpack,
-/obj/item/tool/wirecutters,
-/obj/item/tool/screwdriver,
+/obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -19489,9 +19520,13 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "xHi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/status_display,
-/turf/closed/wall/mainship,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id = "qm_warehouse";
+	name = "\improper Warehouse Shutters"
+	},
+/obj/structure/plasticflaps/sturdy,
+/turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "xHU" = (
 /turf/open/floor/mainship/orange{
@@ -51316,8 +51351,8 @@ vgo
 vgo
 vgo
 hrA
-wvV
 vgo
+wvV
 swO
 fzt
 vGG
@@ -51573,8 +51608,8 @@ vAn
 vAn
 vAn
 bYG
-mXR
 vAn
+mXR
 swv
 vAn
 wII
@@ -51827,10 +51862,10 @@ wYz
 xfo
 wYz
 cHE
-ocK
+cHE
 lxK
-hhf
-dmU
+fQO
+cHE
 dUt
 hhf
 hhf
@@ -52085,10 +52120,10 @@ wYz
 wYz
 cHE
 peH
-eGl
+hhf
 prY
-moP
 ekT
+moP
 hzD
 cSp
 nMG
@@ -52342,14 +52377,14 @@ xKE
 kWc
 kWc
 xkF
-xHi
+hhf
 doG
 rpv
+eLx
 iYf
 iYf
 iYf
-iYf
-iYf
+exV
 osF
 hXJ
 cCZ
@@ -52599,9 +52634,9 @@ gMb
 gMb
 gMb
 nAM
-xbi
+xHi
 iiU
-vcN
+gDg
 uIy
 syt
 syt
@@ -52857,8 +52892,8 @@ gMb
 gMb
 nAM
 xbi
-qKL
-vcN
+ocK
+eGl
 xjF
 gUa
 gUa
@@ -53115,8 +53150,8 @@ gMb
 otn
 xZo
 cim
-exV
-xjF
+vcN
+dmU
 gUa
 gUa
 gUa
@@ -54124,9 +54159,9 @@ kDx
 cxw
 mxq
 dpY
+dpY
 pfU
 dpY
-igh
 pCc
 dpY
 dpY
@@ -54381,11 +54416,11 @@ kDx
 kwo
 qPc
 dpY
+dpY
 aHp
 dpY
+igh
 cjl
-dpY
-dpY
 dpY
 dpY
 dpY
@@ -54915,7 +54950,7 @@ wXm
 niH
 qQf
 ndN
-qQf
+ndN
 iRM
 qQf
 ixx
@@ -55148,8 +55183,8 @@ kDx
 kDx
 kDx
 kDx
-kDx
 hFZ
+kDx
 oZN
 vmD
 vmD

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -20,7 +20,7 @@
 /obj/machinery/air_alarm{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "acn" = (
 /obj/machinery/camera/autoname/mainship{
@@ -142,6 +142,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"akL" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "akW" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -178,6 +184,14 @@
 "amG" = (
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hull/lower_hull)
+"amQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "anb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -408,6 +422,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/orange/full,
 /area/mainship/living/briefing)
+"aDK" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "aDU" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -586,7 +605,10 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/yellow_cargo,
+/obj/effect/turf_decal/warning_stripes/box/empty,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "aLV" = (
 /obj/machinery/light/mainship{
@@ -607,7 +629,8 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/obj/effect/turf_decal/warning_stripes/box/empty,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/squads/general)
 "aME" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -645,6 +668,10 @@
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
+"aPv" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange,
+/area/mainship/squads/general)
 "aPM" = (
 /obj/structure/ship_ammo/cas/rocket/keeper,
 /turf/open/floor/mainship/cargo,
@@ -712,12 +739,12 @@
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
 "aSw" = (
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/light/mainship,
+/turf/open/floor/mainship/sterile/purple/side,
+/area/mainship/medical/chemistry)
 "aSJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
@@ -880,10 +907,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "baH" = (
-/obj/structure/bed/chair/office/dark,
-/obj/item/paper/chemistry,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "bbl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -1226,16 +1254,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "bzT" = (
-/obj/machinery/light/mainship{
-	dir = 1
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 5
 	},
-/obj/structure/sink{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/area/mainship/squads/general)
 "bAT" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
@@ -1485,6 +1508,12 @@
 	},
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
+"bNf" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "bNh" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1585,7 +1614,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "bRC" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -1603,7 +1634,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "bSp" = (
 /obj/structure/cable,
@@ -1784,7 +1817,7 @@
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/food_or_drink/sugary_snack,
 /obj/effect/spawner/random/food_or_drink/bread,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "cei" = (
 /obj/structure/disposalpipe/segment,
@@ -1837,6 +1870,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"cfP" = (
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "chD" = (
 /obj/item/toy/plush/carp,
 /turf/open/space/basic,
@@ -1865,8 +1902,9 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cjl" = (
-/obj/machinery/marine_selector/gear/smartgun,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
 /area/mainship/squads/general)
 "cjC" = (
 /turf/open/floor/mainship/yellow_cargo,
@@ -2330,7 +2368,9 @@
 /area/mainship/engineering/engineering_workshop)
 "cSy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "cSz" = (
 /obj/structure/cable,
@@ -2372,6 +2412,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/reagent_containers/food/snacks/popcorn,
 /turf/open/floor/mainship/sterile/side{
 	dir = 5
 	},
@@ -2541,6 +2582,11 @@
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"dcT" = (
+/turf/open/floor/mainship/yellow_cargo/arrow{
+	dir = 8
+	},
+/area/mainship/hallways/aft_hallway)
 "dcY" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -2689,7 +2735,7 @@
 	dir = 2
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "dkW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -2856,7 +2902,10 @@
 /obj/structure/sign/poster{
 	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/obj/effect/turf_decal/warning_stripes/box/empty,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "duo" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -2928,6 +2977,15 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating,
 /area/mainship/command/telecomms)
+"dAf" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "dBm" = (
 /obj/structure/table/wood,
 /obj/item/toy/deck/kotahi,
@@ -3162,6 +3220,12 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
+"dOT" = (
+/obj/machinery/marine_selector/gear/engi,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "dPp" = (
 /obj/machinery/marine_selector/clothes/commander,
 /turf/open/floor/mainship,
@@ -3500,9 +3564,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "ekh" = (
-/obj/machinery/marine_selector/gear/smartgun,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "ekk" = (
 /obj/effect/turf_decal/warning_stripes/thick{
@@ -3549,7 +3612,7 @@
 /area/mainship/engineering/port_atmos)
 "elQ" = (
 /obj/structure/sign/poster,
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "emg" = (
 /turf/closed/wall/mainship/research/containment/wall/purple{
@@ -3686,6 +3749,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
+"ezf" = (
+/obj/machinery/marine_selector/clothes/leader,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "ezh" = (
 /obj/machinery/firealarm{
 	dir = 4
@@ -3830,13 +3897,19 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 8;
-	name = "\improper Medical Storage Airlock"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "eHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3846,8 +3919,7 @@
 /area/mainship/engineering/engineering_workshop)
 "eIM" = (
 /obj/machinery/camera/autoname/mainship,
-/obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "eJJ" = (
 /obj/machinery/light/mainship{
@@ -3949,9 +4021,6 @@
 /area/mainship/command/self_destruct)
 "ePj" = (
 /obj/structure/cable,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
@@ -4014,7 +4083,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
 "eTN" = (
-/turf/open/floor/mainship/red/full,
+/obj/structure/table/mainship/nometal,
+/obj/item/weapon/gun/shotgun/pump,
+/obj/item/ammo_magazine/handful/buckshot,
+/obj/item/ammo_magazine/handful/buckshot,
+/turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "eTR" = (
 /obj/structure/cable,
@@ -4047,7 +4120,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "eWJ" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -4273,6 +4346,11 @@
 	dir = 9
 	},
 /area/mainship/command/cic)
+"fhe" = (
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "fhi" = (
 /obj/machinery/light/red{
 	dir = 1
@@ -4306,6 +4384,12 @@
 /obj/machinery/air_alarm,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"fld" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "flk" = (
 /obj/machinery/door_control/ai/exterior{
 	dir = 4
@@ -4418,6 +4502,20 @@
 /obj/structure/sign/prop4,
 /turf/closed/wall/mainship,
 /area/mainship/living/cryo_cells)
+"fpZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/earmuffs,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/ammo_magazine/revolver/standard_revolver,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/gloves/marine/fingerless,
+/obj/item/weapon/gun/revolver/standard_revolver,
+/obj/item/clothing/head/tgmcberet/red,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "fqj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/bed/stool{
@@ -4475,7 +4573,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/platebotc,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "ftY" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/misc/table_lighting,
@@ -4625,7 +4723,7 @@
 "fAy" = (
 /obj/structure/table/mainship/nometal,
 /obj/effect/spawner/random/food_or_drink/sugary_snack,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "fAJ" = (
 /turf/closed/wall/mainship,
@@ -4704,7 +4802,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/weapon,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "fFd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4769,7 +4869,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue,
 /area/mainship/squads/general)
 "fHl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4827,7 +4927,9 @@
 /area/mainship/hallways/starboard_hallway)
 "fKK" = (
 /obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "fLM" = (
 /obj/structure/window/reinforced{
@@ -4858,6 +4960,17 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"fMB" = (
+/obj/structure/cable,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/chemistry{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/medical/lower_medical)
 "fNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4896,7 +5009,7 @@
 /obj/machinery/light/mainship{
 	dir = 4
 	},
-/obj/machinery/marine_selector/clothes/leader,
+/obj/effect/turf_decal/warning_stripes/box/empty,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "fPM" = (
@@ -4923,12 +5036,17 @@
 /turf/open/shuttle/escapepod/six,
 /area/mainship/command/self_destruct)
 "fTy" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
+"fTH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "fTZ" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship/small{
@@ -5022,10 +5140,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "fZX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -5085,7 +5203,7 @@
 /obj/effect/ai_node,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "gbc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5477,7 +5595,7 @@
 /area/mainship/shipboard/brig)
 "gxL" = (
 /obj/machinery/marine_selector/clothes/engi,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/orange,
 /area/mainship/squads/general)
 "gze" = (
 /obj/effect/ai_node,
@@ -5505,6 +5623,7 @@
 /obj/item/tool/crowbar,
 /obj/item/tool/wrench,
 /obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
@@ -5538,11 +5657,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
 /area/mainship/squads/general)
 "gFW" = (
 /obj/machinery/marine_selector/gear/engi,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "gGb" = (
 /obj/structure/table/mainship/nometal,
@@ -5979,6 +6102,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/item/trash/barcaridine,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hlE" = (
@@ -6152,7 +6276,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/machinery/loadout_vendor,
+/obj/effect/turf_decal/warning_stripes/box/empty,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hvY" = (
@@ -6210,6 +6334,7 @@
 /area/mainship/squads/general)
 "hDi" = (
 /obj/structure/cable,
+/obj/effect/urban/decal/trash/fifteen,
 /turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
@@ -6248,7 +6373,7 @@
 "hGE" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/orange,
 /area/mainship/squads/general)
 "hGO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6383,7 +6508,7 @@
 /area/mainship/hull/lower_hull)
 "hPG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/yellow_cargo/arrow,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "hPQ" = (
 /obj/effect/ai_node,
@@ -6546,9 +6671,7 @@
 "hWC" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/blue{
-	dir = 4
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hWO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -6560,10 +6683,17 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
 "hYl" = (
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
 	},
-/area/mainship/medical/chemistry)
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "hYr" = (
 /obj/machinery/landinglight/cas{
 	dir = 1;
@@ -6689,6 +6819,12 @@
 /obj/item/tool/crowbar,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"igL" = (
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "igO" = (
 /obj/item/trash/cigbutt,
 /turf/open/floor/wood,
@@ -6734,7 +6870,7 @@
 /area/mainship/hallways/hangar/droppod)
 "ikM" = (
 /obj/machinery/vending/weapon,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "ilc" = (
 /obj/structure/rack,
@@ -6788,6 +6924,11 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
+"imE" = (
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
+/area/mainship/squads/general)
 "imJ" = (
 /obj/machinery/door/firedoor/mainship{
 	dir = 2;
@@ -6877,14 +7018,12 @@
 /turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "iuw" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
-/obj/structure/cable,
-/obj/machinery/light/mainship{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "iuG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6969,9 +7108,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
+/obj/effect/turf_decal/warning_stripes/box/arrow{
 	dir = 8
 	},
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "iCT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -7027,7 +7170,7 @@
 /area/mainship/living/tankerbunks)
 "iFI" = (
 /obj/machinery/marine_selector/clothes/smartgun,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "iHy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7078,7 +7221,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue/corner{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -7783,7 +7928,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "jPt" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
@@ -7963,8 +8108,8 @@
 /obj/structure/sign/prop1{
 	dir = 1
 	},
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/floor,
+/obj/machinery/marine_selector/gear/smartgun,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "kfm" = (
 /turf/open/floor/mainship/mono,
@@ -8091,17 +8236,6 @@
 /turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "ksb" = (
-/obj/machinery/firealarm{
-	dir = 8
-	},
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/rifle/m412,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
-/obj/item/ammo_magazine/rifle,
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
@@ -8398,6 +8532,17 @@
 /obj/machinery/status_display,
 /turf/closed/wall/mainship,
 /area/mainship/command/telecomms)
+"kHb" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/obj/structure/table/mainship/nometal,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/turf/open/floor/mainship/red,
+/area/mainship/shipboard/firing_range)
 "kHp" = (
 /obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/floor,
@@ -8641,9 +8786,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "kUV" = (
 /obj/machinery/power/apc/mainship/hardened,
@@ -8917,6 +9060,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"lki" = (
+/turf/open/floor/mainship/blue{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "lkD" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/mainship/mono,
@@ -9047,6 +9195,12 @@
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
 /area/mainship/living/tankerbunks)
+"lpB" = (
+/obj/machinery/marine_selector/clothes/medic,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/squads/general)
 "lqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9109,11 +9263,10 @@
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
 /obj/effect/spawner/random/engineering/extinguisher/miniweighted,
-/obj/effect/turf_decal/warning_stripes/thin{
-	dir = 4
-	},
 /obj/item/ammo_magazine/shotgun/blank,
-/turf/open/floor/mainship/red/full,
+/turf/open/floor/mainship/red{
+	dir = 6
+	},
 /area/mainship/shipboard/firing_range)
 "lue" = (
 /obj/machinery/camera/autoname/mainship{
@@ -9329,6 +9482,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
+"lFM" = (
+/obj/machinery/vending/medical/shipside,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "lGi" = (
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
@@ -9432,7 +9591,9 @@
 /area/mainship/engineering/engineering_workshop)
 "lJV" = (
 /obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "lJX" = (
 /obj/structure/sink{
@@ -9571,7 +9732,9 @@
 "lRs" = (
 /obj/machinery/marine_selector/gear/medic,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "lSk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9852,6 +10015,7 @@
 /area/mainship/shipboard/weapon_room)
 "mfH" = (
 /obj/item/paper/xenoresearch2,
+/obj/effect/urban/decal/trash/fourteen,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/medical_science)
 "mgw" = (
@@ -9918,6 +10082,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/trash/crushed_bottle/soutogrape,
 /turf/open/floor/mainship/sterile/purple/corner,
 /area/mainship/medical/medical_science)
 "mmh" = (
@@ -9937,8 +10102,7 @@
 /obj/structure/sign/poster{
 	dir = 1
 	},
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "mng" = (
 /turf/open/floor/mainship/terragov/north{
@@ -10147,6 +10311,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"mBE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "mBZ" = (
 /turf/open/space,
 /area/space)
@@ -10210,11 +10383,16 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "mHi" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/surgical_tray,
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "mHk" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/mainship/living/mechpilotquarters)
@@ -10315,7 +10493,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/corporateliaison)
 "mNM" = (
-/turf/open/floor/mainship/yellow_cargo/arrow{
+/turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/squads/general)
@@ -10385,9 +10563,7 @@
 /area/mainship/command/cic)
 "mQq" = (
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
+/turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "mQy" = (
 /obj/structure/table/mainship/nometal,
@@ -10422,7 +10598,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
 /area/mainship/squads/general)
 "mRL" = (
 /obj/structure/cable,
@@ -10435,20 +10613,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "mSh" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/dropper,
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/structure/closet/walllocker/hydrant/extinguisher{
-	dir = 8
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/obj/machinery/light/mainship{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "mSo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10509,6 +10680,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"mXe" = (
+/turf/open/floor/mainship/blue/corner,
+/area/mainship/squads/general)
 "mXf" = (
 /obj/machinery/vending/medical/shipside,
 /turf/open/floor/mainship/sterile/dark,
@@ -10792,10 +10966,9 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 8
-	},
-/area/mainship/medical/chemistry)
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "nla" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/mainship/yellow_cargo/arrow{
@@ -10826,6 +10999,10 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
+"noR" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/squads/general)
 "npN" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
@@ -10853,7 +11030,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "nsC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11097,19 +11274,26 @@
 	},
 /area/mainship/command/self_destruct)
 "nIF" = (
-/obj/machinery/vending/medical/shipside,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/upper_medical)
 "nIG" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "nJd" = (
-/obj/machinery/light/mainship{
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/turf/open/floor/mainship/sterile/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "nJG" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/firing_range)
@@ -11397,8 +11581,11 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/structure/closet/walllocker/hydrant/extinguisher,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "oco" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship{
@@ -11437,6 +11624,15 @@
 	dir = 1
 	},
 /area/mainship/hallways/starboard_hallway)
+"oeI" = (
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "ogF" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/mainship,
@@ -11543,6 +11739,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "onZ" = (
@@ -11598,12 +11798,9 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "osh" = (
-/obj/structure/closet/walllocker/hydrant/extinguisher,
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "osF" = (
 /obj/structure/closet/crate/weapon,
 /obj/structure/disposalpipe/segment,
@@ -11837,7 +12034,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "oJs" = (
 /turf/open/floor/mainship/terragov/north,
@@ -11851,6 +12050,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/item/reagent_containers/food/snacks/popcorn,
+/obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/mainship/sterile/side{
 	dir = 6
 	},
@@ -11860,7 +12061,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "oNK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -11983,6 +12184,16 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
+"oUY" = (
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/mainship{
+	dir = 1
+	},
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plating/platebotc,
+/area/mainship/medical/chemistry)
 "oWP" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -12169,9 +12380,22 @@
 /turf/open/floor/plating,
 /area/mainship/squads/req)
 "pfi" = (
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "pfH" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -12223,9 +12447,11 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/hallways/hangar)
 "pii" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship/white,
-/area/mainship/medical/chemistry)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "pjB" = (
 /obj/item/clothing/head/warning_cone,
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12430,6 +12656,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"pvz" = (
+/obj/machinery/vending/MarineMed,
+/turf/open/floor/mainship/black/full,
+/area/mainship/squads/general)
 "pvW" = (
 /obj/item/toy/deck,
 /obj/structure/table/wood,
@@ -12456,6 +12686,12 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
+"pxw" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "pya" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -12474,7 +12710,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
+/turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/mainship/squads/general)
@@ -12655,7 +12891,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "pJv" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -12768,6 +13004,12 @@
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
+"pPG" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/sterile/side{
+	dir = 9
+	},
+/area/mainship/squads/general)
 "pPR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12822,6 +13064,9 @@
 "pRb" = (
 /obj/effect/spawner/random/misc/plant,
 /obj/machinery/bot/cleanbot,
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
 "pSV" = (
@@ -13033,7 +13278,7 @@
 /area/mainship/hallways/boxingring)
 "qhf" = (
 /obj/machinery/marine_selector/clothes/medic,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/squads/general)
 "qiy" = (
 /obj/structure/cable,
@@ -13206,14 +13451,24 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "qtI" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship_hull,
 /area/mainship/engineering/port_atmos)
+"qtX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "qvJ" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
@@ -13324,6 +13579,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
+"qzM" = (
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "qAE" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -13422,6 +13683,12 @@
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
 /turf/open/floor/plating,
 /area/mainship/squads/req)
+"qHm" = (
+/obj/machinery/holopad,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "qHv" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/stack/sheet/glass/glass{
@@ -13494,6 +13761,18 @@
 	dir = 1
 	},
 /area/mainship/squads/req)
+"qME" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "qMG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -13557,6 +13836,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "qOC" = (
@@ -13791,9 +14074,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "rbo" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
@@ -14102,13 +14383,14 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ryp" = (
-/obj/structure/sink{
-	dir = 4
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "ryB" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/hexagon,
@@ -14332,9 +14614,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "rNX" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
-	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "rOr" = (
 /obj/machinery/holopad,
@@ -14592,6 +14873,10 @@
 	dir = 8
 	},
 /area/mainship/engineering/ce_room)
+"sdS" = (
+/obj/machinery/marine_selector/clothes/engi,
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "seg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -14652,10 +14937,9 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/command/cic)
 "sjY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/turf/open/floor/mainship/blue{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "skU" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -14799,6 +15083,7 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
+/mob/living/simple_animal/cat/martin/martina,
 /turf/open/floor/mainship/green{
 	dir = 1
 	},
@@ -14821,7 +15106,7 @@
 /area/mainship/hallways/aft_hallway)
 "swY" = (
 /obj/machinery/marine_selector/gear/medic,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "sxa" = (
 /obj/machinery/power/apc/mainship/hardened{
@@ -14963,15 +15248,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "sFM" = (
-/obj/machinery/chem_master,
-/obj/item/reagent_containers/glass/beaker/bluespace,
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "sGk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "sGA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -14982,15 +15267,21 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
+"sGL" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "sGU" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "sIN" = (
 /obj/effect/landmark/start/job/medicalofficer,
-/obj/effect/ai_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "sJa" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/floor,
@@ -15033,7 +15324,9 @@
 /area/mainship/engineering/port_atmos)
 "sMn" = (
 /obj/machinery/vending/MarineMed,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "sMF" = (
 /obj/machinery/light/mainship{
@@ -15148,6 +15441,7 @@
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = 10
 	},
+/obj/item/trash/boonie,
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 8
 	},
@@ -15297,7 +15591,9 @@
 /area/mainship/command/cic)
 "tgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "tgl" = (
 /obj/structure/cable,
@@ -15371,8 +15667,17 @@
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
 "tkS" = (
-/turf/open/floor/mainship/sterile/purple/side,
-/area/mainship/medical/chemistry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
+/area/mainship/squads/general)
 "tkW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15380,7 +15685,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "tlj" = (
 /obj/machinery/door/firedoor/mainship{
@@ -15527,6 +15832,16 @@
 	dir = 1
 	},
 /area/space)
+"twv" = (
+/obj/structure/bed/chair/office/dark,
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "txW" = (
 /obj/docking_port/stationary/ert_big,
 /turf/open/space,
@@ -15665,6 +15980,8 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,
 /obj/item/tool/weldpack,
+/obj/item/tool/wirecutters,
+/obj/item/tool/screwdriver,
 /turf/open/floor/mainship/green{
 	dir = 8
 	},
@@ -15700,7 +16017,7 @@
 /obj/structure/sign/prop1{
 	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "tEV" = (
 /obj/structure/cable,
@@ -15816,7 +16133,7 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/orange/full,
 /area/mainship/squads/general)
 "tKu" = (
 /obj/structure/cable,
@@ -15861,10 +16178,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
-/area/mainship/medical/chemistry)
+/obj/machinery/bot/cleanbot,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/upper_medical)
 "tOm" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/mainship/orange/full,
@@ -15987,7 +16303,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "tVr" = (
-/turf/open/floor/mainship/yellow_cargo/arrow,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "tVF" = (
 /obj/machinery/light/mainship,
@@ -16049,11 +16365,11 @@
 	},
 /area/mainship/squads/general)
 "tXJ" = (
-/obj/machinery/marine_selector/clothes/smartgun,
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/marine_selector/clothes/smartgun,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "tXZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -16077,6 +16393,7 @@
 "ubk" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/computer/med_data/laptop,
+/obj/item/trash/cheesie,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ubn" = (
@@ -16235,7 +16552,7 @@
 "ukJ" = (
 /obj/machinery/marine_selector/clothes/medic,
 /obj/machinery/light/mainship,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/squads/general)
 "umj" = (
 /obj/structure/sink{
@@ -16814,28 +17131,23 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "uVF" = (
-/obj/machinery/loadout_vendor,
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "uWB" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/crew_quarters/toilet)
 "uWK" = (
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/stack/sheet/mineral/phoron,
-/obj/item/reagent_containers/dropper,
-/obj/structure/table/mainship/nometal,
-/obj/item/tool/hand_labeler,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/obj/machinery/air_alarm{
+	dir = 1
+	},
+/obj/structure/sign/prop1,
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "uXb" = (
 /obj/effect/turf_decal/warning_stripes/thick/corner{
 	dir = 8
@@ -16876,10 +17188,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "uZR" = (
-/turf/open/floor/mainship/sterile/purple/corner{
-	dir = 8
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
 	},
-/area/mainship/medical/chemistry)
+/area/mainship/squads/general)
 "vab" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16948,6 +17260,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"vdy" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "vdN" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -17013,6 +17331,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"vgs" = (
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/squads/general)
 "vha" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17236,20 +17557,12 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "vwL" = (
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "vxx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17275,9 +17588,8 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "vyG" = (
-/obj/structure/sign/chemistry,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/turf/open/floor/mainship/orange/full,
+/area/mainship/squads/general)
 "vyJ" = (
 /turf/open/floor/mainship/hexagon,
 /area/mainship/shipboard/weapon_room)
@@ -17415,9 +17727,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
 "vIv" = (
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 4
-	},
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "vIy" = (
 /obj/structure/rack,
@@ -17457,6 +17767,12 @@
 "vMr" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/brig)
+"vMv" = (
+/obj/machinery/vending/medical/shipside,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vMM" = (
 /obj/effect/soundplayer/deltaplayer,
 /obj/structure/sign/evac,
@@ -17505,8 +17821,20 @@
 	dir = 4
 	},
 /obj/item/paper/xenoresearch3,
+/obj/effect/urban/decal/trash/ten,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"vSf" = (
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/squads/general)
 "vSo" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -17537,9 +17865,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "vTy" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/obj/structure/sink,
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/chemistry)
 "vTG" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
@@ -17562,16 +17890,11 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "vWG" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
-/obj/item/ammo_magazine/revolver/standard_revolver,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/obj/item/clothing/head/tgmcberet/red,
-/turf/open/floor/mainship/red/full,
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "vWL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17581,16 +17904,8 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "vXR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/blue/corner{
-	dir = 4
-	},
+/obj/machinery/marine_selector/gear/smartgun,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "vXY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17704,7 +18019,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "wgn" = (
 /obj/structure/cable,
@@ -17790,8 +18105,18 @@
 /area/mainship/living/bridgebunks)
 "wkJ" = (
 /obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/upper_medical)
+/area/mainship/medical/chemistry)
 "wml" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
@@ -17898,6 +18223,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/floor,
 /area/mainship/command/corporateliaison)
+"wsd" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "wsG" = (
 /obj/structure/bed/chair/nometal{
 	dir = 4
@@ -17911,8 +18250,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo/arrow{
+/obj/effect/turf_decal/warning_stripes/box/small{
 	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
 /area/mainship/squads/general)
 "wsX" = (
@@ -17944,6 +18289,11 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"wtX" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 10
+	},
+/area/mainship/squads/general)
 "wup" = (
 /turf/closed/wall/mainship/research/containment/wall/corner,
 /area/mainship/medical/medical_science)
@@ -18028,11 +18378,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/chapel)
 "wAZ" = (
-/obj/structure/table/mainship/nometal,
-/obj/item/weapon/gun/shotgun/pump,
-/obj/item/ammo_magazine/handful/buckshot,
-/obj/item/ammo_magazine/handful/buckshot,
-/turf/open/floor/mainship/red/full,
+/turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "wBa" = (
 /obj/structure/cable,
@@ -18081,7 +18427,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "wDQ" = (
 /obj/machinery/door/airlock/mainship/secure{
@@ -18168,6 +18514,20 @@
 /obj/machinery/telecomms/server/presets/delta,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"wIn" = (
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/stack/sheet/mineral/phoron,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/mainship/nometal,
+/obj/item/tool/hand_labeler,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
+/area/mainship/medical/chemistry)
 "wII" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -18248,9 +18608,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "wNn" = (
-/obj/machinery/chem_dispenser,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/surgical_tray,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "wNF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18376,11 +18737,23 @@
 /obj/machinery/faxmachine/cic{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = -8
+/obj/item/toy/deck{
+	pixel_y = 12;
+	pixel_x = -15
 	},
-/obj/item/toy/deck,
-/obj/item/toy/deck/kotahi,
+/obj/item/toy/deck/kotahi{
+	pixel_y = 13;
+	pixel_x = 16
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 12;
+	pixel_y = -3
+	},
+/obj/effect/spawner/random/misc/paperbin{
+	pixel_y = -5;
+	pixel_x = -9
+	},
+/obj/item/tool/pen,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "wTX" = (
@@ -18532,7 +18905,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "xdy" = (
 /obj/effect/landmark/start/job/ai,
@@ -18651,14 +19026,16 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "xkC" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship{
+/obj/effect/turf_decal/warning_stripes/box/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/box/arrow{
 	dir = 8
 	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
-/area/mainship/medical/lower_medical)
+/area/mainship/squads/general)
 "xkD" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/cargo,
@@ -18724,11 +19101,15 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
+"xop" = (
+/obj/machinery/marine_selector/gear/medic,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/squads/general)
 "xoE" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/blue,
 /area/mainship/squads/general)
 "xpe" = (
 /obj/structure/cable,
@@ -18787,7 +19168,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "xth" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18813,7 +19194,7 @@
 /area/mainship/hallways/hangar)
 "xuy" = (
 /obj/machinery/firealarm,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "xuA" = (
 /obj/item/clothing/head/warning_cone,
@@ -19383,9 +19764,9 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "xXt" = (
-/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/chemistry)
+/area/mainship/medical/upper_medical)
 "xXK" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/icefloor/warnplate{
@@ -19397,7 +19778,8 @@
 	dir = 1
 	},
 /obj/structure/sign/prop1,
-/turf/open/floor/mainship/yellow_cargo,
+/obj/effect/turf_decal/warning_stripes/box/empty,
+/turf/open/floor/mainship/sterile/side,
 /area/mainship/squads/general)
 "xYg" = (
 /obj/structure/cable,
@@ -19628,7 +20010,9 @@
 /area/mainship/hallways/hangar/droppod)
 "yhG" = (
 /obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "yiF" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
@@ -19673,6 +20057,10 @@
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor/mainship/hexagon,
 /area/mainship/engineering/engine_core)
+"ykL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/squads/general)
 "ylc" = (
 /turf/open/floor/mainship/red{
 	dir = 8
@@ -44742,12 +45130,12 @@ rSA
 ujw
 lCL
 xzF
-pii
-dLo
-dLo
-dLo
-dLo
-pii
+olX
+wcT
+wcT
+wcT
+wcT
+olX
 qBm
 kuy
 wcT
@@ -44999,12 +45387,12 @@ vkm
 mvs
 bUW
 xzF
-dLo
-bzT
+wcT
+xjG
 nkX
 hYl
-uZR
-dLo
+dQG
+wcT
 wcT
 wcT
 olX
@@ -45256,12 +45644,12 @@ lTH
 duU
 lGi
 iwj
-dLo
+nIF
 osh
-uWK
-wNn
-sFM
-dLo
+wnJ
+wnJ
+shx
+wcT
 lkD
 qJz
 xiT
@@ -45512,13 +45900,13 @@ mXw
 lTu
 mvs
 xAX
-vyG
-dLo
+lAT
+nIF
 fZP
 gaD
 xXt
-pfi
-dLo
+qjj
+wcT
 poR
 jsE
 jsE
@@ -45773,9 +46161,9 @@ aJH
 dkD
 qtB
 xqW
-nIF
-tkS
-dLo
+wnJ
+rQU
+wcT
 lkD
 qJz
 jsE
@@ -46017,22 +46405,22 @@ tyN
 tyN
 tyN
 mvs
-dQG
-shx
-rQU
-qjj
-qVu
-mXf
-xjG
-wcT
+qzM
+igL
+akL
+twv
+bNf
+wIn
+vdy
+dLo
 kSC
 yjx
 ftK
 tNW
 pJs
-baH
-pfi
-dLo
+oBq
+qVu
+wcT
 kly
 tjp
 cVd
@@ -46275,21 +46663,21 @@ yfw
 kuc
 mvs
 oca
-wnJ
-wnJ
+sGL
+wIn
 vwL
-oBq
+lFM
 sIN
 aSw
-wcT
+dLo
 hiV
-eUN
-kVD
+yjx
+nIF
 ryp
 mSh
 wNn
-sFM
-dLo
+mXf
+wcT
 uob
 tur
 fDn
@@ -46535,18 +46923,18 @@ vTy
 fTy
 iuw
 mHi
-mHi
+dAf
 wkJ
 nJd
-wcT
+dLo
 jLn
 osb
-pii
-dLo
-dLo
-dLo
-dLo
-pii
+olX
+wcT
+wcT
+wcT
+wcT
+olX
 qvJ
 qvJ
 gkL
@@ -46788,14 +47176,14 @@ xVg
 tVP
 lTe
 mvs
-wcT
-wcT
-wcT
-wcT
-wcT
+kVD
+kVD
+kVD
+oUY
+kVD
 eGM
-wcT
-wcT
+kVD
+dLo
 jLn
 yjx
 mvs
@@ -47049,10 +47437,10 @@ hJw
 gBJ
 ePj
 fEb
-xkC
-mmC
+fEb
+wsd
 orC
-orC
+fMB
 fuy
 yjx
 mvs
@@ -47307,7 +47695,7 @@ iwj
 lAT
 lAT
 lAT
-lAT
+qtX
 mgw
 mgw
 nMm
@@ -47564,10 +47952,10 @@ lSQ
 mNf
 qFX
 iMF
-lAT
-lAT
-lAT
-nMm
+qME
+pii
+pii
+mBE
 mzF
 mvs
 nku
@@ -50657,7 +51045,7 @@ vAn
 swv
 vAn
 vAn
-vAn
+dcT
 vAn
 vAn
 vAn
@@ -54271,20 +54659,20 @@ uqV
 jDL
 rUF
 swY
-wsR
-fEq
+pfi
+oeI
 lJV
-sMn
-mNM
+baH
+xkC
 swY
 rUF
-gFW
+dOT
 mNM
 fEq
 oIT
 sMn
 pyS
-gFW
+dOT
 rUF
 kMi
 dBu
@@ -54529,19 +54917,19 @@ tVF
 rUF
 dtI
 kUU
-rOr
-pGb
-pGb
+noR
+uZR
+aDK
 tVr
 xXT
 rUF
 tKs
 krM
 rOr
-eMz
+vyG
 pGb
 fYB
-xXT
+uWK
 mBc
 vmD
 nmm
@@ -54784,20 +55172,20 @@ kTI
 jQT
 vmD
 hme
-qhf
+lpB
 tkW
-pGb
-kHp
-oAz
-pGb
+uZR
+pPG
+wtX
+aDK
 qhf
 hme
-gxL
-mNM
+sdS
+pGb
 oAz
 kHp
 pGb
-pyS
+syR
 gxL
 hme
 rUF
@@ -55043,11 +55431,11 @@ rUF
 mBc
 lRs
 tkW
-pGb
-kHp
-pGb
-pGb
-swY
+vgs
+bzT
+cjl
+sFM
+xop
 rUF
 gFW
 pGb
@@ -55055,12 +55443,12 @@ pGb
 kHp
 pGb
 syR
-gFW
+aPv
 rUF
-sMn
+pvz
 iBL
 uVF
-pyS
+fTH
 acl
 mqK
 hPb
@@ -55282,11 +55670,11 @@ eQb
 eQb
 rUF
 vVG
-cPg
+lki
 mRy
-aKr
+xWS
 hvS
-aJV
+ezf
 rUF
 wDi
 ngh
@@ -55300,8 +55688,8 @@ ffo
 rUF
 aLA
 rbd
-tgi
-tgi
+hPG
+ykL
 tgi
 hPG
 aMp
@@ -55309,13 +55697,13 @@ rUF
 tED
 krM
 pGb
-eMz
+vyG
 pGb
 fYB
 elQ
 rUF
 eIM
-sjY
+sGk
 rNX
 wDN
 wfO
@@ -55558,23 +55946,23 @@ rUF
 oNs
 wsR
 yhG
-lJV
-fKK
-mNM
+vMv
+pxw
+vSf
 ukJ
 rUF
 pqm
-mNM
-yhG
+fhe
+fld
 xbP
 fKK
-pyS
+amQ
 hGE
 rUF
 xuy
-sjY
-pGb
-syR
+sGk
+vIv
+fTH
 fAy
 mqK
 ukb
@@ -55796,10 +56184,10 @@ cMr
 miU
 rUF
 xWS
-mRy
-cPg
+vfL
 vDF
 cPg
+aKr
 fHj
 rUF
 diF
@@ -55829,9 +56217,9 @@ oXs
 rUF
 ekL
 ikM
-sjY
+sGk
 ikM
-syR
+fTH
 cef
 mqK
 lys
@@ -56053,10 +56441,10 @@ eiA
 cKB
 rUF
 hWC
-vXR
+vfL
 cPg
 cPg
-cPg
+aJV
 xoE
 rUF
 unO
@@ -56311,10 +56699,10 @@ tpi
 rUF
 nIn
 vfL
-cPg
-rHh
-eMz
-eMz
+mXe
+qHm
+sjY
+imE
 ryY
 xVU
 bSp
@@ -56343,9 +56731,9 @@ cPg
 llW
 rUF
 ekh
-sjY
-cjl
-syR
+sGk
+cPg
+fTH
 wfO
 mqK
 uKH
@@ -56567,11 +56955,11 @@ cqY
 cRE
 rUF
 dPp
-vfL
-cPg
+tkS
+imE
 xWS
 fPK
-vVG
+ezf
 rUF
 lSq
 bSp
@@ -56600,9 +56988,9 @@ cPg
 lOp
 rUF
 kdD
-sjY
-pGb
-syR
+sGk
+vXR
+fTH
 cef
 mqK
 uKH
@@ -56857,9 +57245,9 @@ cPg
 lOp
 rUF
 mnb
-sjY
+sGk
 vIv
-syR
+fTH
 fAy
 mqK
 uKH
@@ -57113,10 +57501,10 @@ ciZ
 cPg
 lOp
 rUF
-kHp
+cfP
 iBL
 eWu
-pyS
+fTH
 jOQ
 mqK
 lRc
@@ -58882,7 +59270,7 @@ bDv
 bDv
 cEe
 bDv
-tDC
+fpZ
 fmP
 nhn
 nbh
@@ -59913,7 +60301,7 @@ wJe
 nJG
 qxw
 jiE
-ylc
+kHb
 nJG
 cwD
 uJT

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -5097,7 +5097,6 @@
 	},
 /area/mainship/living/chapel)
 "fZP" = (
-/obj/machinery/power/apc/mainship,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -560,11 +560,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "aKE" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
+/obj/item/toy/plush/gnome,
+/obj/item/weapon/combat_knife,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "aKX" = (
 /obj/effect/turf_decal/warning_stripes/thin,
 /obj/machinery/landinglight/cas{
@@ -577,6 +576,9 @@
 /area/mainship/hallways/hangar)
 "aLA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/structure/sign/poster{
+	dir = 1
+	},
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
@@ -595,6 +597,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/sign/poster,
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
 	},
@@ -746,13 +749,15 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "aUp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/mainship/black{
+/obj/structure/bed/bunkbed,
+/obj/machinery/light/mainship{
 	dir = 8
 	},
-/area/mainship/squads/general)
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/landmark/start/job/squadleader,
+/obj/effect/landmark/start/job/squadleader,
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "aVn" = (
 /obj/structure/orbital_cannon,
 /obj/machinery/light/mainship/small{
@@ -774,7 +779,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "aWF" = (
-/obj/effect/soundplayer/deltaplayer,
+/obj/machinery/vending/weapon,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "aXc" = (
@@ -889,11 +898,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "bby" = (
-/obj/effect/ai_node,
-/obj/structure/prop/mainship/name_stencil/G,
-/turf/open/floor/mainship/black{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "bch" = (
 /obj/structure/bed/chair/comfy/black,
@@ -943,10 +952,8 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
 "bfk" = (
-/obj/machinery/light/mainship{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/prop/mainship/name_stencil/M,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "bfC" = (
@@ -1076,9 +1083,10 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "brH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black,
-/area/mainship/squads/general)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "brL" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -1442,9 +1450,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
-	},
+/obj/structure/prop/flag,
+/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
@@ -1470,13 +1477,11 @@
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
 "bNh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/ntlogo,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "bNl" = (
 /obj/structure/bed/bunkbed,
@@ -1521,14 +1526,10 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/medical/upper_medical)
 "bPC" = (
-/obj/machinery/camera/autoname/mainship{
-	dir = 8
-	},
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpsespawner/marine/burst,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "bPG" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -1665,9 +1666,8 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/command/self_destruct)
 "bWg" = (
-/obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/terragov/north{
-	dir = 9
+	dir = 5
 	},
 /area/mainship/hallways/starboard_hallway)
 "bWq" = (
@@ -1843,14 +1843,12 @@
 /area/mainship/squads/req)
 "ciN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "ciZ" = (
-/obj/structure/prop/mainship/name_stencil,
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cjl" = (
 /obj/machinery/marine_selector/gear/smartgun,
@@ -2112,6 +2110,12 @@
 	dir = 4
 	},
 /area/mainship/squads/req)
+"cDG" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/hallways/starboard_hallway)
 "cDN" = (
 /obj/machinery/light/mainship/small{
 	dir = 8
@@ -2203,9 +2207,6 @@
 /area/mainship/command/telecomms)
 "cMq" = (
 /obj/item/trash/cigbutt,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "cNy" = (
@@ -2259,8 +2260,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
 "cRE" = (
-/obj/item/clothing/head/warning_cone,
-/turf/open/floor/mainship/mono,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "cRJ" = (
 /obj/structure/bed/bunkbed,
@@ -2542,10 +2543,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "dfI" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "dfT" = (
 /obj/structure/window/reinforced{
@@ -2860,9 +2859,9 @@
 	},
 /area/mainship/medical/lower_medical)
 "dvX" = (
-/obj/structure/sign/safety/cryogenic,
-/turf/closed/wall/mainship,
-/area/mainship/living/cryo_cells)
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "dvZ" = (
 /obj/item/attachable/bayonet,
 /obj/structure/table/mainship/nometal,
@@ -3315,9 +3314,19 @@
 	},
 /area/mainship/hallways/hangar)
 "edj" = (
-/obj/item/stack/tile/plasteel,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/quick_vendor/beginner,
+/turf/open/floor/mainship/black{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "edD" = (
 /obj/structure/cable,
@@ -3548,20 +3557,11 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hull/lower_hull)
 "esQ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/vending/weapon,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/vending/weapon,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "euc" = (
 /obj/machinery/power/apc{
@@ -3815,20 +3815,19 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
-	},
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "eLs" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/terragov/north{
+	dir = 8
+	},
+/area/mainship/squads/general)
 "eLt" = (
 /obj/item/stool,
 /obj/effect/decal/cleanable/blood,
@@ -3849,14 +3848,12 @@
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "eMJ" = (
-/obj/item/facepaint/green,
-/obj/item/facepaint/green,
-/obj/item/facepaint/green,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/structure/table/reinforced,
-/turf/open/floor/mainship/black,
+/obj/machinery/camera/autoname/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/black{
+	dir = 4
+	},
 /area/mainship/squads/general)
 "eNw" = (
 /turf/closed/wall/mainship,
@@ -3966,6 +3963,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/briefing)
+"eTF" = (
+/obj/item/grown/sunflower,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "eTN" = (
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
@@ -3986,10 +3987,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "eUy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/ntlogo/nt3,
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "eUN" = (
 /obj/machinery/light/mainship{
@@ -4014,10 +4013,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "eWM" = (
-/obj/item/trash/cigbutt,
-/obj/effect/urban/decal/trash/eight,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/quick_vendor/beginner,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "eXm" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4541,9 +4548,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "fzZ" = (
 /obj/machinery/firealarm,
@@ -4748,16 +4753,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "fJI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "fKj" = (
 /obj/structure/table/mainship/nometal,
@@ -4778,19 +4775,13 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "fLM" = (
-/obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "fLQ" = (
 /obj/effect/ai_node,
@@ -4879,7 +4870,7 @@
 /area/mainship/medical/upper_medical)
 "fTZ" = (
 /turf/open/floor/mainship/terragov/north{
-	dir = 10
+	dir = 9
 	},
 /area/mainship/hallways/starboard_hallway)
 "fUs" = (
@@ -5538,7 +5529,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/ntlogo/nt2,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "gMu" = (
 /obj/machinery/light/mainship/small{
@@ -5738,7 +5729,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/turf/open/floor/mainship/terragov/north,
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
 /area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
@@ -5809,10 +5802,11 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "hdY" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "heh" = (
 /turf/open/floor/mainship/cargo/arrow{
@@ -5857,9 +5851,10 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 1
+/obj/machinery/light/floor{
+	dir = 8
 	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hhf" = (
 /turf/closed/wall/mainship,
@@ -6104,9 +6099,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "hxc" = (
-/obj/machinery/vending/armor_supply,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/mainship/black{
-	dir = 1
+	dir = 4
 	},
 /area/mainship/squads/general)
 "hxz" = (
@@ -6217,8 +6214,11 @@
 /area/mainship/living/commandbunks)
 "hJe" = (
 /obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/squadsmartgunner,
-/obj/effect/landmark/start/job/squadsmartgunner,
+/obj/machinery/light/mainship{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/squadmarine,
+/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "hJw" = (
@@ -6265,10 +6265,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"hNd" = (
-/obj/effect/urban/decal/trash/twelve,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
 "hOe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6408,10 +6404,9 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
+/area/mainship/living/tankerbunks)
 "hUf" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -6497,6 +6492,11 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
+"hYV" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "hZe" = (
 /turf/open/floor/plating/mainship/striped{
@@ -6615,10 +6615,8 @@
 /area/mainship/hallways/hangar)
 "igO" = (
 /obj/item/trash/cigbutt,
-/turf/open/floor/mainship/black{
-	dir = 8
-	},
-/area/mainship/squads/general)
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "ihg" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/mainship/tcomms,
@@ -6705,9 +6703,9 @@
 	},
 /area/mainship/living/commandbunks)
 "imr" = (
-/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/black{
-	dir = 4
+	dir = 5
 	},
 /area/mainship/squads/general)
 "imx" = (
@@ -6790,9 +6788,9 @@
 	},
 /area/mainship/squads/general)
 "isK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/mainship/black{
-	dir = 8
+	dir = 4
 	},
 /area/mainship/squads/general)
 "isR" = (
@@ -6800,7 +6798,7 @@
 /area/mainship/living/mechpilotquarters)
 "its" = (
 /obj/machinery/bot/roomba,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "iuw" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -6828,11 +6826,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "iws" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/turf/open/floor/mainship/ntlogo,
-/area/mainship/squads/general)
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "ixx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7274,9 +7273,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/black{
-	dir = 1
+/obj/machinery/light/floor{
+	dir = 8
 	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jcy" = (
 /obj/structure/table/wood,
@@ -7385,11 +7385,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jlV" = (
-/obj/item/trash/cigbutt{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/mainship/yellow_cargo,
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jmu" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -7749,8 +7746,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/computerframe,
-/turf/open/floor/plating,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "jTl" = (
 /turf/closed/wall/mainship,
@@ -7832,6 +7828,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/prop/mainship/name_stencil/G,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "kbe" = (
@@ -7844,15 +7841,14 @@
 	},
 /area/mainship/living/chapel)
 "kbg" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "kbE" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -8035,8 +8031,7 @@
 	},
 /area/mainship/shipboard/firing_range)
 "ksd" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
+/turf/open/floor/mainship/black/corner{
 	dir = 4
 	},
 /area/mainship/squads/general)
@@ -8306,10 +8301,18 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "kGk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/loadout_vendor,
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship/black{
-	dir = 9
+	dir = 5
 	},
 /area/mainship/squads/general)
 "kGq" = (
@@ -8344,13 +8347,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "kId" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/ntlogo/nt2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "kJX" = (
 /obj/structure/window/framed/mainship/hull,
@@ -8394,13 +8395,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "kMf" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/quick_vendor/beginner,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/facepaint/green,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "kMi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -8468,11 +8465,12 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "kQp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -8748,10 +8746,10 @@
 /turf/open/floor/mainship_hull,
 /area/space)
 "lgL" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/quick_vendor/beginner,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lgM" = (
@@ -9227,14 +9225,10 @@
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "lEz" = (
-/obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/squadsmartgunner,
-/obj/effect/landmark/start/job/squadsmartgunner,
-/obj/machinery/light/mainship{
-	dir = 8
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/area/mainship/squads/general)
 "lES" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/chapel)
@@ -9338,10 +9332,12 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "lIW" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/vending/weapon,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "lJt" = (
 /obj/machinery/firealarm,
@@ -9455,12 +9451,17 @@
 	},
 /area/mainship/squads/req)
 "lPY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
+/obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lQb" = (
 /obj/structure/table/mainship/nometal,
@@ -9605,8 +9606,10 @@
 	},
 /area/mainship/command/airoom)
 "lVR" = (
-/obj/structure/prop/flag,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "lWc" = (
@@ -9653,6 +9656,7 @@
 	id = "or2privacyshutter";
 	name = "Privacy Shutters"
 	},
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_two)
 "lXN" = (
@@ -9691,17 +9695,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/paper/overwatch,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "lYQ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
+/area/mainship/shipboard/firing_range)
 "mam" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9857,8 +9856,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "mng" = (
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
 /area/mainship/squads/general)
 "mnH" = (
 /obj/machinery/bot/cleanbot,
@@ -10082,7 +10082,6 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "mEk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/mainship/black{
 	dir = 8
@@ -10387,9 +10386,6 @@
 /obj/machinery/light/floor{
 	dir = 4
 	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/machinery/iv_drip,
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -10488,9 +10484,19 @@
 	},
 /area/mainship/shipboard/firing_range)
 "nbu" = (
-/obj/effect/urban/decal/trash/fifteen,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/obj/item/trash/cigbutt{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "nbC" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood,
@@ -10523,9 +10529,15 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
 "ndA" = (
-/obj/structure/flora/ausbushes/goldenbush,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "ndG" = (
 /obj/structure/bed/chair/sofa/right,
 /obj/item/bedsheet/ce{
@@ -10810,8 +10822,8 @@
 /area/mainship/hull/lower_hull)
 "nwR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/computerframe,
-/turf/open/floor/plating,
+/obj/machinery/loadout_vendor,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nwX" = (
 /obj/machinery/landinglight/tadpole{
@@ -10884,9 +10896,8 @@
 /area/mainship/hallways/hangar)
 "nzV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/stack/tile/plasteel,
 /obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "nAb" = (
 /obj/effect/ai_node,
@@ -11067,9 +11078,9 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "nNV" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "nNY" = (
 /obj/machinery/camera/autoname/mainship,
 /obj/structure/ship_ammo/cas/heavygun,
@@ -11166,10 +11177,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "nUc" = (
-/obj/item/clothing/mask/muzzle,
-/obj/structure/prop/flag/som,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/squads/general)
 "nVl" = (
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/explosive,
@@ -11307,6 +11318,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"ocu" = (
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
+/area/mainship/hallways/starboard_hallway)
 "ocE" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -11404,12 +11421,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "onk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/urban/decal/trash/eight,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/ntlogo,
+/area/mainship/squads/general)
 "onC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner{
@@ -11621,15 +11635,7 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "oCN" = (
-/obj/item/facepaint/green,
-/obj/item/facepaint/green,
-/obj/item/facepaint/green,
-/obj/item/facepaint/green,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/item/tool/hand_labeler,
-/obj/structure/table/reinforced,
+/obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "oDl" = (
@@ -11665,12 +11671,11 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "oGT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black{
-	dir = 9
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
 "oHj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -11742,13 +11747,7 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/squads/general)
 "oJs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/mainship/ntlogo/nt3,
+/turf/open/floor/mainship/terragov/north,
 /area/mainship/squads/general)
 "oKO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -11983,15 +11982,13 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "paG" = (
-/obj/item/coin/iron,
-/obj/machinery/vending/cigarette,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 4
-	},
-/area/mainship/squads/general)
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/squadsmartgunner,
+/obj/effect/landmark/start/job/squadsmartgunner,
+/obj/effect/landmark/start/job/squadsmartgunner,
+/obj/effect/landmark/start/job/squadsmartgunner,
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "paT" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -12010,11 +12007,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pbh" = (
-/obj/effect/ai_node,
-/obj/structure/prop/mainship/name_stencil/C,
-/turf/open/floor/mainship/black{
-	dir = 5
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pbx" = (
 /obj/machinery/light/mainship,
@@ -12281,7 +12278,6 @@
 /obj/machinery/light/mainship{
 	dir = 1
 	},
-/obj/item/paper/overwatch,
 /turf/open/floor/mainship/green{
 	dir = 9
 	},
@@ -12390,7 +12386,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pzU" = (
-/obj/machinery/computer/cryopod,
 /obj/machinery/light/mainship{
 	dir = 4
 	},
@@ -12780,15 +12775,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "pWo" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "pWs" = (
 /obj/structure/cable,
@@ -12937,11 +12928,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "qjf" = (
-/obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/squadleader,
-/obj/effect/landmark/start/job/squadleader,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/obj/structure/cable,
+/obj/machinery/vending/cigarette,
+/obj/item/coin/iron,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "qjj" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/storage/firstaid/o2{
@@ -13010,9 +13001,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "qlX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/mainship/black{
-	dir = 8
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
 	},
 /area/mainship/squads/general)
 "qmr" = (
@@ -13310,15 +13300,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "qGH" = (
-/obj/structure/bed/bunkbed,
-/obj/effect/landmark/start/job/squadmarine,
-/obj/effect/landmark/start/job/squadmarine,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/turf/open/space/basic,
+/area/mainship/hull/lower_hull)
 "qHj" = (
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
 /turf/open/floor/plating,
@@ -13544,9 +13527,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "qRK" = (
 /mob/living/simple_animal/corgi/walten,
@@ -13656,28 +13637,11 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "qXc" = (
-/obj/machinery/vending/marineFood,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/turf/open/floor/mainship/black{
-	dir = 4
+/obj/item/trash/cigbutt{
+	pixel_x = 5;
+	pixel_y = -8
 	},
+/turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
 "qXC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14131,19 +14095,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "rEw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14183,10 +14135,11 @@
 /turf/open/floor/mainship/sterile/corner,
 /area/mainship/medical/upper_medical)
 "rFS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/black{
-	dir = 10
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "rGg" = (
 /turf/open/floor/mainship/sterile/dark,
@@ -14349,12 +14302,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "rUm" = (
-/obj/structure/prop/mainship/name_stencil/M,
-/obj/effect/ai_node,
-/turf/open/floor/mainship/black{
-	dir = 5
-	},
-/area/mainship/squads/general)
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "rUw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -14375,12 +14325,6 @@
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"rVQ" = (
-/obj/machinery/vending/armor_supply,
-/turf/open/floor/mainship/black{
-	dir = 9
-	},
-/area/mainship/squads/general)
 "rWv" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -14442,10 +14386,9 @@
 	dir = 4
 	},
 /obj/item/trash/cigbutt{
-	pixel_x = -8;
-	pixel_y = 3
+	pixel_x = 5;
+	pixel_y = -8
 	},
-/obj/effect/urban/decal/trash/eight,
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
 "rZh" = (
@@ -14674,10 +14617,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "sqc" = (
-/obj/machinery/light/mainship{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/mainship,
+/obj/machinery/quick_vendor/beginner,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "srb" = (
 /obj/structure/closet/toolcloset,
@@ -14856,7 +14803,6 @@
 	dir = 8
 	},
 /obj/machinery/computer/camera_advanced/overwatch/medical,
-/obj/item/paper/overwatch,
 /turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "sEl" = (
@@ -15129,15 +15075,9 @@
 /turf/open/floor/cult,
 /area/medical/morgue)
 "sXV" = (
-/obj/item/trash/cigbutt{
-	pixel_x = 5;
-	pixel_y = -8
+/turf/open/floor/mainship/terragov/north{
+	dir = 4
 	},
-/obj/item/trash/cigbutt{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "sYd" = (
 /obj/structure/table/mainship/nometal,
@@ -15228,10 +15168,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
 "tfQ" = (
-/obj/machinery/loadout_vendor,
-/turf/open/floor/mainship/black{
-	dir = 10
-	},
+/obj/structure/table/reinforced,
+/obj/item/facepaint/green,
+/turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "tgg" = (
 /obj/structure/table/mainship/nometal,
@@ -15538,9 +15477,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tAO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/stack/tile/plasteel,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/terragov{
+	dir = 1
+	},
 /area/mainship/squads/general)
 "tBh" = (
 /obj/machinery/firealarm{
@@ -16073,12 +16012,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "udi" = (
-/obj/structure/table/reinforced,
-/obj/item/tool/hand_labeler,
-/obj/item/facepaint/green,
-/turf/open/floor/mainship/black{
-	dir = 10
-	},
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/mainship/black,
 /area/mainship/squads/general)
 "udk" = (
 /obj/structure/cable,
@@ -16194,14 +16129,6 @@
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
 "umU" = (
-/obj/effect/landmark/start/latejoin,
-/obj/machinery/light/mainship{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/writing{
-	desc = "It looks like a writing in blood. It says, 'I went back to sleep, but I will come back to the same nightmare.'";
-	dir = 4
-	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
 "uny" = (
@@ -16325,9 +16252,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/obj/structure/prop/mainship/name_stencil/C,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "uvy" = (
 /obj/structure/cable,
@@ -16466,6 +16392,7 @@
 	pixel_x = -18;
 	pixel_y = -12
 	},
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/operating_room_one)
 "uCk" = (
@@ -17054,8 +16981,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "voa" = (
-/obj/machinery/holopad,
-/turf/open/floor/mainship/black,
+/obj/machinery/light/floor{
+	dir = 8
+	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "vou" = (
 /turf/closed/wall/mainship,
@@ -17097,9 +17026,9 @@
 	},
 /area/mainship/engineering/engineering_workshop)
 "vtk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/cryopod,
 /turf/open/floor/mainship/black{
-	dir = 9
+	dir = 4
 	},
 /area/mainship/squads/general)
 "vua" = (
@@ -17590,11 +17519,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/item/paper/memorial,
 /obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
+/obj/item/paper/memorial,
+/turf/open/floor/mainship/terragov/north,
 /area/mainship/hallways/starboard_hallway)
 "wcT" = (
 /turf/closed/wall/mainship/white,
@@ -17618,9 +17545,7 @@
 /area/mainship/shipboard/weapon_room)
 "weY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/mainship{
-	dir = 8
-	},
+/obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "wff" = (
@@ -17708,13 +17633,15 @@
 /turf/closed/wall/mainship,
 /area/mainship/living/bridgebunks)
 "wiL" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/mainship/living/cryo_cells)
 "wiO" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/reagentgrinder{
@@ -18440,12 +18367,18 @@
 /turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "xbv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/living/cryo_cells)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/quick_vendor/beginner,
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "xbA" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/camera/autoname/mainship{
@@ -18632,8 +18565,9 @@
 	},
 /area/mainship/command/self_destruct)
 "xmJ" = (
-/obj/structure/computerframe,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
 /area/mainship/squads/general)
 "xnO" = (
 /turf/closed/wall/mainship/research/containment/wall/corner{
@@ -18756,11 +18690,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar/droppod)
 "xvA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/mainship/black{
-	dir = 4
+	dir = 6
 	},
 /area/mainship/squads/general)
 "xvF" = (
@@ -18859,6 +18791,7 @@
 /area/mainship/command/corporateliaison)
 "xAr" = (
 /obj/machinery/light/mainship,
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
 /turf/open/floor/mainship/black{
 	dir = 4
 	},
@@ -18939,16 +18872,15 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "xBS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/trash/cigbutt{
-	pixel_x = 5;
-	pixel_y = -8
-	},
-/obj/effect/urban/decal/trash/nine,
-/turf/open/floor/wood,
-/area/mainship/living/cryo_cells)
+/obj/machinery/quick_vendor/beginner,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "xBT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19088,19 +19020,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "xLV" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/black{
-	dir = 1
-	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "xLZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -19348,9 +19272,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
 "xYh" = (
-/obj/item/trash/cigbutt{
-	pixel_x = 5;
-	pixel_y = -8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
@@ -54949,12 +54872,12 @@ vmD
 vmD
 vmD
 vmD
-vmD
+bLP
 lVR
 kGc
 bbl
 vyj
-eQb
+miU
 tlT
 mBc
 rUF
@@ -55206,9 +55129,9 @@ vmD
 vmD
 rug
 vmD
-vmD
-hTV
-eQb
+tpi
+tFb
+kGc
 uej
 lhT
 eQb
@@ -55463,13 +55386,13 @@ vmD
 vmD
 vmD
 vmD
-vmD
-tqD
-bWg
-xdN
+eel
+pgh
+vDH
 fTZ
-tFb
-kGc
+xdN
+ocu
+tqD
 rUF
 bJB
 bRc
@@ -55506,7 +55429,7 @@ hGE
 rUF
 xuy
 sjY
-oAz
+pGb
 syR
 fAy
 mqK
@@ -55720,13 +55643,13 @@ vmD
 vmD
 vmD
 vmD
-vmD
 miU
-waC
-oOX
+eQb
+fqj
 gYa
-pgh
-vDH
+oOX
+waC
+miU
 rUF
 xWS
 mRy
@@ -55977,13 +55900,13 @@ vmD
 vmD
 vmD
 vmD
-vmD
-cKB
-eKC
-fGV
-bLP
+tpi
 eQb
-fqj
+kGc
+bWg
+fGV
+cDG
+cKB
 rUF
 hWC
 vXR
@@ -55994,9 +55917,9 @@ xoE
 rUF
 unO
 isJ
-dfI
+rrh
 udi
-rVQ
+sbB
 fee
 fee
 fee
@@ -56234,42 +56157,42 @@ vmD
 vmD
 rug
 vmD
-vmD
+eel
 iay
 ciN
-ndA
+tpi
 eel
-eQb
+eTF
 tpi
 rUF
 nIn
 vfL
 cPg
 rHh
-cPg
-cPg
+eMz
+eMz
 ryY
 xVU
 bSp
-cPg
-lOp
+kMf
+tfQ
 eYx
 rHh
 cPg
 cMq
 its
 cPg
-sqc
+cPg
 kQp
-sqc
 cPg
-tis
-sqc
 cPg
-sqc
+onk
 cPg
 cPg
 cPg
+cPg
+cPg
+buS
 cPg
 cPg
 cPg
@@ -56491,13 +56414,13 @@ vmD
 vmD
 vmD
 vmD
-vmD
+miU
 cRE
-vmD
-vmD
+miU
+tpi
+miU
+hYV
 cRE
-vmD
-vmD
 rUF
 dPp
 vfL
@@ -56508,27 +56431,27 @@ vVG
 rUF
 lSq
 bSp
-rrh
+dfI
 oCN
-hxc
+eYx
 cPg
-buS
-xLV
-eMz
-eMz
+rFS
+rDn
+qXc
+rDn
 kbg
 bNh
+rFS
+rDn
+tJA
+rDn
+oGT
 xLV
-xYh
-jlV
-kbg
-buS
-xLV
-eMz
-jlV
-wiL
-aWF
-cPg
+rFS
+rDn
+tJA
+rDn
+oGT
 cPg
 lOp
 rUF
@@ -56752,9 +56675,9 @@ oGN
 mOo
 mXm
 mXm
-mXm
-mXm
-mXm
+eKC
+eKC
+hTV
 hEc
 uyy
 cBw
@@ -56769,23 +56692,23 @@ cPg
 lOp
 eYx
 cPg
-tJA
-xLV
-eMz
-xYh
-kbg
-kId
 esQ
-eMz
-eMz
-kbg
-tJA
-xLV
-jlV
 xYh
-kbg
-cPg
-cPg
+bYP
+xYh
+ndA
+gMl
+esQ
+nbu
+bYP
+xYh
+pbh
+xLV
+esQ
+xYh
+bYP
+xYh
+pbh
 cPg
 lOp
 rUF
@@ -57022,30 +56945,30 @@ aJV
 eMz
 eYx
 bSp
-rrh
-eMJ
-hxc
-cPg
-bYP
-rDn
-eMz
-eMz
-pWo
-oJs
-xLV
-jlV
-sXV
-pWo
-bYP
-xLV
-jlV
-eMz
-pWo
-cPg
-cPg
 cPg
 lOp
-mBc
+eYx
+cPg
+rFS
+rDn
+tis
+eMz
+pWo
+gMl
+jlV
+eMz
+rHh
+eMz
+ciZ
+rHh
+jlV
+eMz
+cPg
+eMz
+ciZ
+cPg
+lOp
+rUF
 kHp
 iBL
 eWu
@@ -57281,33 +57204,33 @@ mvQ
 pVb
 lkH
 xvA
-mvQ
-ciZ
-lkH
-lkH
-ini
+imr
+bpK
+aWF
+kId
+bpK
 bby
 lIW
 fJI
-lkH
-ini
-rUm
-lIW
-lkH
-lkH
-hdY
+esQ
+xYh
+cPg
+xYh
 pbh
-lkH
-lkH
-lkH
-ksd
+cPg
+hdY
+xYh
+cPg
+xYh
+pbh
+tis
 ini
-rUF
+mBc
 rUF
 jTU
 rUF
 alq
-rUF
+mBc
 mqK
 uKH
 jWH
@@ -57537,27 +57460,27 @@ eMz
 rIt
 isJ
 fee
-aUp
+fee
 mEk
-isK
+cPg
 rFS
-oGT
-rFS
-vtk
-kGk
-qlX
-ffo
-khM
-sbB
-ffo
-fee
-tfQ
-khM
-sbB
-ffo
-igO
-fee
-fee
+eMz
+cPg
+eMz
+pWo
+gMl
+jlV
+eMz
+cPg
+eMz
+ciZ
+cPg
+jlV
+eMz
+cPg
+eMz
+ciZ
+cPg
 fee
 cey
 fee
@@ -57791,30 +57714,30 @@ uyy
 uyy
 nJG
 nJG
+nJG
+qjf
+mng
+eLs
+xmJ
+cPg
+esQ
+eMz
+buS
+eMz
 nNV
-bSp
-mng
-xmJ
-xmJ
-mng
+gMl
+vVG
+cCg
 buS
-fLM
 eMz
-cCg
-qRu
-iws
-fLM
+nNV
+cPg
+vVG
 eMz
-cCg
-qRu
 buS
-fLM
 eMz
-cCg
-qRu
+nNV
 cPg
-cPg
-mxo
 mxo
 mxo
 mxo
@@ -58050,28 +57973,28 @@ xRb
 cvj
 nJG
 hoq
-mng
-xmJ
-xmJ
+qlX
+tAO
+oJs
+adk
 edj
-tJA
 fLM
-eMz
-eMz
+tJA
 qRu
+xbv
 gMl
-fLM
-eMz
-eMz
+xBS
 qRu
 tJA
-fLM
-eMz
-eMz
 qRu
+sqc
 cPg
-rHh
-hlO
+eWM
+fLM
+tJA
+qRu
+sqc
+cPg
 osT
 hlO
 aat
@@ -58307,28 +58230,28 @@ kAq
 qEu
 pko
 bSp
-mng
-xmJ
-xmJ
-mng
-bYP
-kMf
-eMz
-eMz
-lgL
-eUy
-kMf
-eMz
-eMz
-lgL
-bYP
-kMf
-eMz
-eMz
-lgL
+lEz
+sXV
+nUc
+cPg
+aJV
 cPg
 cPg
-aat
+cPg
+lgL
+gMl
+aJV
+cPg
+cPg
+cPg
+aJV
+cPg
+aJV
+cPg
+cPg
+cPg
+aJV
+cPg
 hlO
 lNe
 hlO
@@ -58567,32 +58490,32 @@ jEy
 nzV
 nwR
 jRR
-tAO
+bpK
 bpK
 weY
-brH
-uvr
-bfk
+bpK
+jRR
+bpK
 kaa
-weY
-brH
+bpK
+bpK
 fzT
 bfk
 bpK
-weY
-brH
+bpK
+bpK
 uvr
-bfk
 bpK
 bpK
-iZI
+bpK
+bpK
 iZI
 voR
 pnf
 pnf
 pnf
 cPg
-cPg
+eUy
 hRA
 iXQ
 iXQ
@@ -58822,7 +58745,7 @@ nbh
 eeX
 tdQ
 cPg
-rHh
+lPY
 hcr
 adk
 cPg
@@ -58849,7 +58772,7 @@ tis
 cPg
 cPg
 tis
-cPg
+dvX
 rKn
 sYv
 sBr
@@ -59077,35 +59000,35 @@ fmP
 jCY
 ykn
 pko
+vtk
+lkH
+lkH
+pzU
+lkH
+vtk
+ksd
+cPg
+gMl
+cPg
+cPg
+cPg
+cPg
+gMl
+cPg
+cPg
+cPg
+cPg
+gMl
+cPg
+cPg
+cPg
+cPg
+cPg
+cPg
+cPg
+pzU
+isK
 sPp
-aKE
-bPC
-paG
-imr
-lkH
-bFc
-ini
-lPY
-bFc
-aLV
-bFc
-ini
-lPY
-bFc
-aLV
-bFc
-ini
-lPY
-lkH
-gaz
-lkH
-lkH
-lkH
-pzU
-qXc
-pzU
-lkH
-lkH
 xAr
 rKn
 uzA
@@ -59334,36 +59257,36 @@ fmP
 jCY
 vWG
 nJG
-rKn
-rKn
-rKn
-rKn
-rKn
-fpB
-rRa
-heh
-wpT
-aSJ
-dlQ
-aSJ
-heh
-wpT
-rRa
-dlQ
-aSJ
-heh
-vmB
-fpB
-aSJ
 cwD
 wJh
+cwD
 wJh
-dvX
+cwD
 aSJ
-aSJ
-wJh
-wJh
-xpw
+kGk
+lkH
+hxc
+bFc
+eMJ
+bFc
+lkH
+hxc
+bFc
+aLV
+bFc
+lkH
+hxc
+lkH
+gaz
+cPg
+cPg
+cPg
+cPg
+rKn
+rKn
+rKn
+rKn
+rKn
 rKn
 gou
 bNs
@@ -59591,36 +59514,36 @@ fmP
 jCY
 eTN
 nJG
-eLs
+cwD
+wJh
+cwD
+wJh
+xpw
+fpB
+rRa
+heh
+wpT
+aSJ
+dlQ
+aSJ
+heh
+wpT
+rRa
+dlQ
+aSJ
+heh
+vmB
+fpB
+aSJ
+umU
+umU
+umU
+umU
+rKn
 vAb
 gUW
 gXY
 xjs
-aSJ
-qGH
-kFl
-xBS
-qzp
-aSJ
-qzp
-hNd
-gfi
-cRJ
-aSJ
-cRJ
-rqX
-ucj
-lEz
-aSJ
-cwD
-wJh
-wJh
-cwD
-aSJ
-cwD
-wJh
-wJh
-cwD
 rKn
 ouE
 uSe
@@ -59848,36 +59771,36 @@ qxw
 jiE
 ylc
 nJG
-fRw
-nwy
-nUc
-fYk
-tOZ
+cwD
+wJh
+cwD
+wJh
+cwD
 aSJ
-ktb
-xqr
+aUp
+kFl
 rZg
-lEe
+qzp
 aSJ
-dnw
-nMY
-onk
-ktb
+qzp
+mog
+gfi
+cRJ
 aSJ
-qjf
+cRJ
 rqX
 ucj
 hJe
 aSJ
-cwD
-wJh
-wJh
-cwD
-aSJ
-cwD
-wJh
-wJh
-cwD
+umU
+umU
+umU
+umU
+rKn
+nwy
+rUm
+fYk
+tOZ
 rKn
 ouE
 iDP
@@ -60105,36 +60028,36 @@ dYv
 aws
 mQq
 nJG
-fRw
+cwD
+wJh
+cwD
+wJh
+cwD
+aSJ
+ktb
+xqr
+wiL
+lEe
+aSJ
+dnw
+nMY
+ucj
+ktb
+aSJ
+paG
+rqX
+ucj
+ktb
+aSJ
+umU
+umU
+umU
+umU
+rKn
 iWR
 eLt
 owh
 snm
-eCd
-lsh
-hOm
-atN
-pHC
-eCd
-lsh
-qqP
-kQS
-ktb
-eCd
-lsh
-rqX
-atN
-ktb
-eCd
-rzd
-wJh
-wJh
-cwD
-eCd
-rzd
-wJh
-wJh
-cwD
 rKn
 ouE
 uSe
@@ -60361,37 +60284,37 @@ bDv
 dYv
 uTv
 wAZ
-nJG
-fRw
+lYQ
+rzd
+wJh
+cwD
+wJh
+cwD
+eCd
+lsh
+hOm
+atN
+pHC
+eCd
+lsh
+qqP
+kQS
+ktb
+eCd
+lsh
+rqX
+atN
+ktb
+eCd
+umU
+umU
+umU
+umU
+rKn
 hua
 ooi
 fbC
 oUt
-aSJ
-bNl
-nbu
-qqP
-ktb
-aSJ
-ktb
-mog
-eWM
-ved
-aSJ
-ved
-rqX
-rqX
-ktb
-aSJ
-cwD
-umU
-lWc
-cwD
-aSJ
-cwD
-lWc
-lWc
-cwD
 rKn
 fgk
 jaF
@@ -60619,36 +60542,36 @@ vSE
 ksb
 ltX
 nJG
+cwD
+lWc
+cwD
+lWc
+cwD
+aSJ
+bNl
+rqX
+qqP
+ktb
+aSJ
+ktb
+mog
+igO
+ved
+aSJ
+ved
+rqX
+rqX
+ktb
+aSJ
+umU
+aKE
+bPC
+aSJ
 rKn
 vSJ
 rKn
 rKn
 rKn
-aSJ
-aSJ
-kir
-hcb
-aSJ
-aSJ
-aSJ
-kir
-hcb
-aSJ
-aSJ
-aSJ
-kir
-hcb
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
-aSJ
 rKn
 uzA
 aOM
@@ -60876,33 +60799,33 @@ nJG
 nJG
 nJG
 nJG
-lYQ
+aSJ
+aSJ
+aSJ
+aSJ
+aSJ
+aSJ
+aSJ
+kir
+hcb
+aSJ
+aSJ
+aSJ
+kir
+hcb
+aSJ
+aSJ
+aSJ
+kir
+hcb
+aSJ
+aSJ
+aSJ
+aSJ
+aSJ
+aSJ
+iws
 wHk
-wPV
-mDY
-wPV
-wPV
-wPV
-sYv
-qFT
-mDY
-wPV
-wPV
-qFT
-sYv
-xbv
-mDY
-wPV
-sYv
-qFT
-wPV
-hME
-wPV
-wPV
-hME
-wPV
-wPV
-wPV
 wPV
 wPV
 sYv
@@ -61133,32 +61056,32 @@ oxO
 oxO
 oxO
 oxO
+brH
+brH
+wPV
+mDY
+wPV
+wPV
+wPV
+sYv
+qFT
+mDY
+wPV
+wPV
+qFT
+sYv
+wPV
+mDY
+wPV
+sYv
+qFT
+wPV
+hME
+wPV
+wPV
+hME
+wPV
 hPF
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
-esN
 esN
 esN
 esN
@@ -61390,36 +61313,36 @@ esN
 esN
 esN
 esN
+brL
+brL
 esN
 esN
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
-nWT
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+esN
+qGH
+qGH
+qGH
 nWT
 nWT
 nWT
@@ -61650,33 +61573,33 @@ nWT
 nWT
 nWT
 nWT
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
-qpC
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
+nWT
 qpC
 qpC
 qpC
@@ -61906,34 +61829,34 @@ qpC
 qpC
 qpC
 qpC
-aiT
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
-qVo
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
+qpC
 qVo
 qVo
 qVo
@@ -62189,8 +62112,8 @@ qVo
 qVo
 qVo
 qVo
-mBZ
-mBZ
+qVo
+qVo
 mBZ
 mBZ
 mBZ

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -352,12 +352,19 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig)
 "aAu" = (
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/computer/cloning_console/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "aAQ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -392,11 +399,14 @@
 /turf/open/floor/carpet,
 /area/mainship/living/commandbunks)
 "aCM" = (
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/whitecyanthree{
+/obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
+	},
+/turf/open/floor/whitecyanfour{
+	dir = 4
 	},
 /area/mainship/medical/lower_medical)
 "aDc" = (
@@ -889,11 +899,6 @@
 /obj/effect/spawner/random/medical/firstaid/alwaysspawns,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
-"baH" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 6
-	},
-/area/mainship/squads/general)
 "bbl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -1493,7 +1498,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/marine_selector/clothes,
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "bNl" = (
 /obj/structure/bed/bunkbed,
@@ -1867,7 +1876,13 @@
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "ciZ" = (
-/obj/machinery/marine_selector/clothes,
+/obj/item/trash/cigbutt{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "cjl" = (
@@ -2120,11 +2135,7 @@
 	},
 /area/mainship/command/cic)
 "cCg" = (
-/obj/item/trash/cigbutt,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "cCy" = (
 /turf/closed/wall/mainship/outer,
@@ -3526,18 +3537,13 @@
 /turf/open/floor/plating,
 /area/mainship/engineering/upper_engineering)
 "ejJ" = (
-/obj/structure/disposalpipe/segment{
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/effect/turf_decal/medical_decals/doc{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/computer/cloning_console/vats,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/whitecyantwo,
 /area/mainship/medical/lower_medical)
 "ekh" = (
 /obj/machinery/camera/autoname/mainship,
@@ -3763,9 +3769,15 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
 "eBB" = (
-/obj/effect/soundplayer/deltaplayer,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
+/obj/machinery/quick_vendor/beginner,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "eCc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4107,19 +4119,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"eWM" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/quick_vendor/beginner,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "eXm" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4868,7 +4867,11 @@
 /area/mainship/hallways/hangar)
 "fJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/mainship,
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
 "fKj" = (
 /obj/structure/table/mainship/nometal,
@@ -5100,6 +5103,19 @@
 /area/mainship/shipboard/weapon_room)
 "gaz" = (
 /obj/machinery/vending/marineFood,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
+/obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
@@ -5914,13 +5930,6 @@
 /obj/machinery/landinglight/tadpole,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"hdY" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "heh" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
@@ -6658,6 +6667,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/structure/sign/engie{
+	dir = 8
+	},
 /turf/open/floor/mainship/black{
 	dir = 10
 	},
@@ -6956,7 +6968,7 @@
 /area/mainship/living/mechpilotquarters)
 "its" = (
 /obj/machinery/bot/roomba,
-/turf/open/floor/mainship/ntlogo,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "iuw" = (
 /obj/structure/disposalpipe/segment,
@@ -7582,9 +7594,20 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "jlV" = (
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/bioprinter/stocked,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/operating_room_two)
 "jmu" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 4
@@ -8076,14 +8099,12 @@
 	},
 /area/mainship/living/chapel)
 "kbg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/structure/sign/electricshock{
 	dir = 8
 	},
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship/yellow_cargo,
+/turf/open/floor/mainship/black{
+	dir = 8
+	},
 /area/mainship/squads/general)
 "kbE" = (
 /obj/structure/window/framed/mainship/requisitions,
@@ -8643,11 +8664,12 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "kMt" = (
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/obj/machinery/vending/weapon,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "kML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/camera/autoname/mainship{
@@ -9209,11 +9231,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/starboard_hallway)
-"lpn" = (
-/obj/structure/sign/electricshock,
-/obj/effect/soundplayer/deltaplayer,
-/turf/closed/wall/mainship,
-/area/mainship/squads/general)
 "lpt" = (
 /obj/docking_port/stationary/supply/vehicle,
 /turf/open/floor/mainship/empty,
@@ -9225,14 +9242,20 @@
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "lqS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/table/mainship/nometal,
+/obj/machinery/light/floor,
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = -10;
+	pixel_y = 15
 	},
-/obj/effect/turf_decal/medical_decals/triage/edge{
-	dir = 8
+/obj/item/reagent_containers/glass/beaker/cryomix{
+	name = "cryo beaker";
+	pixel_x = 10;
+	pixel_y = 13
 	},
-/turf/open/floor/whitecyanfour{
-	dir = 4
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
 	},
 /area/mainship/medical/lower_medical)
 "lrn" = (
@@ -9575,13 +9598,14 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "lIW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
 	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "lJt" = (
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/silver/full,
@@ -9716,25 +9740,6 @@
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
 /obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
-/obj/item/reagent_containers/food/snacks/protein_pack,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lQb" = (
@@ -9743,11 +9748,9 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "lQN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/computer/sleep_console{
-	dir = 8
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
@@ -9852,12 +9855,11 @@
 /turf/open/floor/mainship/sterile/side,
 /area/mainship/medical/lower_medical)
 "lTL" = (
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/medical_decals/triage/edge{
 	dir = 8
 	},
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "lTQ" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -10140,15 +10142,6 @@
 /turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
 "mng" = (
-/obj/item/trash/cigbutt{
-	pixel_x = 5;
-	pixel_y = -8
-	},
-/obj/item/trash/cigbutt{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/trash/cigbutt,
 /turf/open/floor/mainship/terragov/north{
 	dir = 9
 	},
@@ -10470,13 +10463,6 @@
 	dir = 5
 	},
 /area/mainship/squads/req)
-"mKk" = (
-/obj/effect/ai_node,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "mKE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10681,17 +10667,11 @@
 /area/mainship/engineering/port_atmos)
 "mUU" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/sleep_console{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/medical_decals/triage{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "mVr" = (
@@ -10808,7 +10788,8 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "ncg" = (
-/obj/machinery/vending/weapon,
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
 /turf/open/floor/mainship/black{
 	dir = 1
 	},
@@ -10827,13 +10808,6 @@
 /obj/machinery/vending/weapon,
 /turf/open/floor/mainship/floor,
 /area/mainship/living/mechpilotquarters)
-"ndA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
 "ndG" = (
 /obj/structure/bed/chair/sofa/right,
 /obj/item/bedsheet/ce{
@@ -11384,8 +11358,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "nNV" = (
-/obj/machinery/vending/weapon,
-/turf/open/floor/mainship/yellow_cargo,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
 "nNY" = (
 /obj/machinery/camera/autoname/mainship,
@@ -11750,10 +11724,6 @@
 /obj/structure/prop/flag,
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
-"onk" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship/ntlogo,
-/area/mainship/squads/general)
 "onC" = (
 /obj/structure/sink{
 	dir = 4
@@ -11904,20 +11874,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "oyZ" = (
-/obj/structure/table/mainship/nometal,
-/obj/machinery/light/floor,
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = -10;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/glass/beaker/cryomix{
-	name = "cryo beaker";
-	pixel_x = 10;
-	pixel_y = 13
-	},
-/turf/open/floor/mainship/sterile/side{
+/obj/effect/turf_decal/medical_decals/triage{
 	dir = 1
+	},
+/turf/open/floor/whitecyanthree{
+	dir = 8
 	},
 /area/mainship/medical/lower_medical)
 "ozU" = (
@@ -11997,11 +11958,7 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "oGT" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship/ntlogo/nt2,
+/turf/open/floor/mainship/cargo/arrow,
 /area/mainship/squads/general)
 "oHj" = (
 /obj/effect/turf_decal/warning_stripes/thin{
@@ -12339,12 +12296,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "pbh" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
+/obj/effect/soundplayer/deltaplayer,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/hangar)
 "pbx" = (
 /obj/machinery/light/mainship,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -13409,20 +13363,6 @@
 	dir = 4
 	},
 /area/space)
-"qqg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/cloning/vats,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "qqh" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/red{
@@ -13909,11 +13849,9 @@
 	},
 /area/mainship/living/chapel)
 "qRu" = (
+/obj/machinery/holopad,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/general)
@@ -14030,7 +13968,7 @@
 	pixel_x = 5;
 	pixel_y = -8
 	},
-/turf/open/floor/mainship/ntlogo/nt2,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "qXC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14558,40 +14496,15 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "rGl" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
+/obj/machinery/bot/cleanbot,
+/obj/machinery/bodyscanner{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/structure/sign/nosmoking_2{
-	dir = 4;
-	pixel_y = -4
+/obj/effect/turf_decal/warning_stripes/stripedsquare,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
 	},
-/obj/item/storage/surgical_tray,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/spray/surgery{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -6;
-	pixel_y = 12
-	},
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
+/area/mainship/medical/lower_medical)
 "rHh" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
@@ -15063,14 +14976,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "sqc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/quick_vendor/beginner,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/quick_vendor/beginner,
-/turf/open/floor/mainship/yellow_cargo,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "srb" = (
 /obj/structure/closet/toolcloset,
@@ -15341,11 +15254,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "sHF" = (
-/obj/machinery/vending/weapon,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship/yellow_cargo,
+/obj/machinery/holopad,
+/turf/open/floor/mainship/ntlogo,
 /area/mainship/squads/general)
 "sIN" = (
 /obj/effect/landmark/start/job/medicalofficer,
@@ -16349,14 +16259,40 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "tWq" = (
-/obj/machinery/door/firedoor/multi_tile{
+/obj/machinery/door/poddoor/shutters/opened/medbay{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters/mainship{
+	id = "or2privacyshutter";
+	name = "\improper Privacy Shutters";
 	dir = 1
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/structure/sign/nosmoking_2{
+	dir = 4;
+	pixel_y = -4
 	},
+/obj/item/storage/surgical_tray,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/spray/surgery{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
+/area/mainship/medical/operating_room_two)
 "tWD" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
@@ -16625,8 +16561,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "unO" = (
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
+/obj/structure/sign/prop1{
+	dir = 1
+	},
 /turf/open/floor/mainship/black{
 	dir = 9
 	},
@@ -17000,20 +16937,6 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/living/mechpilotquarters)
-"uKQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/lower_medical)
 "uLb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/reagent_containers/hypospray/autoinjector/synaptizine_expired,
@@ -17214,14 +17137,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "uVk" = (
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/effect/turf_decal/medical_decals/doc{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/whitecyantwo,
-/area/mainship/medical/lower_medical)
+/obj/machinery/quick_vendor/beginner,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship/yellow_cargo,
+/area/mainship/squads/general)
 "uVF" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -17742,14 +17669,19 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/firing_range)
 "vBY" = (
-/obj/machinery/bot/cleanbot,
-/obj/machinery/bodyscanner{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
 	},
-/obj/effect/turf_decal/warning_stripes/stripedsquare,
-/turf/open/floor/mainship/sterile/side{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/turf_decal/medical_decals/triage{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "vCB" = (
 /obj/structure/table/mainship,
@@ -18006,21 +17938,6 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"vYo" = (
-/obj/machinery/door/poddoor/shutters/opened/medbay{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/mainship{
-	id = "or2privacyshutter";
-	name = "\improper Privacy Shutters";
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/bioprinter/stocked,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/operating_room_two)
 "vZa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18942,18 +18859,19 @@
 /turf/open/floor/mainship/green/full,
 /area/mainship/squads/req)
 "xbv" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/quick_vendor/beginner,
-/turf/open/floor/mainship/yellow_cargo,
-/area/mainship/squads/general)
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "xbA" = (
 /obj/structure/table/mainship/nometal,
 /obj/machinery/camera/autoname/mainship{
@@ -19093,9 +19011,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "xkC" = (
-/turf/open/floor/mainship/sterile/side{
-	dir = 10
-	},
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "xkD" = (
 /obj/structure/closet/emcloset,
@@ -19166,7 +19083,8 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 10
 	},
-/turf/open/floor/mainship/blue,
+/obj/machinery/computer/ordercomp,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "xpe" = (
 /obj/structure/cable,
@@ -19316,6 +19234,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
+/obj/structure/sign/engie{
+	dir = 8
+	},
 /turf/open/floor/mainship/black{
 	dir = 8
 	},
@@ -19462,15 +19383,19 @@
 /turf/open/floor/wood,
 /area/mainship/living/commandbunks)
 "xBS" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/quick_vendor/beginner,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/cloning/vats,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/lower_medical)
 "xBT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -47764,7 +47689,7 @@ xBT
 cYZ
 kWu
 ouq
-mKk
+lQN
 mNf
 qFX
 iMF
@@ -48794,12 +48719,12 @@ mvs
 xZy
 gnK
 xjD
-vBY
+rGl
 bnL
 xVO
 lAT
 lAT
-qqg
+xBS
 yjx
 mvs
 mbQ
@@ -49049,14 +48974,14 @@ lSk
 dpY
 nRz
 usa
-mUU
+vBY
 gNc
 mnH
 gNc
 rHK
-kMt
+lTL
 lAT
-ejJ
+aAu
 yjx
 mvs
 mbQ
@@ -49307,10 +49232,10 @@ fwq
 mvs
 jUl
 lxg
+oyZ
+aiP
+aiP
 aCM
-aiP
-aiP
-lqS
 rrp
 lAT
 nMm
@@ -49562,7 +49487,7 @@ brN
 aWk
 aQX
 mvs
-oyZ
+lqS
 hGO
 bYJ
 pDg
@@ -49821,13 +49746,13 @@ cYZ
 mvs
 kYM
 bFG
-uVk
+ejJ
 dIk
 ksa
 jWB
 dnQ
 lAT
-uKQ
+xbv
 yjx
 mvs
 nla
@@ -50083,7 +50008,7 @@ pEN
 rkq
 xSi
 foU
-lQN
+mUU
 mam
 yjx
 mvs
@@ -50339,7 +50264,7 @@ oCo
 loc
 dNQ
 nRH
-vYo
+jlV
 aDU
 wNF
 lTH
@@ -50596,7 +50521,7 @@ qOa
 uCj
 onC
 lXB
-rGl
+tWq
 mHW
 fom
 oOM
@@ -50846,7 +50771,7 @@ gcM
 tzk
 aWk
 dpY
-eBB
+pbh
 dpY
 mvs
 mvs
@@ -50856,7 +50781,7 @@ mvs
 mvs
 dTh
 gQY
-tWq
+lIW
 nRz
 pdj
 pdj
@@ -55506,14 +55431,14 @@ lRs
 tkW
 oYn
 gBQ
-baH
+rNX
 jBI
 cmb
 rUF
 koX
 pGb
-pGb
-pGb
+oGT
+xkC
 kHp
 syR
 gFW
@@ -55754,7 +55679,7 @@ ngh
 vzy
 khM
 oZY
-koS
+xkC
 koS
 bDg
 ffo
@@ -56011,7 +55936,7 @@ cPg
 lTQ
 lOp
 aDz
-eMz
+cCg
 eMz
 eMz
 eMz
@@ -56268,7 +56193,7 @@ sUT
 tXD
 ini
 mvQ
-lkH
+rNX
 lkH
 lkH
 hPQ
@@ -56280,7 +56205,7 @@ rUF
 rUF
 rUK
 rUF
-lpn
+mBc
 rUF
 hwU
 rUF
@@ -56541,7 +56466,7 @@ cey
 xxM
 wCD
 cey
-fee
+kbg
 fee
 jqy
 iae
@@ -56782,7 +56707,7 @@ bSp
 kMf
 tfQ
 eYx
-rHh
+sHF
 cPg
 cMq
 its
@@ -56791,13 +56716,13 @@ cPg
 kQp
 cPg
 cPg
-onk
-cPg
-cPg
+tis
 cPg
 cPg
 cPg
 buS
+cPg
+cPg
 cPg
 cPg
 cPg
@@ -57039,23 +56964,23 @@ bSp
 dfI
 oCN
 eYx
-cPg
+tJA
 rFS
 rDn
 qXc
+cPg
 rDn
-kbg
 bNh
+rDn
+cPg
+cPg
+rDn
 rFS
-rDn
-tJA
-rDn
-oGT
-xLV
-rFS
-rDn
+ciZ
 tJA
 cPg
+rDn
+rFS
 cPg
 cPg
 lOp
@@ -57296,23 +57221,23 @@ bSp
 cPg
 lOp
 eYx
-cPg
-vVG
-cPg
 bYP
-cPg
-ndA
-gMl
 vVG
+cPg
+cPg
+cPg
+cPg
+kMt
+cPg
 nbu
-bYP
 cPg
-nNV
-xLV
+cPg
 vVG
-cPg
+xLV
 bYP
 cPg
+cPg
+vVG
 cPg
 cPg
 lOp
@@ -57557,19 +57482,19 @@ cPg
 nQH
 xYh
 tis
+cPg
 xYh
 pWo
-gMl
-nQH
-xYh
-rHh
-xYh
-aAu
-rHh
-nQH
 xYh
 cPg
 cPg
+xYh
+nQH
+qRu
+cPg
+cPg
+xYh
+nQH
 cPg
 cPg
 lOp
@@ -57814,19 +57739,19 @@ bpK
 aWF
 kId
 bpK
+bpK
 kId
-lIW
 fJI
-lTL
-rDn
-cPg
-rDn
-pbh
-cPg
-hdY
 rDn
 cPg
 cPg
+rDn
+rFS
+rDn
+cPg
+cPg
+rDn
+rFS
 cPg
 tis
 ini
@@ -58072,18 +57997,18 @@ vVG
 cPg
 cPg
 cPg
-nNV
-gMl
+cPg
+kMt
+cPg
+cPg
+cPg
+cPg
 vVG
 cPg
 cPg
 cPg
-ciZ
 cPg
-jlV
-cPg
-cPg
-cPg
+vVG
 cPg
 cPg
 fee
@@ -58324,23 +58249,23 @@ qjf
 mng
 eLs
 xmJ
-cPg
+buS
 esQ
 xYh
-buS
-xYh
-aAu
-gMl
-esQ
-cCg
-buS
-xYh
-sHF
 cPg
-vVG
-eMz
+cPg
+xYh
+pWo
+xYh
+cMq
+cPg
+xYh
+nQH
+xYh
 buS
 cPg
+xYh
+nQH
 cPg
 cPg
 mxo
@@ -58581,23 +58506,23 @@ hoq
 qlX
 tAO
 oJs
-adk
+nNV
 edj
 fLM
-tJA
-qRu
-xbv
-gMl
-xBS
-qRu
-tJA
-qRu
-sqc
 cPg
-eWM
+cPg
+fLM
+uVk
+fLM
+cPg
+cPg
+fLM
+sqc
 fLM
 tJA
 cPg
+fLM
+eBB
 cPg
 cPg
 osT
@@ -58838,23 +58763,23 @@ bSp
 lEz
 sXV
 nUc
-cPg
+bYP
 aJV
 cPg
-bYP
+cPg
+cPg
 cPg
 lgL
-gMl
-aJV
 cPg
-bYP
 cPg
-aJV
+cPg
 cPg
 aJV
 cPg
 bYP
 cPg
+cPg
+aJV
 cPg
 cPg
 hlO
@@ -59608,7 +59533,7 @@ pko
 vtk
 tXD
 lkH
-lkH
+pzU
 lkH
 vtk
 ksd

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -811,12 +811,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"aYx" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/mainship/terragov/north{
-	dir = 6
-	},
-/area/mainship/hallways/starboard_hallway)
 "aYW" = (
 /obj/machinery/power/apc/mainship{
 	dir = 1
@@ -1089,13 +1083,9 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "brH" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
+/obj/item/grown/sunflower,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "brL" = (
 /turf/closed/wall/mainship/outer,
 /area/space)
@@ -1247,10 +1237,6 @@
 	},
 /turf/open/floor/mainship/yellow_cargo,
 /area/mainship/squads/req)
-"bBv" = (
-/obj/structure/prop/flag,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "bBG" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 5
@@ -1463,8 +1449,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/grass,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
@@ -1679,8 +1665,9 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/command/self_destruct)
 "bWg" = (
+/obj/item/clothing/head/modular/marine,
 /turf/open/floor/mainship/terragov/north{
-	dir = 5
+	dir = 10
 	},
 /area/mainship/hallways/starboard_hallway)
 "bWq" = (
@@ -1947,6 +1934,11 @@
 /obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"cqY" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "csh" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -2215,6 +2207,11 @@
 /obj/item/trash/cigbutt,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
+"cMr" = (
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/obj/item/paper/memorial,
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "cNy" = (
 /obj/effect/turf_decal/warning_stripes/thick{
 	dir = 1
@@ -2343,11 +2340,6 @@
 	dir = 9
 	},
 /area/space)
-"cTl" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 9
-	},
-/area/mainship/hallways/starboard_hallway)
 "cTx" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -3442,6 +3434,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"eiA" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/hallways/starboard_hallway)
 "eiU" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -3826,11 +3824,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/item/clothing/head/modular/marine,
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/mainship/outer,
+/area/mainship/hull/lower_hull)
 "eLq" = (
 /obj/machinery/door/poddoor/mainship/open/cic,
 /obj/machinery/door/firedoor/mainship,
@@ -4114,6 +4110,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/mainship,
 /area/mainship/engineering/ce_room)
+"fbp" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "fbC" = (
 /obj/structure/window/reinforced,
 /obj/item/clothing/shoes/marine/som,
@@ -4209,6 +4210,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
+"fgB" = (
+/obj/structure/cable,
+/obj/machinery/light/mainship/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "fgI" = (
 /obj/structure/rack,
@@ -4878,9 +4887,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "fTZ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
+/obj/structure/cable,
+/obj/machinery/light/mainship/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/lower_hull)
 "fUs" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -5650,11 +5663,6 @@
 /obj/effect/turf_decal/warning_stripes/thick/corner,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar/droppod)
-"gTf" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "gTg" = (
 /obj/structure/table/mainship/nometal,
 /obj/item/folder/blue,
@@ -5742,8 +5750,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/obj/item/grown/sunflower,
-/turf/open/floor/grass,
+/turf/open/floor/mainship/terragov/north{
+	dir = 9
+	},
 /area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
@@ -6056,6 +6065,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"hsr" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "htZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -6417,6 +6430,9 @@
 /area/mainship/command/cic)
 "hTV" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
 /turf/open/floor/mainship/hexagon,
 /area/mainship/living/tankerbunks)
 "hUf" = (
@@ -8545,14 +8561,6 @@
 	dir = 1
 	},
 /area/mainship/medical/lower_medical)
-"kSP" = (
-/obj/structure/cable,
-/obj/machinery/light/mainship/small{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk,
-/area/mainship/hull/lower_hull)
 "kTv" = (
 /obj/effect/ai_node,
 /obj/structure/disposalpipe/segment/corner{
@@ -9839,10 +9847,6 @@
 	dir = 9
 	},
 /area/mainship/command/self_destruct)
-"mkt" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "mle" = (
 /turf/closed/wall/mainship/research/containment/wall/east,
 /area/mainship/medical/medical_science)
@@ -11143,6 +11147,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
+"nQH" = (
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "nRz" = (
 /obj/effect/soundplayer/deltaplayer,
 /turf/closed/wall/mainship/white,
@@ -11362,6 +11370,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"oes" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "ogF" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/mainship,
@@ -11433,6 +11446,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
+"omW" = (
+/obj/structure/prop/flag,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "onk" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/ntlogo,
@@ -13314,9 +13331,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "qGH" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/mainship/outer,
-/area/mainship/hull/lower_hull)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/mainship/living/tankerbunks)
 "qHj" = (
 /obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
 /turf/open/floor/plating,
@@ -15048,11 +15065,6 @@
 	dir = 8
 	},
 /area/mainship/medical/medical_science)
-"sVz" = (
-/obj/structure/flora/tree/dead,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "sVI" = (
 /obj/machinery/landinglight/tadpole,
 /obj/machinery/landinglight/tadpole{
@@ -15163,12 +15175,6 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
-"tfi" = (
-/obj/structure/cable,
-/obj/effect/ai_node,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "tfG" = (
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
@@ -15399,11 +15405,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/mainship/living/grunt_rnr)
-"ttG" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "ttT" = (
 /obj/machinery/vending/marineFood,
 /turf/open/floor/mainship/mono,
@@ -16465,6 +16466,13 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"uDB" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/floor,
+/area/crew_quarters/toilet)
 "uEg" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/wood,
@@ -17444,6 +17452,16 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"vVf" = (
+/obj/effect/landmark/start/latejoin,
+/obj/machinery/light/mainship{
+	dir = 4
+	},
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "vVy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -17505,13 +17523,6 @@
 	},
 /turf/open/floor/mainship/sterile/white,
 /area/mainship/living/bridgebunks)
-"vYj" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "vYo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -17555,10 +17566,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/obj/item/paper/memorial,
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship/mono,
+/area/mainship/hull/lower_hull)
 "wcT" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/upper_medical)
@@ -18738,6 +18750,11 @@
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/green,
 /area/mainship/squads/req)
+"xvO" = (
+/obj/effect/landmark/start/latejoin,
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/living/cryo_cells)
 "xwg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19055,6 +19072,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"xLM" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/mainship/hallways/starboard_hallway)
 "xLV" = (
 /obj/item/trash/cigbutt{
 	pixel_x = -8;
@@ -45640,7 +45662,7 @@ wPV
 iet
 nJP
 dmx
-nJP
+uDB
 tNQ
 iTM
 kRZ
@@ -54130,7 +54152,7 @@ vmD
 vmD
 vmD
 vmD
-mkt
+nQH
 vmD
 rWD
 aHG
@@ -54908,7 +54930,7 @@ hWt
 vmD
 vmD
 vmD
-bBv
+omW
 lVR
 kGc
 bbl
@@ -55425,9 +55447,9 @@ vmD
 eel
 pgh
 vDH
-cTl
+gYa
 xdN
-eKC
+bWg
 tqD
 rUF
 bJB
@@ -55682,9 +55704,9 @@ vmD
 miU
 eQb
 fqj
-gTf
+oes
 oOX
-waC
+cMr
 miU
 rUF
 xWS
@@ -55939,9 +55961,9 @@ vmD
 tpi
 eQb
 kGc
-bWg
+xLM
 fGV
-aYx
+eiA
 cKB
 rUF
 hWC
@@ -56198,7 +56220,7 @@ iay
 ciN
 tpi
 eel
-gYa
+brH
 tpi
 rUF
 nIn
@@ -56455,7 +56477,7 @@ cRE
 miU
 tpi
 miU
-sVz
+cqY
 cRE
 rUF
 dPp
@@ -56708,12 +56730,12 @@ oGN
 oGN
 ezY
 oGN
-ttG
-hTV
+fbp
+bLP
 mXm
-bLP
-bLP
-fTZ
+qGH
+qGH
+hsr
 hEc
 uyy
 cBw
@@ -56966,7 +56988,7 @@ eFo
 eFo
 eFo
 kCs
-hTV
+bLP
 xLu
 xLu
 gcd
@@ -57223,7 +57245,7 @@ eFo
 eFo
 eFo
 pqQ
-hTV
+bLP
 xLu
 uXw
 eZp
@@ -57480,7 +57502,7 @@ lpt
 eFo
 eFo
 gcr
-vYj
+hTV
 xLu
 rOV
 vXQ
@@ -58780,7 +58802,7 @@ nhn
 nbh
 eeX
 tdQ
-cPg
+bSp
 lPY
 hcr
 adk
@@ -58804,7 +58826,7 @@ cPg
 tis
 cPg
 cPg
-tis
+cPg
 cPg
 cPg
 tis
@@ -59037,7 +59059,7 @@ jCY
 ykn
 pko
 vtk
-lkH
+tXD
 lkH
 pzU
 lkH
@@ -59294,7 +59316,7 @@ jCY
 vWG
 nJG
 cwD
-wJh
+xvO
 cwD
 wJh
 cwD
@@ -59551,7 +59573,7 @@ jCY
 eTN
 nJG
 cwD
-wJh
+xvO
 cwD
 wJh
 xpw
@@ -59808,7 +59830,7 @@ jiE
 ylc
 nJG
 cwD
-wJh
+xvO
 cwD
 wJh
 cwD
@@ -60065,7 +60087,7 @@ aws
 mQq
 nJG
 cwD
-wJh
+xvO
 cwD
 wJh
 cwD
@@ -60322,7 +60344,7 @@ uTv
 wAZ
 lYQ
 rzd
-wJh
+xvO
 cwD
 wJh
 cwD
@@ -60579,7 +60601,7 @@ ksb
 ltX
 nJG
 cwD
-lWc
+vVf
 cwD
 lWc
 cwD
@@ -61093,29 +61115,29 @@ oxO
 oxO
 oxO
 oxO
-oxO
+anb
 hUz
-brH
-hUz
-hUz
-hUz
-rCA
-tfi
-brH
+fTZ
 hUz
 hUz
-tfi
-rCA
-hUz
-brH
 hUz
 rCA
-tfi
+waC
+fTZ
 hUz
-kSP
+hUz
+waC
+rCA
+hUz
+fTZ
+hUz
+rCA
+waC
+hUz
+fgB
 hUz
 hUz
-kSP
+fgB
 hUz
 hPF
 esN
@@ -61351,29 +61373,29 @@ esN
 esN
 esN
 esN
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
-qGH
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
+eKC
 esN
 esN
 nWT

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1232,11 +1232,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/open/floor/mainship/purple/full,
 /area/mainship/living/briefing)
-"bAZ" = (
-/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
-/obj/item/paper/memorial,
-/turf/open/floor/mainship/terragov/north,
-/area/mainship/hallways/starboard_hallway)
 "bBk" = (
 /obj/structure/barricade/solid{
 	dir = 4
@@ -1455,10 +1450,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "bLP" = (
-/obj/item/clothing/head/modular/marine,
-/turf/open/floor/mainship/terragov/north{
-	dir = 10
-	},
+/obj/machinery/computer/squad_selector,
+/turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
 "bMe" = (
 /obj/machinery/camera/autoname/mainship{
@@ -1673,10 +1666,9 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/command/self_destruct)
 "bWg" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 9
-	},
-/area/mainship/hallways/starboard_hallway)
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "bWq" = (
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating/icefloor/warnplate{
@@ -1941,6 +1933,10 @@
 /obj/machinery/computer/telecomms/server/preset,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"cqV" = (
+/obj/item/grown/sunflower,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "csh" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -3602,6 +3598,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/living/mechpilotquarters)
+"exQ" = (
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/obj/item/paper/memorial,
+/turf/open/floor/mainship/terragov/north,
+/area/mainship/hallways/starboard_hallway)
 "exV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3815,7 +3816,8 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "eKC" = (
-/obj/structure/prop/flag,
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/mainship/hallways/starboard_hallway)
 "eLq" = (
@@ -4865,9 +4867,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/upper_medical)
 "fTZ" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/mainship/terragov/north{
-	dir = 6
+	dir = 9
 	},
 /area/mainship/hallways/starboard_hallway)
 "fUs" = (
@@ -4966,6 +4967,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"gaq" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 5
+	},
+/area/mainship/hallways/starboard_hallway)
 "gaz" = (
 /obj/machinery/vending/marineFood,
 /obj/item/reagent_containers/food/snacks/protein_pack,
@@ -5460,6 +5466,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"gCL" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/mainship{
+	dir = 8
+	},
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "gES" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -5726,9 +5739,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "gYa" = (
-/obj/structure/flora/tree/dead,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/mainship/terragov/north{
+	dir = 10
+	},
 /area/mainship/hallways/starboard_hallway)
 "gYy" = (
 /turf/open/floor/mainship/green/corner,
@@ -6401,7 +6415,7 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/command/cic)
 "hTV" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/mainship/living/tankerbunks)
 "hUf" = (
@@ -7446,10 +7460,6 @@
 "jsE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"jti" = (
-/obj/machinery/computer/squad_selector,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "jwr" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -8147,6 +8157,11 @@
 	},
 /turf/open/space,
 /area/space)
+"kxM" = (
+/turf/open/floor/mainship/terragov/north{
+	dir = 1
+	},
+/area/mainship/hallways/starboard_hallway)
 "kxN" = (
 /obj/machinery/light/mainship,
 /obj/structure/filingcabinet,
@@ -8737,6 +8752,11 @@
 "leW" = (
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/boxingring)
+"lfc" = (
+/obj/structure/prop/mainship/gelida/lightstick,
+/obj/structure/cable,
+/turf/open/floor/mainship/hexagon,
+/area/mainship/living/tankerbunks)
 "lgF" = (
 /obj/structure/prop/mainship/name_stencil,
 /turf/open/floor/mainship_hull,
@@ -9265,6 +9285,10 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
+"lGF" = (
+/obj/structure/prop/flag,
+/turf/open/floor/grass,
+/area/mainship/hallways/starboard_hallway)
 "lGU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9675,10 +9699,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
-"lYk" = (
-/obj/item/grown/sunflower,
-/turf/open/floor/grass,
-/area/mainship/hallways/starboard_hallway)
 "lYE" = (
 /obj/machinery/door_control/old/medbay{
 	id = "Medbay";
@@ -12345,11 +12365,6 @@
 	dir = 4
 	},
 /area/mainship/command/cic)
-"pwX" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 1
-	},
-/area/mainship/hallways/starboard_hallway)
 "pya" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
@@ -13636,11 +13651,6 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
-"qWG" = (
-/turf/open/floor/mainship/terragov/north{
-	dir = 5
-	},
-/area/mainship/hallways/starboard_hallway)
 "qXc" = (
 /obj/item/trash/cigbutt{
 	pixel_x = 5;
@@ -14463,7 +14473,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed/roller,
@@ -15693,10 +15702,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"tIO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/mainship/living/tankerbunks)
 "tJA" = (
 /turf/open/floor/mainship/ntlogo/nt2,
 /area/mainship/squads/general)
@@ -16013,11 +16018,6 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/living/cryo_cells)
-"ucK" = (
-/obj/structure/prop/mainship/gelida/lightstick,
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "udd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/mainship{
@@ -16109,6 +16109,12 @@
 	dir = 8
 	},
 /area/mainship/medical/lower_medical)
+"uix" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/terragov/north{
+	dir = 6
+	},
+/area/mainship/hallways/starboard_hallway)
 "uiG" = (
 /obj/effect/turf_decal/warning_stripes/thick,
 /turf/open/floor/plating,
@@ -16449,10 +16455,6 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
-"uDG" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/hexagon,
-/area/mainship/living/tankerbunks)
 "uEg" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/wood,
@@ -17536,11 +17538,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/boxingring)
 "waC" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/turf/open/floor/mainship/hexagon,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
 /area/mainship/living/tankerbunks)
 "wcT" = (
 /turf/closed/wall/mainship/white,
@@ -54113,7 +54112,7 @@ vmD
 vmD
 vmD
 vmD
-jti
+bLP
 vmD
 rWD
 aHG
@@ -54891,7 +54890,7 @@ hWt
 vmD
 vmD
 vmD
-eKC
+lGF
 lVR
 kGc
 bbl
@@ -55408,9 +55407,9 @@ vmD
 eel
 pgh
 vDH
-bWg
+fTZ
 xdN
-bLP
+gYa
 tqD
 rUF
 bJB
@@ -55665,9 +55664,9 @@ vmD
 miU
 eQb
 fqj
-pwX
+kxM
 oOX
-bAZ
+exQ
 miU
 rUF
 xWS
@@ -55922,9 +55921,9 @@ vmD
 tpi
 eQb
 kGc
-qWG
+gaq
 fGV
-fTZ
+uix
 cKB
 rUF
 hWC
@@ -56181,7 +56180,7 @@ iay
 ciN
 tpi
 eel
-lYk
+cqV
 tpi
 rUF
 nIn
@@ -56438,7 +56437,7 @@ cRE
 miU
 tpi
 miU
-gYa
+eKC
 cRE
 rUF
 dPp
@@ -56691,12 +56690,12 @@ oGN
 oGN
 ezY
 oGN
-ucK
-uDG
+lfc
+bWg
 mXm
+waC
+waC
 hTV
-hTV
-tIO
 hEc
 uyy
 cBw
@@ -56949,7 +56948,7 @@ eFo
 eFo
 eFo
 kCs
-uDG
+bWg
 xLu
 xLu
 gcd
@@ -57206,7 +57205,7 @@ eFo
 eFo
 eFo
 pqQ
-uDG
+bWg
 xLu
 uXw
 eZp
@@ -57463,7 +57462,7 @@ lpt
 eFo
 eFo
 gcr
-waC
+gCL
 xLu
 rOV
 vXQ

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -384,10 +384,19 @@
 	desc = "Heavy duty, airtight, plastic flaps."
 
 /obj/structure/plasticflaps/sturdy //Anti-unga flaps
-	desc = "Plastic flaps for transporting supplies."
+	desc = "Plastic flaps for transporting supplies. Use wrench to anchor and move it around!"
 	obj_flags = null
 	resistance_flags = XENO_DAMAGEABLE
 
+/obj/structure/plasticflaps/sturdy/wrench_act(mob/living/user, obj/item/tool)
+	playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+	if(anchored)
+		balloon_alert(user, "Plastic flaps are unsecured")
+		anchored = FALSE
+	else
+		balloon_alert(user, "Plastic flaps are secured!")
+		anchored = TRUE
+	return TRUE
 
 	//Magmoor Cryopods
 


### PR DESCRIPTION

## About The Pull Request

Lead the way, Pillar of Spring!
<img width="3329" height="4465" alt="image" src="https://github.com/user-attachments/assets/06b12d7a-d5b7-4de7-abdf-7bd2e6eba2e9" />

Change medbay to be more compacted but optimized in light of medical staff's input:
Old
<img width="750" height="837" alt="image" src="https://github.com/user-attachments/assets/5ad17ac3-0830-4971-be74-750f90be4bc2" />
New
<img width="966" height="806" alt="image" src="https://github.com/user-attachments/assets/693d5ebb-a086-4232-8005-f81fc0eeef17" />

Due to droppods moving, vehicle bay have changed as well.
Old
<img width="984" height="718" alt="image" src="https://github.com/user-attachments/assets/ce652362-7248-4f7e-b806-7c9d7354456f" />
New
<img width="1003" height="761" alt="image" src="https://github.com/user-attachments/assets/500e0c8a-7880-4a67-86a7-940a3544b999" />

New update with req! Rearrange some vendors in req to better suit the needs of planetside marines and add plastic flaps so that marines cannot push crates out of supply drop zone. You can wrench the plastic flaps to move them if you so desire to:
Old
<img width="449" height="390" alt="image" src="https://github.com/user-attachments/assets/0c8a4aea-051c-4211-bac7-855c56ec3ce2" />
New
<img width="458" height="789" alt="image" src="https://github.com/user-attachments/assets/636a0a90-14c6-4fe3-911a-26c9daa860fe" />
See how crates flow through flaps and people can't jump or enter through flaps.
[dreamseeker_VZS0Ao8UZq.webm](https://github.com/user-attachments/assets/0568cd13-7eeb-453a-868f-12bd6ea88d4c)
Use wrench to move flaps!
[dreamseeker_zVl1AHt8q7.webm](https://github.com/user-attachments/assets/db91e173-a632-4580-b8d9-d044ee7f56d9)

Prep have changed to make it easier to prepare for both people who come in ready in round start and late players:
Old
<img width="386" height="508" alt="image" src="https://github.com/user-attachments/assets/a8672809-e53f-49db-8bba-8cd341f47933" />
New
<img width="1017" height="1291" alt="image" src="https://github.com/user-attachments/assets/d7393836-d95f-48d6-959d-2b13da4a7428" />

Changed south of prep to faciliate SD wall cutting.
<img width="841" height="719" alt="image" src="https://github.com/user-attachments/assets/76ff27d6-8486-47de-8044-10a1f8e2ac5e" />


## Why It's Good For The Game

Pillar of Spring is the most recurring shipside map in TGMC, and it makes sense that it carries all the QoL for prep given that marines change overtime.

## Changelog

:cl:
add: Changes in Pillar of Spring medbay, droppods, vehicle bay, prep, and req.
balance: Pillar of Spring's north side of SD requires less wall cutting.
/:cl:
