### PR TITLE
Fixes attachment ability stacking exploit

### DIFF
--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -69,6 +69,8 @@
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachments_allowed, starting_attachments = starting_attachments)
 	update_appearance(UPDATE_ICON)
 
+	if(!(attach_features_flags & ATTACH_ACTIVATION))
+		return
 	var/datum/action/item_action/toggle/new_toggle
 	if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
 		new_toggle = new /datum/action/item_action/toggle/stun_proof(src)

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -67,7 +67,15 @@
 	. = ..()
 	AddElement(/datum/element/attachment, slot, attach_icon, on_attach, on_detach, null, can_attach, pixel_shift_x, pixel_shift_y, attach_features_flags, attach_delay, detach_delay, mob_overlay_icon = mob_overlay_icon, mob_pixel_shift_x = mob_pixel_shift_x, mob_pixel_shift_y = mob_pixel_shift_y, attachment_layer = attachment_layer, attach_sound = 'sound/machines/click.ogg')
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachments_allowed, starting_attachments = starting_attachments)
-	update_icon()
+	update_appearance(UPDATE_ICON)
+
+	var/datum/action/item_action/toggle/new_toggle
+	if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
+		new_toggle = new /datum/action/item_action/toggle/stun_proof(src)
+	else
+		new_toggle = new(src)
+	if(toggle_signal)
+		new_toggle.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
 
 /obj/item/armor_module/item_action_slot_check(mob/user, slot)
 	return FALSE //these should never be usable on their own
@@ -118,22 +126,12 @@
 ///Adds or removes actions based on whether the parent is in the correct slot.
 /obj/item/armor_module/proc/handle_actions(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
-	if(prefered_slot && (slot != prefered_slot) || !CHECK_BITFIELD(attach_features_flags, ATTACH_ACTIVATION))
-		LAZYREMOVE(actions_types, /datum/action/item_action/toggle)
-		var/datum/action/item_action/toggle/old_action = locate(/datum/action/item_action/toggle) in actions
-		old_action?.remove_action(user)
-		return
+	var/datum/action/item_action/toggle/toggle_action = locate(/datum/action/item_action/toggle) in actions
 
-	LAZYADD(actions_types, /datum/action/item_action/toggle)
-	var/datum/action/item_action/toggle/new_action = locate(/datum/action/item_action/toggle) in actions
-	if(!new_action)
-		if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
-			new_action = new /datum/action/item_action/toggle/stun_proof(src)
-		else
-			new_action = new(src)
-	if(toggle_signal)
-		new_action.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
-	new_action.give_action(user)
+	if(prefered_slot && (slot != prefered_slot) || !CHECK_BITFIELD(attach_features_flags, ATTACH_ACTIVATION))
+		toggle_action?.remove_action(user)
+		return
+	toggle_action.give_action(user)
 
 /obj/item/armor_module/ui_action_click(mob/user, datum/action/item_action/toggle/action)
 	action.set_toggle(activate(user))

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -122,7 +122,7 @@
 		actions = null
 		return
 	LAZYADD(actions_types, /datum/action/item_action/toggle)
-	var/datum/action/item_action/toggle/new_action = new(src)
+	var/datum/action/item_action/toggle/new_action
 	if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
 		new_action = new /datum/action/item_action/toggle/stun_proof(src)
 	else

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -69,6 +69,9 @@
 	AddComponent(/datum/component/attachment_handler, attachments_by_slot, attachments_allowed, starting_attachments = starting_attachments)
 	update_icon()
 
+/obj/item/armor_module/item_action_slot_check(mob/user, slot)
+	return FALSE //these should never be usable on their own
+
 /// Called before a module is attached.
 /obj/item/armor_module/proc/can_attach(obj/item/attaching_to, mob/user)
 	return TRUE
@@ -119,14 +122,15 @@
 		LAZYREMOVE(actions_types, /datum/action/item_action/toggle)
 		var/datum/action/item_action/toggle/old_action = locate(/datum/action/item_action/toggle) in actions
 		old_action?.remove_action(user)
-		actions = null
 		return
+
 	LAZYADD(actions_types, /datum/action/item_action/toggle)
-	var/datum/action/item_action/toggle/new_action
-	if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
-		new_action = new /datum/action/item_action/toggle/stun_proof(src)
-	else
-		new_action = new(src)
+	var/datum/action/item_action/toggle/new_action = locate(/datum/action/item_action/toggle) in actions
+	if(!new_action)
+		if(attach_features_flags & ATTACH_ACTIVATE_STUNNED)
+			new_action = new /datum/action/item_action/toggle/stun_proof(src)
+		else
+			new_action = new(src)
 	if(toggle_signal)
 		new_action.keybinding_signals = list(KEYBINDING_NORMAL = toggle_signal)
 	new_action.give_action(user)

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -100,6 +100,8 @@
 	parent.hard_armor = parent.hard_armor.detachArmor(hard_armor)
 	parent.soft_armor = parent.soft_armor.detachArmor(soft_armor)
 	parent.slowdown -= slowdown
+	if(attach_features_flags & ATTACH_ACTIVATION)
+		handle_actions(null, user, null)
 	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	parent = null
 	icon_state = initial(icon_state)


### PR DESCRIPTION

## About The Pull Request
Removing attachments that have actions associated with them actually removes the action from the mob.
This prevents stacking multiple attachment powers such as multiple uses of armourlock, etc.

Reworked how toggle actions are set with armour modules more generally.
Instead of making infinite toggle actions into the void, a single action is created on init and given/taken from the user as needed.
Also ensured that armour module toggle actions are never given directly to the user (i.e. without being on a suit of armour)
## Why It's Good For The Game
Exploit bad.
Infinite action datums bad.
## Changelog
:cl:
fix: fixed an exploit with stacking attachment abilities
/:cl:
