### PR TITLE
Fixes a storage exploit

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -369,6 +369,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 /datum/storage/proc/on_alt_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER
+	//todo: Else where in this datum it just checks ishuman, but it should really just check for dextrous
+	if(isliving && !user.dextrous) //bad xeno.
+		return
 	if(parent.Adjacent(user))
 		open(user)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -370,7 +370,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 /datum/storage/proc/on_alt_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 	//todo: Else where in this datum it just checks ishuman, but it should really just check for dextrous
-	if(isliving && !user.dextrous) //bad xeno.
+	if(isliving(user) && !user.dextrous) //bad xeno.
 		return
 	if(parent.Adjacent(user))
 		open(user)


### PR DESCRIPTION

## About The Pull Request
Fixes an exploit that let people equip items that they shouldn't... namely this means certain xenos can no longer equip weapons and stab/shoot marines with impunity.
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: fixed an exploit that let certain xenos and other mobs equip and use items they shouldn't be able to
/:cl:
