### PR TITLE
Armourlock can be used while stunned

### DIFF
--- a/code/__DEFINES/attachments.dm
+++ b/code/__DEFINES/attachments.dm
@@ -29,6 +29,8 @@
 #define ATTACH_BYPASS_ALLOWED_LIST (1<<6)
 #define ATTACH_DIFFERENT_MOB_ICON_STATE (1<<7)
 #define ATTACH_GREYSCALE_PARENT_COPY (1<<8)
+///Lets you activate the thing even while stunned, but not unconscious
+#define ATTACH_ACTIVATE_STUNNED (1<<9)
 
 //gun attachment slot defines
 #define ATTACHMENT_SLOT_RAIL "rail"

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -70,6 +70,11 @@
 	deselect()
 	return ..()
 
+/datum/action/item_action/toggle/stun_proof/can_use_action(silent, override_flags, selecting)
+	if(QDELETED(owner) || owner.stat || owner.restrained())
+		return FALSE
+	return TRUE
+
 /datum/action/item_action/toggle/suit_toggle
 	keybinding_signals = list(KEYBINDING_NORMAL = COMSIG_KB_SUITLIGHT)
 

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -121,6 +121,10 @@
 		return
 	LAZYADD(actions_types, /datum/action/item_action/toggle)
 	var/datum/action/item_action/toggle/new_action = new(src)
+	if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
+		new_action = new /datum/action/item_action/toggle/stun_proof(src)
+	else
+		new_action = new(src)
 	if(toggle_signal)
 		new_action.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
 	new_action.give_action(user)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -533,20 +533,10 @@
 	icon_state = "mod_armorlock"
 	worn_icon_state = "mod_armorlock_a"
 	slowdown = 0.1
-	attach_features_flags = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
+	attach_features_flags = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB|ATTACH_ACTIVATE_STUNNED
 	slot = ATTACHMENT_SLOT_MODULE
 	toggle_signal = COMSIG_KB_ARMORMODULE
 	COOLDOWN_DECLARE(armorlock_cooldown)
-	///This is the armor amounts we will be adding and removing when armor lock is activated
-	var/datum/armor/locked_armor_mod = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 50, FIRE = 50, ACID = 50)
-
-/obj/item/armor_module/module/armorlock/Initialize(mapload)
-	. = ..()
-	locked_armor_mod = getArmor(arglist(locked_armor_mod))
-
-/obj/item/armor_module/module/armorlock/Destroy()
-	. = ..()
-	locked_armor_mod = null
 
 /obj/item/armor_module/module/armorlock/activate(mob/living/user)
 	if(!COOLDOWN_FINISHED(src, armorlock_cooldown))


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.

If you are stunned/lying down etc (but not unconscious), you are still able to toggle your safe space bubble.

Also removed some unused code from when armourlock used to just give more armour.
## Why It's Good For The Game
Probably the main time you want to use this is when you are getting your face eaten by a bunch of gribbles/stunned into a corner. Now you can actually use it in those scenarios.

Will need testing though as this could potentially be quite strong.
## Changelog
:cl:
balance: The armourlock module can be used while stunned
/:cl:
