### PR TITLE
ISG change

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -105,8 +105,8 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG|AMMO_TARGET_TURF
 	damage = 100
 	penetration = 200
-	max_range = 30
-	shell_speed = 0.75
+	max_range = 25
+	shell_speed = 1.5
 	accurate_range = 21
 	handful_amount = 1
 
@@ -124,7 +124,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_PASS_THROUGH_TURF|AMMO_PASS_THROUGH_MOVABLE
 	damage = 275
 	penetration = 75
-	shell_speed = 7
+	shell_speed = 4
 	accurate_range = 24
 	max_range = 35
 

--- a/code/modules/projectiles/magazines/mounted.dm
+++ b/code/modules/projectiles/magazines/mounted.dm
@@ -182,13 +182,14 @@
 	caliber = CALIBER_15CM
 	max_rounds = 1
 	reload_delay = 8 SECONDS
-	default_ammo = /datum/ammo/rocket/heavy_isg
+	default_ammo = /datum/ammo/rocket/heavy_isg/unguided
 
 /obj/item/ammo_magazine/heavy_isg/he
 	name = "FK-88 HE shell (155mm Shell)"
 	desc = "A 15cm HE shell for the FK-88 mounted flak gun. Right-click with other hand to swap between unguided and guided modes."
-	default_ammo = /datum/ammo/rocket/heavy_isg
-	var/guided = TRUE
+	default_ammo = /datum/ammo/rocket/heavy_isg/unguided
+	///Whether this is direct fire or not
+	var/guided = FALSE
 
 /obj/item/ammo_magazine/heavy_isg/he/attack_hand_alternate(mob/living/user)
 	if(guided)


### PR DESCRIPTION

## About The Pull Request
the ISG/whatever flakgun number 9727874 is called has had its HE shells changed so they are unguided by default.
You can still toggle grief mode if you so desire.
Additionally, shell speed changed from a comical 0.75 to a slightly less comical 1.5
Max range reduced to 25 from 30.

For the AP ammo, shell speed changed to 4 from an absurd 7, and max range changed to 30 from 35.
## Why It's Good For The Game
This gun is fucking griefing meme pick, but this should make it at least marginally more viable for genuine use.
## Changelog
:cl:
balance: FK-88 HE shells are unguided by default, and have higher shell speed. AP shells have lower shell speed and minimum range
/:cl:
