### PR TITLE
Surgery enhancements

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -1,40 +1,36 @@
-#define SURGERY_TOOL_CUTTING "surgery_tool_cutting"
-#define SURGERY_TOOL_CLAMPING "surgery_tool_clamping"
-#define SURGERY_TOOL_RETRACTING "surgery_tool_RETRACTING"
-#define SURGERY_TOOL_CAUTERIZING "surgery_tool_cauterizing"
-
 ///List of tools for generic cutting surgery steps
-GLOBAL_LIST_INIT(surgery_cut_tools, list(
-	/obj/item/tool/surgery/scalpel = 100,
-	/obj/item/tool/kitchen/knife = 75,
-	/obj/item/shard = 50,
-	/obj/item/weapon/combat_knife = 25,
-	/obj/item/attachable/bayonet = 25,
-	/obj/item/weapon/shiv = 15,
-	/obj/item/stack/throwing_knife = 15,
-	/obj/item/weapon/sword = 5,
-))
+#define SURGERY_TOOL_CUTTING list( \
+	/obj/item/tool/surgery/scalpel = 100, \
+	/obj/item/tool/kitchen/knife = 75, \
+	/obj/item/shard = 50, \
+	/obj/item/weapon/combat_knife = 25, \
+	/obj/item/attachable/bayonet = 25, \
+	/obj/item/weapon/shiv = 15, \
+	/obj/item/stack/throwing_knife = 15, \
+	/obj/item/weapon/sword = 5, \
+)
 ///List of tools for generic clamping surgery steps
-GLOBAL_LIST_INIT(surgery_clamp_tools, list(
-	/obj/item/tool/surgery/hemostat = 100,
-	/obj/item/stack/cable_coil = 75,
-	/obj/item/assembly/mousetrap = 10,
-))
+#define SURGERY_TOOL_CLAMPING list( \
+	/obj/item/tool/surgery/hemostat = 100, \
+	/obj/item/stack/cable_coil = 75, \
+	/obj/item/assembly/mousetrap = 10, \
+)
 ///List of tools for generic retracting surgery steps
-GLOBAL_LIST_INIT(surgery_retract_tools, list(
-	/obj/item/tool/surgery/retractor = 100,
-	/obj/item/tool/crowbar = 75,
-	/obj/item/tool/kitchen/utensil/fork = 50,
-))
+#define SURGERY_TOOL_RETRACTING list( \
+	/obj/item/tool/surgery/retractor = 100, \
+	/obj/item/tool/crowbar = 75, \
+	/obj/item/tool/kitchen/utensil/fork = 50, \
+)
 ///List of tools for generic cauterising surgery steps
-GLOBAL_LIST_INIT(surgery_cauterize_tools, list(
-	/obj/item/tool/surgery/cautery = 100,
-	/obj/item/clothing/mask/cigarette = 75,
-	/obj/item/tool/lighter = 50,
-	/obj/item/tool/weldingtool = 25,
-	/obj/item/tool/pickaxe/plasmacutter = 5, //you gotta be desperate
-))
+#define SURGERY_TOOL_CAUTERIZING list( \
+	/obj/item/tool/surgery/cautery = 100, \
+	/obj/item/clothing/mask/cigarette = 75, \
+	/obj/item/tool/lighter = 50, \
+	/obj/item/tool/weldingtool = 25, \
+	/obj/item/tool/pickaxe/plasmacutter = 5, \
+)
 
+///List of all surgery step datums
 GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 
 /// Surgery Steps - Initialize all /datum/surgery_step into a list

--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -1,0 +1,47 @@
+#define SURGERY_TOOL_CUTTING "surgery_tool_cutting"
+#define SURGERY_TOOL_CLAMPING "surgery_tool_clamping"
+#define SURGERY_TOOL_RETRACTING "surgery_tool_RETRACTING"
+#define SURGERY_TOOL_CAUTERIZING "surgery_tool_cauterizing"
+
+///List of tools for generic cutting surgery steps
+GLOBAL_LIST_INIT(surgery_cut_tools, list(
+	/obj/item/tool/surgery/scalpel = 100,
+	/obj/item/tool/kitchen/knife = 75,
+	/obj/item/shard = 50,
+	/obj/item/weapon/combat_knife = 25,
+	/obj/item/attachable/bayonet = 25,
+	/obj/item/weapon/shiv = 15,
+	/obj/item/stack/throwing_knife = 15,
+	/obj/item/weapon/sword = 5,
+))
+///List of tools for generic clamping surgery steps
+GLOBAL_LIST_INIT(surgery_clamp_tools, list(
+	/obj/item/tool/surgery/hemostat = 100,
+	/obj/item/stack/cable_coil = 75,
+	/obj/item/assembly/mousetrap = 10,
+))
+///List of tools for generic retracting surgery steps
+GLOBAL_LIST_INIT(surgery_retract_tools, list(
+	/obj/item/tool/surgery/retractor = 100,
+	/obj/item/tool/crowbar = 75,
+	/obj/item/tool/kitchen/utensil/fork = 50,
+))
+///List of tools for generic cauterising surgery steps
+GLOBAL_LIST_INIT(surgery_cauterize_tools, list(
+	/obj/item/tool/surgery/cautery = 100,
+	/obj/item/clothing/mask/cigarette = 75,
+	/obj/item/tool/lighter = 50,
+	/obj/item/tool/weldingtool = 25,
+	/obj/item/tool/pickaxe/plasmacutter = 5, //you gotta be desperate
+))
+
+GLOBAL_LIST_INIT(surgery_steps, init_surgery())
+
+/// Surgery Steps - Initialize all /datum/surgery_step into a list
+/proc/init_surgery()
+	var/list/surgeries = list()
+	for(var/surgery_step_type in subtypesof(/datum/surgery_step))
+		var/datum/surgery_step/step = new surgery_step_type
+		surgeries += step
+
+	return sort_surgeries(surgeries)

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -273,6 +273,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			else
 				to_chat(user, span_notice("[src] is full."))
 
+/obj/item/clothing/mask/cigarette/surgery_tool_check()
+	return lit
+
 /obj/item/clothing/mask/cigarette/proc/light(flavor_text = null)
 	if(lit)
 		return
@@ -602,6 +605,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			turn_off(user, FALSE)
 	else
 		return ..()
+
+/obj/item/tool/lighter/surgery_tool_check()
+	return heat
 
 /obj/item/tool/lighter/proc/turn_off(mob/living/bearer, silent = TRUE)
 	if(heat)

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -223,6 +223,9 @@
 		return FALSE
 	return ..()
 
+/obj/item/tool/weldingtool/surgery_tool_check()
+	return welding
+
 ///fetches the correct weldint spark sprite to use. ideally we should replace this with an automatically centering system
 /atom/proc/get_weld_spark_icon_and_state()
 	return list('icons/effects/welding_effect.dmi', "welding_sparks")

--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -119,6 +119,8 @@
 	toggle(user)
 	user.changeNext_move(CLICK_CD_LONG)
 
+/obj/item/tool/pickaxe/plasmacutter/surgery_tool_check()
+	return powered
 
 //Toggles the cutter off and on
 /obj/item/tool/pickaxe/plasmacutter/proc/toggle(mob/user, silent)

--- a/code/game/objects/items/weapons/energy.dm
+++ b/code/game/objects/items/weapons/energy.dm
@@ -86,6 +86,9 @@
 	H.update_inv_l_hand()
 	H.update_inv_r_hand()
 
+/obj/item/weapon/energy/sword/surgery_tool_check()
+	return active
+
 ///Handles all the state switch stuff
 /obj/item/weapon/energy/sword/proc/switch_state(datum/source, mob/living/user)
 	SIGNAL_HANDLER

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -5,6 +5,7 @@
 	can_infect = 1
 	allowed_tools = list(
 		/obj/item/tool/surgery/circular_saw = 100,
+		/obj/item/weapon/energy/sword = 75,
 		/obj/item/tool/hatchet = 75,
 		/obj/item/weapon/sword = 75,
 	)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -49,11 +49,7 @@
 
 
 /datum/surgery_step/open_encased/retract
-	allowed_tools = list(
-		/obj/item/tool/surgery/retractor = 100,
-		/obj/item/tool/crowbar = 75,
-	)
-
+	allowed_tools = SURGERY_TOOL_RETRACTING
 	min_duration = RETRACT_OPEN_ENCASED_MIN_DURATION
 	max_duration = RETRACT_OPEN_ENCASED_MAX_DURATION
 	open_case_step = 2.5
@@ -88,11 +84,7 @@
 
 
 /datum/surgery_step/open_encased/close
-	allowed_tools = list(
-		/obj/item/tool/surgery/retractor = 100,
-		/obj/item/tool/crowbar = 75,
-	)
-
+	allowed_tools = SURGERY_TOOL_RETRACTING
 	min_duration = RETRACT_CLOSE_ENCASED_MIN_DURATION
 	max_duration = RETRACT_CLOSE_ENCASED_MAX_DURATION
 	open_case_step = 3
@@ -145,16 +137,7 @@
 	return ..()
 
 /datum/surgery_step/fat_removal
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
-		/obj/item/weapon/combat_knife = 25,
-		/obj/item/attachable/bayonet = 25,
-		/obj/item/weapon/shiv = 15,
-		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword = 5,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 	min_duration = DEFAT_MIN_DURATION
 	max_duration = DEFAT_MAX_DURATION
 	priority = 2

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -150,8 +150,10 @@
 		/obj/item/tool/kitchen/knife = 75,
 		/obj/item/shard = 50,
 		/obj/item/weapon/combat_knife = 25,
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/weapon/shiv = 15,
 		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword/mercsword = 1,
+		/obj/item/weapon/sword = 5,
 	)
 	min_duration = DEFAT_MIN_DURATION
 	max_duration = DEFAT_MAX_DURATION

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -22,12 +22,7 @@
 		return 1
 
 /datum/surgery_step/eye/cut_open
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 15,
-		/obj/item/weapon/shiv = 15,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 
 	min_duration = EYE_CUT_MIN_DURATION
 	max_duration = EYE_CUT_MAX_DURATION
@@ -92,12 +87,7 @@
 	target.apply_damage(10, BRUTE, affected, updating_health = TRUE)
 
 /datum/surgery_step/eye/mend_eyes
-	allowed_tools = list(
-		/obj/item/tool/surgery/hemostat = 100,
-		/obj/item/stack/cable_coil = 75,
-		/obj/item/assembly/mousetrap = 10,
-	)
-
+	allowed_tools = SURGERY_TOOL_CLAMPING
 	min_duration = EYE_MEND_MIN_DURATION
 	max_duration = EYE_MEND_MAX_DURATION
 	eye_step = 2
@@ -126,14 +116,7 @@
 
 
 /datum/surgery_step/eye/cauterize
-	allowed_tools = list(
-		/obj/item/tool/surgery/cautery = 100,
-		/obj/item/clothing/mask/cigarette = 75,
-		/obj/item/tool/lighter = 50,
-		/obj/item/tool/weldingtool = 25,
-		/obj/item/tool/pickaxe/plasmacutter = 5,
-	)
-
+	allowed_tools = SURGERY_TOOL_CAUTERIZING
 	min_duration = EYE_CAUTERISE_MIN_DURATION
 	max_duration = EYE_CAUTERISE_MAX_DURATION
 	eye_step = 3

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -25,7 +25,8 @@
 	allowed_tools = list(
 		/obj/item/tool/surgery/scalpel = 100,
 		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
+		/obj/item/shard = 15,
+		/obj/item/weapon/shiv = 15,
 	)
 
 	min_duration = EYE_CUT_MIN_DURATION
@@ -130,6 +131,7 @@
 		/obj/item/clothing/mask/cigarette = 75,
 		/obj/item/tool/lighter = 50,
 		/obj/item/tool/weldingtool = 25,
+		/obj/item/tool/pickaxe/plasmacutter = 5,
 	)
 
 	min_duration = EYE_CAUTERISE_MIN_DURATION

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -19,16 +19,7 @@
 	return SURGERY_CAN_USE
 
 /datum/surgery_step/face/cut_face
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
-		/obj/item/weapon/combat_knife = 25,
-		/obj/item/attachable/bayonet = 25,
-		/obj/item/weapon/shiv = 15,
-		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword = 5,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 
 	min_duration = FACIAL_CUT_MIN_DURATION
 	max_duration = FACIAL_CUT_MAX_DURATION
@@ -58,12 +49,7 @@
 
 
 /datum/surgery_step/face/mend_vocal
-	allowed_tools = list(
-		/obj/item/tool/surgery/hemostat = 100,
-		/obj/item/stack/cable_coil = 75,
-		/obj/item/assembly/mousetrap = 10,
-	)
-
+	allowed_tools = SURGERY_TOOL_CLAMPING
 	min_duration = FACIAL_MEND_MIN_DURATION
 	max_duration = FACIAL_MEND_MAX_DURATION
 	face_step = 1
@@ -121,14 +107,7 @@
 
 
 /datum/surgery_step/face/cauterize
-	allowed_tools = list(
-		/obj/item/tool/surgery/cautery = 100,
-		/obj/item/clothing/mask/cigarette = 75,
-		/obj/item/tool/lighter = 50,
-		/obj/item/tool/weldingtool = 25,
-		/obj/item/tool/pickaxe/plasmacutter = 5,
-	)
-
+	allowed_tools = SURGERY_TOOL_CAUTERIZING
 	min_duration = FACIAL_CAUTERISE_MIN_DURATION
 	max_duration = FACIAL_CAUTERISE_MAX_DURATION
 	face_step = 3

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -23,6 +23,11 @@
 		/obj/item/tool/surgery/scalpel = 100,
 		/obj/item/tool/kitchen/knife = 75,
 		/obj/item/shard = 50,
+		/obj/item/weapon/combat_knife = 25,
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/weapon/shiv = 15,
+		/obj/item/stack/throwing_knife = 15,
+		/obj/item/weapon/sword = 5,
 	)
 
 	min_duration = FACIAL_CUT_MIN_DURATION
@@ -121,6 +126,7 @@
 		/obj/item/clothing/mask/cigarette = 75,
 		/obj/item/tool/lighter = 50,
 		/obj/item/tool/weldingtool = 25,
+		/obj/item/tool/pickaxe/plasmacutter = 5,
 	)
 
 	min_duration = FACIAL_CAUTERISE_MIN_DURATION

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -114,8 +114,10 @@
 		/obj/item/tool/kitchen/knife = 75,
 		/obj/item/shard = 50,
 		/obj/item/weapon/combat_knife = 25,
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/weapon/shiv = 15,
 		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword/mercsword = 1,
+		/obj/item/weapon/sword = 5,
 	)
 
 	min_duration = 60
@@ -248,6 +250,7 @@
 		/obj/item/clothing/mask/cigarette = 75,
 		/obj/item/tool/lighter = 50,
 		/obj/item/tool/weldingtool = 25,
+		/obj/item/tool/pickaxe/plasmacutter = 5, //you gotta be desperate
 	)
 
 	min_duration = CAUTERY_MIN_DURATION

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -106,19 +106,8 @@
 	affected.createwound(BURN, 12.5)
 	affected.update_wounds()
 
-
-
 /datum/surgery_step/generic/cut_open
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
-		/obj/item/weapon/combat_knife = 25,
-		/obj/item/attachable/bayonet = 25,
-		/obj/item/weapon/shiv = 15,
-		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword = 5,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 
 	min_duration = 60
 	max_duration = 80
@@ -154,12 +143,7 @@
 
 
 /datum/surgery_step/generic/clamp_bleeders
-	allowed_tools = list(
-		/obj/item/tool/surgery/hemostat = 100,
-		/obj/item/stack/cable_coil = 75,
-		/obj/item/assembly/mousetrap = 20,
-	)
-
+	allowed_tools = SURGERY_TOOL_CLAMPING
 	min_duration = 40
 	max_duration = 60
 
@@ -194,11 +178,7 @@
 
 
 /datum/surgery_step/generic/retract_skin
-	allowed_tools = list(
-		/obj/item/tool/surgery/retractor = 100,
-		/obj/item/tool/crowbar = 75,
-		/obj/item/tool/kitchen/utensil/fork = 50,
-	)
+	allowed_tools = SURGERY_TOOL_RETRACTING
 
 	min_duration = 30
 	max_duration = 40
@@ -245,13 +225,7 @@
 
 
 /datum/surgery_step/generic/cauterize
-	allowed_tools = list(
-		/obj/item/tool/surgery/cautery = 100,
-		/obj/item/clothing/mask/cigarette = 75,
-		/obj/item/tool/lighter = 50,
-		/obj/item/tool/weldingtool = 25,
-		/obj/item/tool/pickaxe/plasmacutter = 5, //you gotta be desperate
-	)
+	allowed_tools = SURGERY_TOOL_CAUTERIZING
 
 	min_duration = CAUTERY_MIN_DURATION
 	max_duration = CAUTERY_MAX_DURATION
@@ -288,9 +262,9 @@
 ///Sewing people closed. Not fast, but works on corpses.
 /datum/surgery_step/generic/repair
 	allowed_tools = list(
-		/obj/item/tool/surgery/suture = 100,
-		/obj/item/stack/cable_coil = 75,
-		/obj/item/shard = 20,
+	/obj/item/tool/surgery/suture = 100,
+	/obj/item/stack/cable_coil = 75,
+	/obj/item/shard = 20,
 	)
 	surgery_skill_required = SKILL_SURGERY_TRAINED
 	open_step = 0

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -18,12 +18,7 @@
 	return SURGERY_CANNOT_USE
 
 /datum/surgery_step/head/peel
-	allowed_tools = list(
-		/obj/item/tool/surgery/retractor = 100,
-		/obj/item/tool/crowbar = 75,
-		/obj/item/tool/kitchen/utensil/fork = 50,
-	)
-
+	allowed_tools = SURGERY_TOOL_RETRACTING
 	min_duration = 30
 	max_duration = 40
 	reattach_step = 0
@@ -119,14 +114,7 @@
 
 
 /datum/surgery_step/head/prepare
-	allowed_tools = list(
-		/obj/item/tool/surgery/cautery = 100,
-		/obj/item/clothing/mask/cigarette = 75,
-		/obj/item/tool/lighter = 50,
-		/obj/item/tool/weldingtool = 25,
-		/obj/item/tool/pickaxe/plasmacutter = 5,
-	)
-
+	allowed_tools = SURGERY_TOOL_CAUTERIZING
 	min_duration = 60
 	max_duration = 80
 	reattach_step = 3

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -124,6 +124,7 @@
 		/obj/item/clothing/mask/cigarette = 75,
 		/obj/item/tool/lighter = 50,
 		/obj/item/tool/weldingtool = 25,
+		/obj/item/tool/pickaxe/plasmacutter = 5,
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/necrosis.dm
+++ b/code/modules/surgery/necrosis.dm
@@ -17,9 +17,14 @@
 /datum/surgery_step/necro/fix_dead_tissue //Debridement
 
 	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,		\
-		/obj/item/tool/kitchen/knife = 75,	\
-		/obj/item/shard = 50, 		\
+		/obj/item/tool/surgery/scalpel = 100,
+		/obj/item/tool/kitchen/knife = 75,
+		/obj/item/shard = 50,
+		/obj/item/weapon/combat_knife = 25,
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/weapon/shiv = 15,
+		/obj/item/stack/throwing_knife = 15,
+		/obj/item/weapon/sword = 5,
 	)
 
 	can_infect = 1

--- a/code/modules/surgery/necrosis.dm
+++ b/code/modules/surgery/necrosis.dm
@@ -16,16 +16,7 @@
 
 /datum/surgery_step/necro/fix_dead_tissue //Debridement
 
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
-		/obj/item/weapon/combat_knife = 25,
-		/obj/item/attachable/bayonet = 25,
-		/obj/item/weapon/shiv = 15,
-		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword = 5,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 
 	can_infect = 1
 	blood_level = 1

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -25,6 +25,11 @@
 		/obj/item/tool/surgery/scalpel = 100,
 		/obj/item/tool/kitchen/knife = 75,
 		/obj/item/shard = 50,
+		/obj/item/weapon/combat_knife = 25,
+		/obj/item/attachable/bayonet = 25,
+		/obj/item/weapon/shiv = 15,
+		/obj/item/stack/throwing_knife = 15,
+		/obj/item/weapon/sword = 5,
 	)
 
 	min_duration = ROBOLIMB_CUT_MIN_DURATION
@@ -94,6 +99,7 @@
 		/obj/item/clothing/mask/cigarette = 75,
 		/obj/item/tool/lighter = 50,
 		/obj/item/tool/weldingtool = 25,
+		/obj/item/tool/pickaxe/plasmacutter = 5,
 	)
 
 	min_duration = ROBOLIMB_PREPARE_MIN_DURATION

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -21,16 +21,7 @@
 	return SURGERY_CAN_USE
 
 /datum/surgery_step/limb/cut
-	allowed_tools = list(
-		/obj/item/tool/surgery/scalpel = 100,
-		/obj/item/tool/kitchen/knife = 75,
-		/obj/item/shard = 50,
-		/obj/item/weapon/combat_knife = 25,
-		/obj/item/attachable/bayonet = 25,
-		/obj/item/weapon/shiv = 15,
-		/obj/item/stack/throwing_knife = 15,
-		/obj/item/weapon/sword = 5,
-	)
+	allowed_tools = SURGERY_TOOL_CUTTING
 
 	min_duration = ROBOLIMB_CUT_MIN_DURATION
 	max_duration = ROBOLIMB_CUT_MAX_DURATION
@@ -61,12 +52,7 @@
 
 
 /datum/surgery_step/limb/mend
-	allowed_tools = list(
-		/obj/item/tool/surgery/retractor = 100,
-		/obj/item/tool/crowbar = 75,
-		/obj/item/tool/kitchen/utensil/fork = 50,
-	)
-
+	allowed_tools = SURGERY_TOOL_RETRACTING
 	min_duration = ROBOLIMB_MEND_MIN_DURATION
 	max_duration = ROBOLIMB_MEND_MAX_DURATION
 	limb_step = 1
@@ -94,14 +80,7 @@
 
 
 /datum/surgery_step/limb/prepare
-	allowed_tools = list(
-		/obj/item/tool/surgery/cautery = 100,
-		/obj/item/clothing/mask/cigarette = 75,
-		/obj/item/tool/lighter = 50,
-		/obj/item/tool/weldingtool = 25,
-		/obj/item/tool/pickaxe/plasmacutter = 5,
-	)
-
+	allowed_tools = SURGERY_TOOL_CAUTERIZING
 	min_duration = ROBOLIMB_PREPARE_MIN_DURATION
 	max_duration = ROBOLIMB_PREPARE_MAX_DURATION
 	limb_step = 2

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -22,20 +22,6 @@
 	var/can_infect = 0 //Evil infection stuff that will make everyone hate me
 	var/blood_level = 0 //How much blood this step can get on surgeon. 1 - hands, 2 - full body
 
-/datum/surgery_step/New()
-	. = ..()
-	if(islist(allowed_tools))
-		return
-	switch(allowed_tools)
-		if(SURGERY_TOOL_CUTTING)
-			allowed_tools = GLOB.surgery_cut_tools
-		if(SURGERY_TOOL_CLAMPING)
-			allowed_tools = GLOB.surgery_clamp_tools
-		if(SURGERY_TOOL_RETRACTING)
-			allowed_tools = GLOB.surgery_retract_tools
-		if(SURGERY_TOOL_CAUTERIZING)
-			allowed_tools = GLOB.surgery_cauterize_tools
-
 ///Returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
 	for(var/option in allowed_tools)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,16 +1,5 @@
 /* SURGERY STEPS */
 
-GLOBAL_LIST_INIT(surgery_steps, init_surgery())
-
-/// Surgery Steps - Initialize all /datum/surgery_step into a list
-/proc/init_surgery()
-	var/list/surgeries = list()
-	for(var/surgery_step_type in subtypesof(/datum/surgery_step))
-		var/datum/surgery_step/step = new surgery_step_type
-		surgeries += step
-
-	return sort_surgeries(surgeries)
-
 /datum/surgery_step
 	var/priority = 0 //Steps with higher priority will be attempted first. Accepts decimals
 
@@ -33,14 +22,28 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 	var/can_infect = 0 //Evil infection stuff that will make everyone hate me
 	var/blood_level = 0 //How much blood this step can get on surgeon. 1 - hands, 2 - full body
 
+/datum/surgery_step/New()
+	. = ..()
+	if(islist(allowed_tools))
+		return
+	switch(allowed_tools)
+		if(SURGERY_TOOL_CUTTING)
+			allowed_tools = GLOB.surgery_cut_tools
+		if(SURGERY_TOOL_CLAMPING)
+			allowed_tools = GLOB.surgery_clamp_tools
+		if(SURGERY_TOOL_RETRACTING)
+			allowed_tools = GLOB.surgery_retract_tools
+		if(SURGERY_TOOL_CAUTERIZING)
+			allowed_tools = GLOB.surgery_cauterize_tools
+
 ///Returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
-	for(var/obj/thing AS in allowed_tools)
-		if(!istype(tool, T))
+	for(var/option in allowed_tools)
+		if(!istype(tool, option))
 			continue
 		if(!tool.surgery_tool_check())
 			continue
-		return allowed_tools[T]
+		return allowed_tools[option]
 	return
 
 //Checks if this step applies to the user mob at all

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -35,10 +35,13 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 
 ///Returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
-	for(var/T in allowed_tools)
-		if(istype(tool, T))
-			return allowed_tools[T]
-	return 0
+	for(var/obj/thing AS in allowed_tools)
+		if(!istype(tool, T))
+			continue
+		if(!tool.surgery_tool_check())
+			continue
+		return allowed_tools[T]
+	return
 
 //Checks if this step applies to the user mob at all
 /datum/surgery_step/proc/is_valid_target(mob/living/carbon/target)
@@ -230,3 +233,7 @@ GLOBAL_LIST_INIT(surgery_steps, init_surgery())
 	var/in_progress = 0
 	var/is_same_target = "" //Safety check to prevent surgery juggling
 	var/necro = 0
+
+///Any special conditions to ensure the tool is valid to use, such as being turned on etc
+/obj/proc/surgery_tool_check()
+	return TRUE

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -157,6 +157,7 @@
 #include "code\__DEFINES\stripping.dm"
 #include "code\__DEFINES\structures.dm"
 #include "code\__DEFINES\supply.dm"
+#include "code\__DEFINES\surgery.dm"
 #include "code\__DEFINES\synthetic.dm"
 #include "code\__DEFINES\text.dm"
 #include "code\__DEFINES\tgs.config.dm"


### PR DESCRIPTION

## About The Pull Request
Generic surgery steps now have shared tool lists instead of having the same thing copy pasted 30 times.

Surgery tools now have a proc to see if they're valid to be used. Currently this is generic, and is used for makeshift tools, such as checking if a welder is even on, etc. In the future this could use the surgery step as an arg to do more sophisticated checks.

Also added a few more ghetoo tool options such as bayonets. See changes for details.
## Why It's Good For The Game
Better maintainability, more surgery variety for the desperate and needy.
## Changelog
:cl:
add: Added some more makeshift surgery tool options for some surgery steps
fix: Using makeshift surgery tools checks to see if they are in a valid state, such as a welder being on, etc
code: Some generic surgery steps use a shared global list of tool options instead of copy paste lists
/:cl:
