### PR TITLE
Build designator fix

### DIFF
--- a/code/__HELPERS/visual_effects.dm
+++ b/code/__HELPERS/visual_effects.dm
@@ -13,6 +13,13 @@
 	scanline.icon = 'icons/effects/effects.dmi'
 	scanline.icon_state = "scanline"
 	scanline.appearance_flags |= RESET_TRANSFORM
+
+	var/icon_height = get_cached_height()
+	var/icon_width = get_cached_width()
+	if(icon_height > ICON_SIZE_Y || icon_width > ICON_SIZE_X)
+		var/matrix/scan_matrix = scanline.transform
+		scanline.transform = scan_matrix.Scale((icon_width / ICON_SIZE_X), (icon_height / ICON_SIZE_Y))
+
 	// * so it doesn't render
 	var/static/uid_scan = 0
 	scanline.render_target = "*HoloScanline [uid_scan]"

--- a/code/datums/actions/order_designation/base.dm
+++ b/code/datums/actions/order_designation/base.dm
@@ -103,11 +103,14 @@ GLOBAL_LIST_INIT(designator_mode_image_list, list(
 
 ///Toggles on the new mode
 /datum/action/ability/activable/build_designator/proc/activate_mode(new_mode)
-	RegisterSignal(owner, COMSIG_DO_OVERWATCH_RADIAL, PROC_REF(override_cic_radial))
+	var/mob/living/carbon/carbon_owner = owner
+	if(carbon_owner.selected_ability == src)
+		RegisterSignal(owner, COMSIG_DO_OVERWATCH_RADIAL, PROC_REF(override_cic_radial))
 	switch(new_mode)
 		if(BUILD_DESIGNATOR_MODE)
-			RegisterSignal(owner, COMSIG_ATOM_MOUSE_ENTERED, PROC_REF(show_hologram_call))
-			RegisterSignal(owner, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_owner_rotate))
+			if(carbon_owner.selected_ability == src)
+				RegisterSignal(owner, COMSIG_ATOM_MOUSE_ENTERED, PROC_REF(show_hologram_call))
+				RegisterSignal(owner, COMSIG_ATOM_DIR_CHANGE, PROC_REF(on_owner_rotate))
 			target_flags = ABILITY_TURF_TARGET
 			use_state_flags = NONE
 			action_icon_state = "build_designator"


### PR DESCRIPTION

## About The Pull Request
Makes the global 'makeHologram' proc transform to ensure it applies correctly regardless of icon size (build designator holograms were cut off because the icon is now 32x42).

Fixed a signal issue with toggling between modes on designate.
## Why It's Good For The Game
Visual fix, signal override fix.
## Changelog
:cl:
fix: fixed build designator holograms not fully displaying
/:cl:
