### PR TITLE
Removing job positions now bottoms out at 0

### DIFF
--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -248,7 +248,7 @@ GLOBAL_PROTECT(exp_specialmap)
 	if(total_positions == -1)
 		CRASH("remove_job_positions called with [amount] amount for a job set to overflow")
 	var/previous_amount = total_positions
-	total_positions -= amount
+	total_positions = max(total_positions - amount, 0)
 	manage_job_lists(previous_amount)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Adds a max function to make sure the positions don't go below 0
## Why It's Good For The Game
Should hopefully fix some weird cases
## Changelog
:cl:
fix: Removing job positions now bottoms out at 0
/:cl:
