### PR TITLE
Fixes 5 trillion exploits

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -296,8 +296,6 @@
 	. = ..()
 	if(.)
 		return
-	if(!user)
-		return
 	if(!istype(user))
 		return
 	if(anchored)
@@ -311,8 +309,11 @@
 		if(!current_storage.remove_from_storage(src, user.loc, user))
 			return
 
-	if(loc == user && !user.temporarilyRemoveItemFromInventory(src))
-		return
+	if(ismob(loc)) //you shouldn't be able to click on items directly if they are on a mob, other than your own inventory.
+		if(loc != user) //stops a tremendous number of exploits and ghost dupes due to byond being shitty.
+			return
+		if(!user.temporarilyRemoveItemFromInventory(src))
+			return
 
 	if(QDELETED(src))
 		return


### PR DESCRIPTION

## About The Pull Request
Prevents mobs from clicking on items on other mobs (usually inventories).

This fixes a metric butt load of exploits, ghost item duping and all sorts of horribleness that can allow you to stack abilities, get godmode, teleport stuff around the map, and all other sorts of madness.

Thanks to @GravitronBlue for spelling it out for me.

While there shouldn't be any cases where you can click an item on another mob (except for C4, which is uneffected by this anyway), this should probably be TM'd in case there's any other weird cases I've forgotten about.
## Why It's Good For The Game
Exploits bad.
## Changelog
:cl:
fix: fixed exploits around taking items from other mobs and ghost dupes
/:cl:
