### PR TITLE
SH-15 tweaks

### DIFF
--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -246,7 +246,7 @@
 	max_range = 15
 	damage = 17
 	damage_falloff = 0.25
-	penetration = 15
+	penetration = 20
 	sundering = 1.5
 
 /datum/ammo/bullet/shotgun/tx15_flechette/spread
@@ -260,7 +260,7 @@
 	shell_speed = 3
 	max_range = 15
 	damage = 60
-	penetration = 30
+	penetration = 20
 	sundering = 3.5
 
 /datum/ammo/bullet/shotgun/tx15_slug/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1285,7 +1285,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/tx15, /obj/item/attachable/magnetic_harness, /obj/item/weapon/gun/grenade_launcher/underslung)
 
 /obj/item/weapon/gun/rifle/standard_autoshotgun/standard
-	starting_attachment_types = list(/obj/item/attachable/stock/tx15, /obj/item/attachable/magnetic_harness, /obj/item/attachable/heavy_barrel, /obj/item/weapon/gun/grenade_launcher/underslung)
+	starting_attachment_types = list(/obj/item/attachable/stock/tx15, /obj/item/attachable/magnetic_harness, /obj/item/attachable/bayonet, /obj/item/weapon/gun/grenade_launcher/underslung)
 
 /obj/item/weapon/gun/rifle/standard_autoshotgun/plasma_pistol
 	starting_attachment_types = list(/obj/item/attachable/stock/tx15, /obj/item/attachable/motiondetector, /obj/item/attachable/extended_barrel, /obj/item/weapon/gun/pistol/plasma_pistol)


### PR DESCRIPTION

## About The Pull Request
Buff SH-15 flechette to 20 AP from 15
Nerf SH-15 slug AP to 20 AP from 30.

Also in HvH removed the BC from standard SH-15 loadouts and replaced with a bayo.
## Why It's Good For The Game
Currently both ammo types have extremely comparable damage on almost all targets, but slugs shoot faster and more accurately, and have soft CC that combos really well with other stuff like sticky nades. This makes flechette kinda just worse overall.

This change should make flechette clearly better in terms of simple damage (and sunder), while slugs have a clearer trade off of lower damage (especially against high armour targets it currently shreds), while getting spammable soft CC.

Also worth noting that while sh-15 slugs are even more problematic in HvH (where most people have higher armour), this is still mainly focused at HvX, especially at crash pop where its a giga strong combo.

The BC removal for HvH just means its less reliable at long range - notably with a BC if you are in CC range you hitscan targets which is pretty powerful.

I could remove the UGL which is what really makes slugs so strong, but that would just kick flechette further, which really didn't need a nerf.
## Changelog
:cl:
balance: SH-15 slugs reduced to 20 AP from 30
balance: SH-15 flechette increased to 20 AP from 15
balance: Campaign: The standard SH-15 has a bayonet instead of a barrel charger
/:cl:
