### PR TITLE
Sticky resin/weeds no longer slow you down if covered

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -70,6 +70,14 @@
 		return
 	if(crosser.pass_flags & PASS_LOW_STRUCTURE)
 		return
+	//we don't want to slowdown the crosser if there is something on top of the resin
+	for(var/obj/object in orange(0, crosser))
+		if(!object.density)
+			continue
+		if(object == crosser)
+			continue
+		return
+
 	if(ismecha(crosser))
 		var/obj/vehicle/sealed/vehicle = crosser
 		COOLDOWN_INCREMENT(vehicle, cooldown_vehicle_move, slow_amount)


### PR DESCRIPTION

## About The Pull Request
Sticky resin/weeds no longer apply slowdown to you if the resin is covered.
i.e if you're walking over tables and such, slowdown currently still applies to you.
## Why It's Good For The Game
Bug fix/intended behavior thing.
## Changelog
:cl:
fix: Sticky resin/weeds no longer slown you down when moving over dense objects
/:cl:
