### PR TITLE
fixes abduct's reclusive self-knockdown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -703,11 +703,11 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 /// Ends the ability by punishing the owner.
 /datum/action/ability/activable/xeno/oppressor/abduct/proc/failed_pull()
 	SIGNAL_HANDLER
-	xeno_owner.Knockdown(1 SECONDS)
-	xeno_owner.add_slowdown(0.9)
 	succeed_activate()
 	add_cooldown()
 	cleanup_variables()
+	xeno_owner.Knockdown(1 SECONDS)
+	xeno_owner.add_slowdown(0.9)
 
 /// Cleans up any unneeded variables, signals, and undoes any traits that the ability gave.
 /datum/action/ability/activable/xeno/oppressor/abduct/proc/cleanup_variables()


### PR DESCRIPTION

## About The Pull Request
Abduct's knockdown occurs after signals are unregistered. This prevents the knockdown from calling the proc that applies a knockdown... which calls the proc again to do a knockdown... which does it again and again.

## Why It's Good For The Game
Bugfix. I died.

## Changelog
:cl:
fix: Abduct's self-knockdown is no longer reclusive and thus does not self-knockdown for a absurd amount of time.
/:cl:
