### PR TITLE
Medical vendor surgery tab, loadout changes, removes scalpels from surgical webbings, pouches and trays

### DIFF
--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -267,7 +267,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "abf" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1593,7 +1593,7 @@
 /turf/open/floor/mainship,
 /area/mainship/command/cic)
 "ahC" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/machinery/camera/autoname/mainship{
 	dir = 4
 	},
@@ -1953,7 +1953,7 @@
 /turf/open/floor/mainship,
 /area/mainship/medical/lower_medical)
 "aiV" = (
-/obj/machinery/vending/medical,
+/obj/machinery/vending/medical/shipside,
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/medical/medical_science)

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -253,7 +253,6 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
-		/obj/machinery/vending/medical/shipside,
 	),
 	VENDOR_FACTION_VALHALLA = list(
 		/obj/machinery/vending/weapon/valhalla,
@@ -265,6 +264,12 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/tool/nopower/valhalla,
 		/obj/machinery/vending/medical/valhalla,
 	),
+	SQUAD_CORPSMAN = list(
+		/obj/machinery/vending/medical/shipside,
+	),
+	SYNTHETIC = list(
+		/obj/machinery/vending/medical/shipside,
+	),
 	VENDOR_FACTION_CRASH = list(
 		/obj/machinery/vending/weapon/crash,
 		/obj/machinery/vending/uniform_supply,
@@ -273,7 +278,6 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
-		/obj/machinery/vending/medical/shipside,
 	)
 ))
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
-		/obj/machinery/vending/medical,
+		/obj/machinery/vending/medical/shipside,
 	),
 	VENDOR_FACTION_VALHALLA = list(
 		/obj/machinery/vending/weapon/valhalla,
@@ -273,7 +273,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
-		/obj/machinery/vending/medical,
+		/obj/machinery/vending/medical/shipside,
 	)
 ))
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -253,6 +253,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
+		/obj/machinery/vending/medical,
 	),
 	VENDOR_FACTION_VALHALLA = list(
 		/obj/machinery/vending/weapon/valhalla,
@@ -262,9 +263,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed/valhalla,
 		/obj/machinery/vending/cigarette/valhalla,
 		/obj/machinery/vending/tool/nopower/valhalla,
-	),
-	SQUAD_CORPSMAN = list(
-		/obj/machinery/vending/medical/shipside,
+		/obj/machinery/vending/medical/valhalla,
 	),
 	VENDOR_FACTION_CRASH = list(
 		/obj/machinery/vending/weapon/crash,
@@ -274,6 +273,7 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed,
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
+		/obj/machinery/vending/medical,
 	)
 ))
 

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -262,7 +262,6 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/MarineMed/valhalla,
 		/obj/machinery/vending/cigarette/valhalla,
 		/obj/machinery/vending/tool/nopower/valhalla,
-		/obj/machinery/vending/medical/valhalla,
 	),
 	SQUAD_CORPSMAN = list(
 		/obj/machinery/vending/medical/shipside,

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -757,7 +757,6 @@
 
 /obj/item/storage/pouch/surgery/PopulateContents()
 	new /obj/item/tool/surgery/scalpel/manager(src)
-	new /obj/item/tool/surgery/scalpel(src)
 	new /obj/item/tool/surgery/hemostat(src)
 	new /obj/item/tool/surgery/retractor(src)
 	new /obj/item/tool/surgery/cautery(src)

--- a/code/game/objects/items/storage/surgical_tray.dm
+++ b/code/game/objects/items/storage/surgical_tray.dm
@@ -8,7 +8,6 @@
 
 /obj/item/storage/surgical_tray/PopulateContents()
 	new /obj/item/tool/surgery/scalpel/manager(src)
-	new /obj/item/tool/surgery/scalpel(src)
 	new /obj/item/tool/surgery/hemostat(src)
 	new /obj/item/tool/surgery/retractor(src)
 	new /obj/item/tool/surgery/surgical_membrane(src)

--- a/code/game/objects/items/tools/surgery_tools.dm
+++ b/code/game/objects/items/tools/surgery_tools.dm
@@ -9,14 +9,14 @@
 
 /obj/item/tool/surgery/retractor
 	name = "retractor"
-	desc = "Retracts stuff."
+	desc = "For fine manipulation during surgery."
 	icon_state = "retractor"
 	atom_flags = CONDUCT
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/tool/surgery/hemostat
 	name = "hemostat"
-	desc = "You think you have seen this before."
+	desc = "For removing foreign objects during surgery."
 	icon_state = "hemostat"
 	atom_flags = CONDUCT
 	w_class = WEIGHT_CLASS_SMALL
@@ -24,7 +24,7 @@
 
 /obj/item/tool/surgery/cautery
 	name = "cautery"
-	desc = "This stops bleeding."
+	desc = "For closing incisions to finish a surgery."
 	icon_state = "cautery"
 	atom_flags = CONDUCT
 	w_class = WEIGHT_CLASS_TINY
@@ -85,7 +85,7 @@
 */
 /obj/item/tool/surgery/circular_saw
 	name = "circular saw"
-	desc = "For heavy duty cutting."
+	desc = "For opening someone's ribcage, surgically."
 	icon_state = "saw"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	atom_flags = CONDUCT
@@ -101,6 +101,7 @@
 //misc, formerly from code/defines/weapons.dm
 /obj/item/tool/surgery/bonegel
 	name = "bone gel"
+	desc = "For repairing fractures and closing ribcages."
 	icon_state = "bone-gel"
 	force = 0
 	w_class = WEIGHT_CLASS_SMALL
@@ -108,6 +109,7 @@
 
 /obj/item/tool/surgery/FixOVein
 	name = "FixOVein"
+	desc = "For fixing internal bleeding."
 	icon_state = "fixovein"
 	force = 0
 	throwforce = 1
@@ -117,6 +119,7 @@
 /obj/item/tool/surgery/bonesetter
 	name = "bone setter"
 	icon_state = "bonesetter"
+	desc = "For setting fractured bone after bone gel is applied."
 	force = 8
 	throwforce = 9
 	throw_speed = 3
@@ -127,6 +130,7 @@
 /obj/item/tool/surgery/suture
 	name = "surgical suture"
 	icon_state = "suture"
+	desc = "For healing basic brute and burn damage during surgery."
 	force = 3
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
@@ -135,6 +139,7 @@
 /obj/item/tool/surgery/surgical_membrane
 	name = "surgical membrane"
 	icon_state = "surgical_membrane"
+	desc = "For repairing damaged organs and necrotized tissue during surgery."
 	force = 0
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -152,8 +152,8 @@
 	icon_state = "med"
 	icon_deny = "med-deny"
 	icon_vend = "med-vend"
+	isshared = TRUE
 	//product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
-	req_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY) //only doctors and researchers can access these
 	products = list(
 		"Pill Bottle" = list(
 			/obj/item/storage/pill_bottle/bicaridine = -1,
@@ -211,15 +211,27 @@
 			/obj/item/storage/reagent_tank/tricordrazine = 1,
 			/obj/item/storage/reagent_tank/bktt = 1,
 		),
-		"Misc" = list(
-			/obj/item/tool/research/xeno_analyzer = 2,
-			/obj/item/tool/research/excavation_tool = -1,
+		"Surgical Equipment" = list(
 			/obj/item/storage/pouch/surgery = -1,
 			/obj/item/armor_module/storage/uniform/surgery_webbing = -1,
 			/obj/item/reagent_containers/spray/surgery = -1,
 			/obj/item/tool/soap = 3,
-			/obj/item/clothing/glasses/hud/health = 6,
 			/obj/item/roller = 6,
+			/obj/item/tool/surgery/scalpel/manager = -1,
+			/obj/item/tool/surgery/hemostat = -1,
+			/obj/item/tool/surgery/retractor = -1,
+			/obj/item/tool/surgery/cautery = -1,
+			/obj/item/tool/surgery/circular_saw = -1,
+			/obj/item/tool/surgery/surgical_membrane = -1,
+			/obj/item/tool/surgery/bonegel = -1,
+			/obj/item/tool/surgery/bonesetter = -1,
+			/obj/item/tool/surgery/FixOVein = -1,
+			/obj/item/tool/surgery/suture = -1,
+		),
+		"Misc" = list(
+			/obj/item/tool/research/xeno_analyzer = 2,
+			/obj/item/tool/research/excavation_tool = -1,
+			/obj/item/clothing/glasses/hud/health = 6,
 		),
 	)
 	idle_power_usage = 211
@@ -286,15 +298,28 @@
 			/obj/item/stack/medical/heal_pack/gauze = -1,
 			/obj/item/stack/medical/splint = -1,
 		),
-		"Misc" = list(
-			/obj/item/tool/research/xeno_analyzer = -1,
-			/obj/item/tool/research/excavation_tool = -1,
+		"Surgical Equipment" = list(
 			/obj/item/storage/pouch/surgery = -1,
 			/obj/item/armor_module/storage/uniform/surgery_webbing = -1,
 			/obj/item/reagent_containers/spray/surgery = -1,
 			/obj/item/tool/soap = -1,
-			/obj/item/clothing/glasses/hud/health = -1,
 			/obj/item/roller = -1,
+			/obj/item/tool/surgery/scalpel/manager = -1,
+			/obj/item/tool/surgery/scalpel = -1,
+			/obj/item/tool/surgery/hemostat = -1,
+			/obj/item/tool/surgery/retractor = -1,
+			/obj/item/tool/surgery/cautery = -1,
+			/obj/item/tool/surgery/circular_saw = -1,
+			/obj/item/tool/surgery/surgical_membrane = -1,
+			/obj/item/tool/surgery/bonegel = -1,
+			/obj/item/tool/surgery/bonesetter = -1,
+			/obj/item/tool/surgery/FixOVein = -1,
+			/obj/item/tool/surgery/suture = -1,
+		),
+		"Misc" = list(
+			/obj/item/tool/research/xeno_analyzer = -1,
+			/obj/item/tool/research/excavation_tool = -1,
+			/obj/item/clothing/glasses/hud/health = -1,
 		),
 		"Chemistry Equipment" = list(
 			/obj/item/reagent_containers/syringe = -1,

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -152,7 +152,6 @@
 	icon_state = "med"
 	icon_deny = "med-deny"
 	icon_vend = "med-vend"
-	isshared = TRUE
 	//product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	products = list(
 		"Pill Bottle" = list(
@@ -237,6 +236,7 @@
 	idle_power_usage = 211
 
 /obj/machinery/vending/medical/shipside
+	isshared = TRUE
 	wrenchable = FALSE
 
 /obj/machinery/vending/medical/valhalla

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -237,7 +237,6 @@
 	idle_power_usage = 211
 
 /obj/machinery/vending/medical/shipside
-	isshared = TRUE
 	wrenchable = FALSE
 
 /obj/machinery/vending/medical/valhalla

--- a/code/modules/clothing/modular_armor/attachments/uniform.dm
+++ b/code/modules/clothing/modular_armor/attachments/uniform.dm
@@ -43,7 +43,6 @@
 
 /obj/item/armor_module/storage/uniform/surgery_webbing/PopulateContents()
 	new /obj/item/tool/surgery/scalpel/manager(src)
-	new /obj/item/tool/surgery/scalpel(src)
 	new /obj/item/tool/surgery/hemostat(src)
 	new /obj/item/tool/surgery/retractor(src)
 	new /obj/item/tool/surgery/cautery(src)


### PR DESCRIPTION

## About The Pull Request
Adds surgery tools category to medical vendor, cleans up surgery pouch / webbing tool lists (removes scalpel), Cleans up descriptions (Surgery tools say generally what surgeries they are used for) and adds descriptions for previously undescribed surgery tools. Removes access requirement. replaces non shipside type medical vendors on debugdaelus. Lets synthetics add med vendor contents to their loadouts.

## Why It's Good For The Game
I have been playing med doc, cmo and surgery synth and this PR attempts to fix issues ive found in that time.

I believe there is already enough mechanical separation between this vendor and the marine vendor; as it does not contain chemicals or equipment that is particularly useful for marines; but the limitation on who can vend from it harms support roles.

These changes mean you can make a loadout with surgery tools, cleaner, hypospray, and actually get them; in testing and in game before it just would not allow for med vendor items to be properly vended from loadout vendor. Tried opening an issue here https://github.com/tgstation/TerraGov-Marine-Corps/issues/18716 

Currently you need to get them (Surgery tools, hyposprays, cleaners, reagent bottles) again every round. This adds alot of tedium to 1. playing surgery jobs in general. 2. using hyposprays; anyone other than a Corpsman, Synthetic or Doctor (Eg. a squad leader) needs to hack the vendor ontop of the skill requirement for them.

This is easily the most hacked vendor in the whole game already; for Medhuds, hyposprays or other pill bottles. Med huds also get obtained already from smashing doctor lockers; this allows synths among others to have one in their loadout.

You can also now replace a singular missing surgery tool without vending a new pouch or webbing; if you like dropped it or something, or if you want them in a unique spot in your loadout.

The scalpel is literally a worse incision management system (any scalpel step can be done with IMS), and only should sensibly exist as map loot to be used for emergency surgery. It existing in the current sets of surgery tools only serves to troll people coming from TG, where it is used in every single surgery.

## Changelog
:cl:
add: added surgery tab to medical vendor (the NanotrasenMed Plus)
add: individual surgery tools to medical vendor.
del: removed medical vendor access requirement.
del: removed scalpel from surgery pouches webbings and trays.
qol: you can add items from the medical vendor to your loadout as a synthetic.
/:cl:
