### PR TITLE
wallmount south fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -24,7 +24,7 @@
 			pixel_z = -48
 		if(SOUTH)
 			pixel_w = -16
-			pixel_z = -16
+			pixel_z = 16
 		if(EAST)
 			pixel_w = -48
 			pixel_z = -12
@@ -118,7 +118,7 @@
 			pixel_z = -48
 		if(SOUTH)
 			pixel_w = -16
-			pixel_z = -16
+			pixel_z = 16
 		if(EAST)
 			pixel_w = -48
 			pixel_z = -12
@@ -180,7 +180,7 @@
 			pixel_z = -48
 		if(SOUTH)
 			pixel_w = -16
-			pixel_z = -16
+			pixel_z = 16
 		if(EAST)
 			pixel_w = -48
 			pixel_z = -12


### PR DESCRIPTION

## About The Pull Request
Fixed wallmounts when facing south.
I accidentally had a - when it shouldn't be.
## Why It's Good For The Game
Visual fix.
## Changelog
:cl:
fix: fixed a visual issue for south facing wallmount objects
/:cl:
