### PR TITLE
mutate verb qol

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/mutation_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutation_datum.dm
@@ -131,3 +131,17 @@
 	if(!disk_color || (disk_color in completed_disk_colors))
 		return
 	completed_disk_colors += disk_color
+
+/mob/living/carbon/xenomorph/verb/open_mutation_menu()
+	set name = "Mutate"
+	set desc = "Opens the mutation selector menu."
+	set category = "Alien"
+
+	if((!(SSticker.mode?.round_type_flags & MODE_MUTATIONS_OBTAINABLE) && !HAS_TRAIT(src, TRAIT_VALHALLA_XENO)))
+		to_chat(src, span_warning("Mutations are disabled in this gamemode."))
+		return
+	if(!(xeno_caste.caste_flags & CASTE_MUTATIONS_ALLOWED))
+		to_chat(src, span_warning("Your caste cannot get mutations."))
+		return
+	SStgui.close_user_uis(src, GLOB.mutation_selector)
+	GLOB.mutation_selector.ui_interact(src)


### PR DESCRIPTION

## About The Pull Request
Adds the "Mutate" verb in the Alien tab to quickly open the mutation selector/evolution menu.

<img width="627" height="121" alt="image" src="https://github.com/user-attachments/assets/acdf5e52-de24-4d77-bcb5-49fc8706c51c" />

## Why It's Good For The Game
QOL. Much easier to access than having to open hive status and then click mutations.

## Changelog
:cl:
qol: Mutations can be accessed via the "Mutate" verb in the Alien tab.
/:cl:
