### PR TITLE
fixes right-click attacks with connected vali not giving green blood

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -375,7 +375,7 @@
 
 	connected_weapon = weapon_to_connect
 	ADD_TRAIT(connected_weapon, TRAIT_NODROP, VALI_TRAIT)
-	RegisterSignal(connected_weapon, COMSIG_ITEM_ATTACK, PROC_REF(drain_resource))
+	RegisterSignals(connected_weapon, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_ALTERNATE), PROC_REF(drain_resource))
 	RegisterSignals(connected_weapon, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED), PROC_REF(vali_connect))
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fixes a bug where right-click attacks with a connected vali weapon did not give any green blood.

Closes #18717

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Right-click attacks against xenomorphs with a connected vali weapon now correctly gives green blood.
/:cl:
