### PR TITLE
Oppressor abduct nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -593,7 +593,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	action_icon = 'icons/Xeno/actions/praetorian.dmi'
 	desc = "Throw your tail out and hook in any humans caught in it. Ends prematurely if blocked or hits anything dense."
 	ability_cost = 50
-	cooldown_duration = 12 SECONDS
+	cooldown_duration = 18 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_ABDUCT,
 	)
@@ -638,8 +638,8 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	var/turf/xeno_turf = get_turf(xeno_owner)
 
 	xeno_owner.face_atom(targetted_turf)
-	if(!do_after(owner, 0.1 SECONDS, IGNORE_HELD_ITEM, owner, BUSY_ICON_DANGER) || !can_use_ability(targetted_turf, TRUE, ABILITY_IGNORE_SELECTED_ABILITY))
-		add_cooldown(1 SECONDS)
+	if(!do_after(owner, 0.2 SECONDS, IGNORE_HELD_ITEM, owner, BUSY_ICON_DANGER) || !can_use_ability(targetted_turf, TRUE, ABILITY_IGNORE_SELECTED_ABILITY))
+		add_cooldown(cooldown_duration * 0.5)
 		return
 	xeno_owner.face_atom(targetted_turf)
 	turf_line = get_traversal_line(get_step(xeno_turf, get_cardinal_dir(xeno_turf, targetted_turf)), check_path(xeno_turf, targetted_turf, PASS_THROW))
@@ -652,16 +652,22 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		telegraphed_atoms += new /obj/effect/xeno/abduct_warning(turf_from_line)
 
 	ADD_TRAIT(xeno_owner, TRAIT_IMMOBILE, XENO_TRAIT)
-	ability_timer = addtimer(CALLBACK(src, PROC_REF(pull_them_in)), 0.7 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE)
-	RegisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED, PROC_REF(failed_pull))
-	RegisterSignal(xeno_owner, COMSIG_LIVING_STATUS_STAGGER, PROC_REF(failed_pull))
+	var/pull_time = 0.5 SECONDS + get_dist(xeno_owner, turf_line[length(turf_line)])
+	ability_timer = addtimer(CALLBACK(src, PROC_REF(pull_them_in)), pull_time, TIMER_STOPPABLE|TIMER_UNIQUE)
+	RegisterSignals(xeno_owner, list(
+		SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT),
+		SIGNAL_ADDTRAIT(TRAIT_FLOORED),
+		SIGNAL_ADDTRAIT(TRAIT_STAGGERED),
+		SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED),
+		COMSIG_MOVABLE_MOVED,
+		), PROC_REF(failed_pull))
 
 /datum/action/ability/activable/xeno/oppressor/abduct/on_post_throw(datum/source)
 	. = ..()
 	var/mob/living/carbon/human/human_source = source
 	human_source.Paralyze(0.2 SECONDS * last_known_multiplier)
 	human_source.add_slowdown(0.6 * last_known_multiplier)
-	human_source.adjust_stagger(3 SECONDS * last_known_multiplier)
+	human_source.adjust_stagger(1 SECONDS * last_known_multiplier)
 	REMOVE_TRAIT(human_source, TRAIT_IMMOBILE, THROW_TRAIT)
 	human_source.allow_pass_flags &= ~(PASS_MOB|PASS_XENO)
 
@@ -707,7 +713,13 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 /datum/action/ability/activable/xeno/oppressor/abduct/proc/cleanup_variables()
 	REMOVE_TRAIT(xeno_owner, TRAIT_IMMOBILE, XENO_TRAIT)
 	UnregisterSignal(xeno_owner, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(xeno_owner, COMSIG_LIVING_STATUS_STAGGER)
+	UnregisterSignal(xeno_owner, list(
+		SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT),
+		SIGNAL_ADDTRAIT(TRAIT_FLOORED),
+		SIGNAL_ADDTRAIT(TRAIT_STAGGERED),
+		SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED),
+		COMSIG_MOVABLE_MOVED,
+		))
 	QDEL_LIST(telegraphed_atoms)
 	deltimer(ability_timer)
 	ability_timer = null


### PR DESCRIPTION

## About The Pull Request
Abduct CD increased to 18 seconds from 12 seconds.
Initial windup increased to 0.2 seconds from 0.1. 
CD for failing initial windup changed from to half normal CD (i.e. 9 seconds) instead of a flat 1 second.
Telegraphed pull duration (time before pull actually happens) now scales with distance. Base time is 0.5 seconds instead of 0.7 seconds, but is increased by 0.1 second per tile of range. i.e. at 2 range windup is 0.7 seconds. At max 7 range it's 1.2 seconds.
Reduced stagger duration on victims to 1 second per captured mob down from 3 seconds per mob.

Also fixed up the signals so now all CC (i.e. stuns/stagger/knockback) will correctly cancel the ability.
## Why It's Good For The Game
Abduct is incredibly powerful, with a low CD, very long range, causes strong CC and is pretty much risk free to spam.

This change ensures it still has it's full utility power and fishing goodness, but:
A. Makes it less spammable
B. Adds a drawback for super long range abducts
C. Lets marines actually cancel it as intended
D. Reduces the soft CC when it succeds (3 seconds PER CAUGHT MARINE is a fucking long ass time, on top of the hard stun and slowdown)
## Changelog
:cl:
balance: Abduct windup now scales with range
balance: Abduct CD increased to 18 seconds from 12
balance: Abduct stagger reduced to 1 second from 3 seconds per human caught
fix: Abduct can be properly cancelled by stuns and stagger
/:cl:
