### PR TITLE
zcrash hmg-08 ammo is now the normal variant

### DIFF
--- a/code/game/objects/machinery/vending/zombie_crash_vendor.dm
+++ b/code/game/objects/machinery/vending/zombie_crash_vendor.dm
@@ -94,7 +94,7 @@
 		/obj/item/weapon/gun/hsg_102 = list(CAT_EMPLACEMENTS, "\"HSG-102\" Emplacement", 14, "emplacement-heavysmartgun"),
 		/obj/item/ammo_magazine/hsg_102 = list(CAT_EMPLACEMENTS, "\"HSG-102\" Ammo", 10, "emplacement-heavysmartgun"),
 		/obj/item/weapon/gun/heavymachinegun = list(CAT_EMPLACEMENTS, "\"HMG-08\" Emplacement", 14, "emplacement-heavymachinegun"),
-		/obj/item/ammo_magazine/heavymachinegun/small = list(CAT_EMPLACEMENTS, "\"HMG-08\" Ammo", 10, "emplacement-heavymachinegun"),
+		/obj/item/ammo_magazine/heavymachinegun = list(CAT_EMPLACEMENTS, "\"HMG-08\" Ammo", 10, "emplacement-heavymachinegun"),
 		/obj/item/weapon/gun/standard_minigun = list(CAT_EMPLACEMENTS, "\"MG-2005\" Emplacement", 14, "emplacement-minigun"),
 		/obj/item/ammo_magazine/heavy_minigun = list(CAT_EMPLACEMENTS, "\"MG-2005\" Ammo", 10, "emplacement-minigun"),
 		/obj/item/weapon/gun/standard_auto_cannon = list(CAT_EMPLACEMENTS, "\"ATR-22\" Emplacement", 14, "emplacement-autocannon"),


### PR DESCRIPTION

## About The Pull Request
HMG-08 ammo from the Zombie Crash vendor is now the normal variant (500 bullets) instead of the small variant (250 bullets).

## Why It's Good For The Game
Makes the ammo reasonable in point cost compared to up buying its emplacement which comes pre-loaded with 500 bullets. In sum, people were abandoning their empty HMG because it was more cost effective to buy a pre-filled HMG.

## Changelog
:cl:
add: HMG-08 ammo from Zombie Crash vendor is now the normal variant (500 bullets).
/:cl:
