### PR TITLE
vote and restart improvements

### DIFF
--- a/code/__DEFINES/_subsystems.dm
+++ b/code/__DEFINES/_subsystems.dm
@@ -152,3 +152,13 @@
 /// but since subsystem wait only considers the last fire,
 /// we need to multiply wait enough that it matches the 2 second interval Life is actually running on
 #define SS_MOBS_BUCKET_DELAY 4
+
+//Delay between auto votes
+#define VOTE_TIMER_DELAY 5 SECONDS
+
+#define SSVOTE_GAMEMODE "gamemode"
+#define SSVOTE_SHIPMAP "shipmap"
+#define SSVOTE_GROUNDMAP "groundmap"
+#define SSVOTE_RESTART "restart"
+#define SSVOTE_CUSTOM "custom"
+

--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -1030,3 +1030,12 @@
 
 /// From [/datum/health_scan/proc/ui_data]: `mob/living/carbon/human/patient`, `list/data`
 #define COMSIG_HEALTH_SCAN_DATA "health_scan_data"
+
+///Gamemode vote finished
+#define COMSIG_GAMEMODE_VOTE_RESULT "gamemode_vote_result"
+///shipmap vote finished
+#define COMSIG_SHIPMAP_VOTE_RESULT "shipmap_vote_result"
+///groundmap vote finished
+#define COMSIG_GROUNDMAP_VOTE_RESULT "groundmap_vote_result"
+///vote cancelled
+#define COMSIG_VOTE_CANCELLED "vote_cancelled"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -367,6 +367,11 @@ SUBSYSTEM_DEF(ticker)
 	if(usr && !check_rights(R_SERVER, TRUE))
 		return
 
+	if(graceful)
+		to_chat_immediate(world, "<h3>[span_boldnotice("Shutting down...")]</h3>")
+		world.Reboot(FALSE)
+		return
+
 	if(!delay)
 		delay = CONFIG_GET(number/mission_end_countdown) * 10
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -488,7 +488,10 @@ SUBSYSTEM_DEF(ticker)
 	START_PROCESSING(SSprocessing, src)
 
 /atom/movable/screen/reboot_timer/process()
-	if(isnull(SSticker.reboot_timer))
-		maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ DELAYED</center>")
-	else
+	if(!isnull(SSticker.reboot_timer))
 		maptext = MAPTEXT_PIXELLARI("<center>Server rebooting in:\n\ [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</center>")
+		return
+	if(SSticker.delay_end)
+		maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ DELAYED</center>")
+		return
+	maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ Cancelled</center>")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -24,7 +24,10 @@ SUBSYSTEM_DEF(ticker)
 	var/round_end_sound_sent = TRUE
 
 	var/delay_end = FALSE					//If set true, the round will not restart on it's own
-	var/admin_delay_notice = ""				//A message to display to anyone who tries to restart the world after a delay
+	///A message to display to anyone who tries to restart the world after a delay
+	var/admin_delay_notice = ""
+	///all roundend preparation done with, all that's left is reboot
+	var/ready_for_reboot = FALSE
 
 	var/time_left							//Pre-game timer
 	var/start_at
@@ -44,6 +47,10 @@ SUBSYSTEM_DEF(ticker)
 	var/list/queued_players = list()		//used for join queues when the server exceeds the hard population cap
 
 	var/list/datum/mind/minds = list() //The characters in the game. Used for objective tracking.
+	///The display of how much time is left before a reboot, given to all clients post-game.
+	var/atom/movable/screen/reboot_timer/reboot_hud
+	/// ID of round reboot timer, if it exists
+	var/reboot_timer = null
 
 /datum/controller/subsystem/ticker/Initialize()
 	load_mode()
@@ -121,14 +128,18 @@ SUBSYSTEM_DEF(ticker)
 				current_state = GAME_STATE_FINISHED
 				GLOB.ooc_allowed = TRUE
 				GLOB.dooc_allowed = TRUE
-				mode.declare_completion(force_ending)
+				declare_completion(force_ending)
 				world.TgsTriggerEvent("tg-Roundend", wait_for_completion = TRUE)
-				addtimer(CALLBACK(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, automatic_vote)), 2 SECONDS)
-				addtimer(CALLBACK(src, PROC_REF(Reboot)), CONFIG_GET(number/vote_period) * 3 + 9 SECONDS)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 				for(var/client/C AS in GLOB.clients)
 					C.mob?.update_sight() // To reveal ghosts
 
+		if(GAME_STATE_FINISHED)
+			if(ready_for_reboot)
+				if(isnull(reboot_timer))
+					reboot_hud.maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ DELAYED</center>")
+				else
+					reboot_hud.maptext = MAPTEXT_PIXELLARI("<center>Server rebooting in:\n\ [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</center>")
 
 /datum/controller/subsystem/ticker/proc/setup()
 	to_chat(world, span_boldnotice("<b>Enjoy the game!</b>"))
@@ -215,6 +226,59 @@ SUBSYSTEM_DEF(ticker)
 	else
 		LAZYADD(round_end_events, cb)
 
+/datum/controller/subsystem/ticker/proc/declare_completion()
+	set waitfor = FALSE
+	mode.declare_completion(force_ending)
+
+	if(isnull(reboot_hud))
+		reboot_hud = new()
+	for(var/client/C in GLOB.clients)
+		C?.screen += reboot_hud
+
+	ready_for_reboot = TRUE
+	standard_reboot()
+
+/datum/controller/subsystem/ticker/proc/standard_reboot()
+	if(!ready_for_reboot)
+		CRASH("Attempted standard reboot without ticker roundend completion")
+
+	Reboot(delay = (CONFIG_GET(number/vote_period) * 3) + (VOTE_TIMER_DELAY) * 5) //all 3 votes
+	SSvote.reset()
+
+	RegisterSignal(SSvote, COMSIG_VOTE_CANCELLED, PROC_REF(on_vote_cancel))
+	RegisterSignal(SSvote, COMSIG_GAMEMODE_VOTE_RESULT, PROC_REF(after_gamemode_vote))
+
+
+	SSvote.initiate_vote( SSVOTE_GAMEMODE, null, TRUE, TRUE)
+
+/datum/controller/subsystem/ticker
+	var/auto_running
+
+///Updates reboot time after gamemode vote and relistens, in case of admin forced vote
+/datum/controller/subsystem/ticker/proc/after_gamemode_vote(datum/source, result)
+	SIGNAL_HANDLER
+	Reboot(delay = (CONFIG_GET(number/vote_period) * 2) + (VOTE_TIMER_DELAY) * 4) //ship and groundmap to go
+
+	//override as admin could cancel auto votes before forcing gamemode vote again
+	RegisterSignal(SSvote, COMSIG_SHIPMAP_VOTE_RESULT, PROC_REF(after_shipmap_vote), TRUE)
+	RegisterSignal(SSvote, COMSIG_GROUNDMAP_VOTE_RESULT, PROC_REF(after_groundmap_vote), TRUE)
+
+///Updates reboot time after shipmape vote
+/datum/controller/subsystem/ticker/proc/after_shipmap_vote(datum/source, result)
+	SIGNAL_HANDLER
+	UnregisterSignal(SSvote, COMSIG_SHIPMAP_VOTE_RESULT)
+	Reboot(delay = CONFIG_GET(number/vote_period) + (VOTE_TIMER_DELAY * 3)) //only groundmap to go
+
+///Updates reboot time after groundmap vote
+/datum/controller/subsystem/ticker/proc/after_groundmap_vote(datum/source, result)
+	SIGNAL_HANDLER
+	UnregisterSignal(SSvote, COMSIG_GROUNDMAP_VOTE_RESULT)
+	Reboot(delay = VOTE_TIMER_DELAY * 2)
+
+///stops listening for map votes, in case of admin intervention
+/datum/controller/subsystem/ticker/proc/on_vote_cancel(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(SSvote, list(COMSIG_SHIPMAP_VOTE_RESULT, COMSIG_GROUNDMAP_VOTE_RESULT))
 
 /datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
 	if(bomb)	//BOOM
@@ -223,13 +287,17 @@ SUBSYSTEM_DEF(ticker)
 		if(epi)
 			explosion(epi, 0, 256, 512, 0, silent = TRUE, explosion_cause="station_explosion_detonation")
 
+///Whether the game has started, including roundend.
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING
 
-
+///Whether the game is currently in progress, excluding roundend
 /datum/controller/subsystem/ticker/proc/IsRoundInProgress()
 	return current_state == GAME_STATE_PLAYING
 
+///Whether the game is currently in progress, excluding roundend
+/datum/controller/subsystem/ticker/proc/IsPostgame()
+	return current_state == GAME_STATE_FINISHED
 
 /datum/controller/subsystem/ticker/Recover()
 	current_state = SSticker.current_state
@@ -296,12 +364,7 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/Reboot(reason, delay)
 	set waitfor = FALSE
 
-	if(usr && !check_rights(R_SERVER))
-		return
-
-	if(graceful)
-		to_chat_immediate(world, "<h3>[span_boldnotice("Shutting down...")]</h3>")
-		world.Reboot(FALSE)
+	if(usr && !check_rights(R_SERVER, TRUE))
 		return
 
 	if(!delay)
@@ -309,24 +372,36 @@ SUBSYSTEM_DEF(ticker)
 
 	var/skip_delay = check_rights()
 	if(delay_end && !skip_delay)
-		to_chat(world, span_boldnotice("An admin has delayed the round end."))
+		to_chat(world, span_boldannounce("An admin has delayed the round end."))
 		return
 
-	to_chat(world, span_boldnotice("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
+	to_chat(world, span_boldannounce("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
+
 
 	var/start_wait = world.time
 	UNTIL(round_end_sound_sent || (world.time - start_wait) > (delay * 2)) //don't wait forever
-	sleep(delay - (world.time - start_wait))
+	if(!isnull(reboot_timer)) //Override existing reboot timers.
+		deltimer(reboot_timer)
+	reboot_timer = addtimer(CALLBACK(src, PROC_REF(reboot_callback), reason), delay, TIMER_STOPPABLE)
 
-	if(delay_end && !skip_delay)
-		to_chat(world, span_boldnotice("Reboot was cancelled by an admin."))
-		return
+/datum/controller/subsystem/ticker/proc/reboot_callback(reason)
+	log_game(span_boldannounce("Rebooting World. [reason]"))
+	world.Reboot()
 
-	log_game("Rebooting World. [reason]")
-	to_chat_immediate(world, "<h3>[span_boldnotice("Rebooting...")]</h3>")
-
-	world.Reboot(TRUE)
-
+/**
+ * Deletes the current reboot timer and nulls the var
+ *
+ * Arguments:
+ * * user - the user that cancelled the reboot, may be null
+ */
+/datum/controller/subsystem/ticker/proc/cancel_reboot(mob/user)
+	if(!reboot_timer)
+		to_chat(user, span_warning("There is no pending reboot!"))
+		return FALSE
+	to_chat(world, span_boldannounce("An admin has delayed the round end."))
+	deltimer(reboot_timer)
+	reboot_timer = null
+	return TRUE
 
 /datum/controller/subsystem/ticker/proc/send_tip_of_the_round()
 	var/tip
@@ -396,3 +471,21 @@ SUBSYSTEM_DEF(ticker)
 		possible_themes += themes
 	if(length(possible_themes))
 		return "[global.config.directory]/reboot_themes/[pick(possible_themes)]"
+
+/atom/movable/screen/reboot_timer
+	screen_loc = "CENTER:-140,TOP:-42"
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_width = 340
+	maptext_height = 64
+	maptext = ""
+	layer = SCREENTIP_LAYER //This is basically an extra screentip
+
+/atom/movable/screen/reboot_timer/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	START_PROCESSING(SSprocessing, src)
+
+/atom/movable/screen/reboot_timer/process()
+	if(isnull(SSticker.reboot_timer))
+		maptext = MAPTEXT_PIXELLARI("<center>Server reboot \n\ DELAYED</center>")
+	else
+		maptext = MAPTEXT_PIXELLARI("<center>Server rebooting in:\n\ [DisplayTimeText(timeleft(SSticker.reboot_timer), 1)]</center>")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -360,7 +360,7 @@ SUBSYSTEM_DEF(ticker)
 	fdel(F)
 	WRITE_FILE(F, the_mode)
 
-
+///Sets the reboot timer if valid
 /datum/controller/subsystem/ticker/proc/Reboot(reason, delay)
 	set waitfor = FALSE
 
@@ -387,9 +387,10 @@ SUBSYSTEM_DEF(ticker)
 		deltimer(reboot_timer)
 	reboot_timer = addtimer(CALLBACK(src, PROC_REF(reboot_callback), reason), delay, TIMER_STOPPABLE)
 
+///Actually reboots the server
 /datum/controller/subsystem/ticker/proc/reboot_callback(reason)
 	log_game(span_boldannounce("Rebooting World. [reason]"))
-	world.Reboot()
+	world.Reboot(TRUE)
 
 /**
  * Deletes the current reboot timer and nulls the var

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -377,6 +377,9 @@ SUBSYSTEM_DEF(ticker)
 
 	to_chat(world, span_boldannounce("Rebooting World in [DisplayTimeText(delay)]. [reason]"))
 
+	if(!delay)
+		reboot_callback(reason)
+		return
 
 	var/start_wait = world.time
 	UNTIL(round_end_sound_sent || (world.time - start_wait) > (delay * 2)) //don't wait forever

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -28,14 +28,14 @@ SUBSYSTEM_DEF(vote)
 	var/list/voting = list()
 	/// If a vote is currently taking place
 	var/vote_happening = FALSE
-	/// The timer id of the shipmap vote
-	var/shipmap_timer_id
 	/// Pop up this vote screen on everyone's screen?
 	var/forced_popup = FALSE
 	/// Shuffle vote choices separately for each client? (topvoting NPC mitigation)
 	var/shuffle_choices = FALSE
 	/// Shuffle vote choices per ckey cache
 	var/list/shuffle_cache = list()
+	///whether we need to auto run a groundmap vote after shipmap, due to a gamemode change
+	var/force_groundmap_vote = FALSE
 
 // Called by master_controller
 /datum/controller/subsystem/vote/fire()
@@ -83,11 +83,11 @@ SUBSYSTEM_DEF(vote)
 			if(!C || C.is_afk())
 				non_voters -= non_voter_ckey
 		if(length(non_voters) > 0)
-			if(mode == "restart")
+			if(mode == SSVOTE_RESTART)
 				choices["Continue Playing"] += length(non_voters)
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
-			else if(mode == "gamemode")
+			else if(mode == SSVOTE_GAMEMODE)
 				if(GLOB.master_mode in choices)
 					choices[GLOB.master_mode] += length(non_voters)
 					if(choices[GLOB.master_mode] >= greatest_votes)
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(vote)
 	var/text
 
 	if(!length(winners))
-		if(mode != "shipmap" && mode != "groundmap")
+		if(mode != SSVOTE_SHIPMAP && mode != SSVOTE_GROUNDMAP)
 			text += "<b>Vote Result: Inconclusive - No Votes!</b>"
 			cleanup_vote(text)
 			return
@@ -125,7 +125,7 @@ SUBSYSTEM_DEF(vote)
 		if(!votes)
 			votes = 0
 		text += "\n<b>[choices[i]]:</b> [votes]"
-	if(mode != "custom")
+	if(mode != SSVOTE_CUSTOM)
 		if(length(winners) > 1)
 			text = "<hr><b>Vote Tied Between:</b>"
 			for(var/option in winners)
@@ -154,48 +154,38 @@ SUBSYSTEM_DEF(vote)
 		return
 	var/restart = FALSE
 	switch(mode)
-		if("restart")
+		if(SSVOTE_RESTART)
 			if(. == "Restart Round")
 				restart = TRUE
-		if("gamemode")
+		if(SSVOTE_GAMEMODE)
 			SSticker.save_mode(.) //changes the next game mode
-			if(GLOB.master_mode == .)
-				return
+			SEND_SIGNAL(src, COMSIG_GAMEMODE_VOTE_RESULT, .)
+
+			//if the game is in preround, we can play the newly voted mode immediately
 			if(SSticker.current_state < GAME_STATE_PLAYING)
-				//if the game is in preround, we can play the newly voted mode immediately
 				GLOB.master_mode = .
 				return
-			if(SSticker.current_state == GAME_STATE_PLAYING)
-				//If round is ongoing, we keep playing the round - vote for restart manually
+
+			//If round is ongoing, we keep playing the round - vote for restart manually
+			if(!SSticker.IsPostgame())
 				return
-			var/ship_change_required
-			var/ground_change_required
-			var/datum/game_mode/new_gamemode = config.pick_mode(.)
-			GLOB.master_mode = . //changes the current gamemode
-			//we check the gamemode's whitelists and blacklists to see if a map change and restart is required
-			if(!(new_gamemode.whitelist_ship_maps && (SSmapping.configs[SHIP_MAP].map_name in new_gamemode.whitelist_ship_maps)) && !(new_gamemode.blacklist_ship_maps && !(SSmapping.configs[SHIP_MAP].map_name in new_gamemode.blacklist_ship_maps)))
-				ship_change_required = TRUE
-			if(!(new_gamemode.whitelist_ground_maps && (SSmapping.configs[GROUND_MAP].map_name in new_gamemode.whitelist_ground_maps)) && !(new_gamemode.blacklist_ground_maps && !(SSmapping.configs[GROUND_MAP].map_name in new_gamemode.blacklist_ground_maps)))
-				ground_change_required = TRUE
-			//we queue up the required votes and restarts
-			if(ship_change_required && ground_change_required)
-				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
-				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), CONFIG_GET(number/vote_period) + 5 SECONDS)
-				SSticker.Reboot("Restarting server when valid ship and ground map selected", (CONFIG_GET(number/vote_period) * 2) + 15 SECONDS)
-				return
-			else if(ship_change_required)
-				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE), 5 SECONDS)
-				SSticker.Reboot("Restarting server when valid ship map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
-			else if(ground_change_required)
-				addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE), 5 SECONDS)
-				SSticker.Reboot("Restarting server when valid ground map selected", CONFIG_GET(number/vote_period) + 15 SECONDS)
+
+			addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_SHIPMAP, null, TRUE), VOTE_TIMER_DELAY)
+			force_groundmap_vote = TRUE
 			return
-		if("groundmap")
+		if(SSVOTE_GROUNDMAP)
 			var/datum/map_config/VM = config.maplist[GROUND_MAP][.]
 			SSmapping.changemap(VM, GROUND_MAP)
-		if("shipmap")
+			SEND_SIGNAL(src, COMSIG_GROUNDMAP_VOTE_RESULT, .)
+		if(SSVOTE_SHIPMAP)
+			SEND_SIGNAL(src, COMSIG_SHIPMAP_VOTE_RESULT, .)
 			var/datum/map_config/VM = config.maplist[SHIP_MAP][.]
 			SSmapping.changemap(VM, SHIP_MAP)
+
+			if(force_groundmap_vote)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_GROUNDMAP, null, TRUE), VOTE_TIMER_DELAY)
+				force_groundmap_vote = FALSE
+			return
 	if(restart)
 		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins)
@@ -208,8 +198,6 @@ SUBSYSTEM_DEF(vote)
 		else
 			to_chat(world, "<span style='boltnotice'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
 			message_admins("A restart vote has passed, but there are active admins on with +SERVER, so it has been canceled. If you wish, you may restart the server.")
-
-
 
 /// Register the vote of one player
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
@@ -265,9 +253,9 @@ SUBSYSTEM_DEF(vote)
 
 		reset()
 		switch(vote_type)
-			if("restart")
+			if(SSVOTE_RESTART)
 				choices.Add("Restart Round", "Continue Playing")
-			if("gamemode")
+			if(SSVOTE_GAMEMODE)
 				multiple_vote = TRUE
 				for(var/datum/game_mode/mode AS in config.votable_modes)
 					var/players = length(GLOB.clients)
@@ -278,7 +266,7 @@ SUBSYSTEM_DEF(vote)
 					if(players < mode.required_players)
 						continue
 					choices.Add(mode.config_tag)
-			if("groundmap")
+			if(SSVOTE_GROUNDMAP)
 				multiple_vote = TRUE
 				if(!lower_admin && SSmapping.groundmap_voted)
 					to_chat(usr, span_warning("The next ground map has already been selected."))
@@ -309,7 +297,7 @@ SUBSYSTEM_DEF(vote)
 					shuffle_choices = TRUE
 				for(var/valid_map in maps)
 					choices.Add(valid_map)
-			if("shipmap")
+			if(SSVOTE_SHIPMAP)
 				multiple_vote = TRUE
 				if(!lower_admin && SSmapping.shipmap_voted)
 					to_chat(usr, span_warning("The next ship map has already been selected."))
@@ -338,7 +326,7 @@ SUBSYSTEM_DEF(vote)
 					shuffle_choices = TRUE
 				for(var/valid_map in maps)
 					choices.Add(valid_map)
-			if("custom")
+			if(SSVOTE_CUSTOM)
 				question = stripped_input(usr, "What is the vote for?")
 				if(!question)
 					return FALSE
@@ -365,7 +353,7 @@ SUBSYSTEM_DEF(vote)
 		initiator = initiator_key
 		started_time = world.time
 		var/text = "[capitalize(mode)] vote started by [initiator ? initiator : "server"]."
-		if(mode == "custom")
+		if(mode == SSVOTE_CUSTOM)
 			text += "<br><i>[question]</i>"
 		log_vote(text)
 		var/vp = CONFIG_GET(number/vote_period)
@@ -389,13 +377,6 @@ SUBSYSTEM_DEF(vote)
 	set category = "OOC"
 	set name = "Vote"
 	SSvote.ui_interact(usr)
-
-///Starts the automatic map vote at the end of each round
-/datum/controller/subsystem/vote/proc/automatic_vote()
-	reset()
-	initiate_vote("gamemode", null, TRUE, TRUE)
-	shipmap_timer_id = addtimer(CALLBACK(src, PROC_REF(initiate_vote), "shipmap", null, TRUE, TRUE), CONFIG_GET(number/vote_period) + 3 SECONDS, TIMER_STOPPABLE)
-	addtimer(CALLBACK(src, PROC_REF(initiate_vote), "groundmap", null, TRUE, TRUE), CONFIG_GET(number/vote_period) * 2 + 6 SECONDS)
 
 /datum/controller/subsystem/vote/ui_state()
 	return GLOB.always_state
@@ -465,6 +446,8 @@ SUBSYSTEM_DEF(vote)
 			if(usr.client.holder)
 				usr.log_message("[key_name_admin(usr)] cancelled a vote.", LOG_ADMIN)
 				message_admins("[key_name_admin(usr)] has cancelled the current vote.")
+				SEND_SIGNAL(src, COMSIG_VOTE_CANCELLED)
+				force_groundmap_vote = FALSE
 				reset()
 		if("toggle_restart")
 			if(usr.client.holder && upper_admin)
@@ -480,19 +463,19 @@ SUBSYSTEM_DEF(vote)
 				CONFIG_SET(flag/allow_vote_shipmap, !CONFIG_GET(flag/allow_vote_shipmap))
 		if("restart")
 			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
-				initiate_vote("restart",usr.key)
+				initiate_vote(SSVOTE_RESTART,usr.key)
 		if("gamemode")
 			if(CONFIG_GET(flag/allow_vote_mode) || usr.client.holder)
-				initiate_vote("gamemode",usr.key)
+				initiate_vote(SSVOTE_GAMEMODE,usr.key)
 		if("groundmap")
 			if(CONFIG_GET(flag/allow_vote_groundmap) || usr.client.holder)
-				initiate_vote("groundmap",usr.key)
+				initiate_vote(SSVOTE_GROUNDMAP,usr.key)
 		if("shipmap")
 			if(CONFIG_GET(flag/allow_vote_shipmap) || usr.client.holder)
-				initiate_vote("shipmap",usr.key)
+				initiate_vote(SSVOTE_SHIPMAP,usr.key)
 		if("custom")
 			if(usr.client.holder)
-				initiate_vote("custom",usr.key)
+				initiate_vote(SSVOTE_CUSTOM,usr.key)
 		if("vote")
 			submit_vote(round(text2num(params["index"])))
 	return TRUE

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -172,7 +172,7 @@ SUBSYSTEM_DEF(vote)
 			if(!SSticker.IsPostgame())
 				return
 
-			addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_SHIPMAP, null, TRUE), VOTE_TIMER_DELAY)
+			addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_SHIPMAP, null, TRUE, TRUE), VOTE_TIMER_DELAY)
 			force_groundmap_vote = TRUE
 			return
 		if(SSVOTE_GROUNDMAP)
@@ -185,7 +185,7 @@ SUBSYSTEM_DEF(vote)
 			SSmapping.changemap(VM, SHIP_MAP)
 
 			if(force_groundmap_vote)
-				addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_GROUNDMAP, null, TRUE), VOTE_TIMER_DELAY)
+				addtimer(CALLBACK(src, PROC_REF(initiate_vote), SSVOTE_GROUNDMAP, null, TRUE, TRUE), VOTE_TIMER_DELAY)
 				force_groundmap_vote = FALSE
 			return
 	if(restart)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -99,8 +99,12 @@ SUBSYSTEM_DEF(vote)
 				. += option
 
 /// Announce the votes tally to everyone
-/datum/controller/subsystem/vote/proc/announce_result()
-	var/list/winners = get_result()
+/datum/controller/subsystem/vote/proc/announce_result(forced_result)
+	var/list/winners
+	if(forced_result)
+		winners = list(forced_result)
+	else
+		winners = get_result()
 	var/text
 
 	if(!length(winners))
@@ -147,9 +151,7 @@ SUBSYSTEM_DEF(vote)
 
 /// Apply the result of the vote if it's possible
 /datum/controller/subsystem/vote/proc/result(default_result)
-	. = default_result
-	if(!.)
-		. = announce_result()
+	. = announce_result(default_result)
 	if(!.)
 		return
 	var/restart = FALSE

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -279,7 +279,7 @@ ADMIN_VERB(set_reboot_time, R_SERVER, "Set Reboot Timer", "Set the restart timer
 		SSticker.delay_end = FALSE
 		SSticker.admin_delay_notice = null
 
-	var/reboot_time = tgui_input_number(user, "Reboot in how many seconds?", "Restart time", 0, 600, 300, 30 SECONDS)
+	var/reboot_time = tgui_input_number(user, "Reboot in how many seconds?", "Restart time", 300, 600, 0, 30 SECONDS)
 	if(!isnum(reboot_time))
 		return
 	SSticker.Reboot(delay = reboot_time SECONDS)
@@ -289,7 +289,10 @@ ADMIN_VERB(set_reboot_time, R_SERVER, "Set Reboot Timer", "Set the restart timer
 
 ADMIN_VERB(delay_end, R_SERVER, "Delay Round End", "Delay the round end", ADMIN_CATEGORY_SERVER)
 	if(SSticker.delay_end)
-		tgui_alert(user, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
+		SSticker.delay_end = FALSE
+		SSticker.admin_delay_notice = null
+		log_admin("[key_name(user)] removed the restart delay.")
+		message_admins("[key_name_admin(user)] removed the restart delay. Note: This does not automatically trigger a new restart timer!")
 		return
 
 	var/delay_reason = input(user, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -115,6 +115,12 @@ ADMIN_VERB(shutdown_server, R_SERVER, "Shutdown Server", "Shuts the server down.
 	sleep(world.tick_lag) //so messages can get sent to players.
 	qdel(world) //there are a few ways to shutdown the server, but this is by far my favorite
 
+ADMIN_VERB(cancel_reboot, R_SERVER, "Cancel Reboot", "Cancels a pending world reboot.", ADMIN_CATEGORY_SERVER)
+	if(!SSticker.cancel_reboot(user))
+		return
+	log_admin("[key_name(user)] cancelled the pending world reboot.")
+	message_admins("[key_name_admin(user)] cancelled the pending world reboot.")
+
 ADMIN_VERB(toggle_ooc, R_SERVER, "Toggle OOC", "Toggles OOC for non-admins.", ADMIN_CATEGORY_SERVER)
 	GLOB.ooc_allowed = !GLOB.ooc_allowed
 
@@ -263,27 +269,45 @@ ADMIN_VERB(delay_start, R_SERVER, "Delay Round Start", "Delay the start of the r
 		log_admin("[key_name(user)] set the pre-game delay to [DisplayTimeText(newtime)].")
 		message_admins("[ADMIN_TPMONTY(user.mob)] set the pre-game delay to [DisplayTimeText(newtime)].")
 
-ADMIN_VERB(delay_end, R_SERVER, "Delay Round End", "Delay the round end", ADMIN_CATEGORY_SERVER)
+ADMIN_VERB(set_reboot_time, R_SERVER, "Set Reboot Timer", "Set the restart timer.", ADMIN_CATEGORY_SERVER)
 	if(!SSticker)
 		return
 
-	if(SSticker.admin_delay_notice)
+	if(SSticker.delay_end)
 		if(alert(user, "Do you want to remove the round end delay?", "Delay Round End", "Yes", "No") != "Yes")
 			return
+		SSticker.delay_end = FALSE
 		SSticker.admin_delay_notice = null
-	else
-		var/reason = input(user, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
-		if(!reason)
-			return
-		if(SSticker.admin_delay_notice)
-			to_chat(user, span_warning("Someone already delayed the round end meanwhile."))
-			return
-		SSticker.admin_delay_notice = reason
 
-	SSticker.delay_end = !SSticker.delay_end
+	var/reboot_time = tgui_input_number(user, "Reboot in how many seconds?", "Restart time", 0, 600, 300, 30 SECONDS)
+	if(!isnum(reboot_time))
+		return
+	SSticker.Reboot(delay = reboot_time SECONDS)
 
-	log_admin("[key_name(user)] [SSticker.delay_end ? "delayed the round-end[SSticker.admin_delay_notice ? " for reason: [SSticker.admin_delay_notice]" : ""]" : "made the round end normally"].")
-	message_admins("<hr><h4>[ADMIN_TPMONTY(user.mob)] [SSticker.delay_end ? "delayed the round-end[SSticker.admin_delay_notice ? " for reason: [SSticker.admin_delay_notice]" : ""]" : "made the round end normally"].</h4><hr>")
+	log_admin("[key_name(user)] set the server to restart in [reboot_time] seconds.")
+	message_admins("<hr><h4>[ADMIN_TPMONTY(user.mob)] set the server to restart in [reboot_time] seconds.</h4><hr>")
+
+ADMIN_VERB(delay_end, R_SERVER, "Delay Round End", "Delay the round end", ADMIN_CATEGORY_SERVER)
+	if(SSticker.delay_end)
+		tgui_alert(user, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
+		return
+
+	var/delay_reason = input(user, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+
+	if(isnull(delay_reason))
+		return
+
+	if(SSticker.delay_end)
+		tgui_alert(user, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
+		return
+
+	SSticker.delay_end = TRUE
+	SSticker.admin_delay_notice = delay_reason
+	if(SSticker.reboot_timer)
+		SSticker.cancel_reboot(user)
+
+	log_admin("[key_name(user)] delayed the round end for reason: [SSticker.admin_delay_notice]")
+	message_admins("[key_name_admin(user)] delayed the round end for reason: [SSticker.admin_delay_notice]")
 
 ADMIN_VERB(toggle_gun_restrictions, R_FUN, "Toggle Gun Restrictions", "Toggle restriction on MP guns", ADMIN_CATEGORY_FUN)
 	if(!config)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -68,3 +68,6 @@
 	SEND_SIGNAL(client, COMSIG_CLIENT_MOB_LOGIN)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGIN, src)
 	client.init_verbs()
+
+	if(SSticker.IsPostgame())
+		client.screen += SSticker.reboot_hud


### PR DESCRIPTION

## About The Pull Request
**Test this shit before merge**

Refactored how gamemode/map votes are done at the end of the round, and how the server restarts.

Added a visible restart timer so people can see exactly when the server is going to restart (or if its delayed).

Also made the vote system announce automatic vote results (i.e. where there was only 1 valid outcome) so players actually see what's going on.

**For admins:**
We now have 3 distinct server verbs.
Cancel restart - cancels the restart timer.
Set restart timer - lets you set a custom restart time (overriding an existing one if it exists), max of 10 minutes.
Delay Round end - Toggles on and off. Stops server autorestart timer from triggering, and cancels any existing timer.

Each time a gamemode vote is done in the post game, map votes will be autotriggered afterwards. This includes admin forced votes. The reboot timer is updated when votes are done - this means lifting the round end delay will set a reboot timer automatically once the next vote is finished, but also means the delay isn't drawn out if certain votes aren't needed (i.e. hvh modes where there's only one choice etc).
## Why It's Good For The Game
Better visibility, hopefully less prone to shitting itself.
## Changelog
:cl:
qol: Added visibility for when the server is going to restart
refactor: refactored some code relating to end of round votes and restarts
admin: Added more server verbs relating to server restarts
/:cl:
