### PR TITLE
Capsule barricade deconstruction doesn't yield as many materials

### DIFF
--- a/_maps/templates/capsule_1.dmm
+++ b/_maps/templates/capsule_1.dmm
@@ -1,39 +1,39 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/barricade/folding,
+/obj/structure/barricade/folding/capsule,
 /turf/template_noop,
 /area/template_noop)
 "c" = (
-/obj/structure/barricade/solid,
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule,
+/obj/structure/barricade/solid/capsule{
 	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
 "f" = (
-/obj/structure/barricade/solid,
+/obj/structure/barricade/solid/capsule,
 /turf/template_noop,
 /area/template_noop)
 "g" = (
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 1
 	},
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
 "q" = (
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 1
 	},
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)
 "s" = (
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 1
 	},
 /turf/template_noop,
@@ -42,38 +42,38 @@
 /turf/template_noop,
 /area/template_noop)
 "z" = (
-/obj/structure/barricade/folding{
+/obj/structure/barricade/folding/capsule{
 	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)
 "C" = (
-/obj/structure/barricade/folding{
+/obj/structure/barricade/folding/capsule{
 	dir = 1
 	},
 /turf/template_noop,
 /area/template_noop)
 "F" = (
-/obj/structure/barricade/solid,
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule,
+/obj/structure/barricade/solid/capsule{
 	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)
 "M" = (
-/obj/structure/barricade/folding{
+/obj/structure/barricade/folding/capsule{
 	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
 "T" = (
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 4
 	},
 /turf/template_noop,
 /area/template_noop)
 "V" = (
-/obj/structure/barricade/solid{
+/obj/structure/barricade/solid/capsule{
 	dir = 8
 	},
 /turf/template_noop,

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -705,6 +705,11 @@
 
 	update_icon()
 
+/obj/structure/barricade/solid/capsule
+	name = "capsule-deployed metal barricade"
+	desc = parent_type::desc + " Deconstruction will yield less materials due to being deployed via capsule."
+	stack_amount = 3
+
 #undef BARRICADE_METAL_LOOSE
 #undef BARRICADE_METAL_ANCHORED
 #undef BARRICADE_METAL_FIRM
@@ -993,6 +998,11 @@
 			take_damage(rand(25, 75), BRUTE, BOMB)
 
 	update_icon()
+
+/obj/structure/barricade/folding/capsule
+	name = "capsule-deployed folding plasteel barricade"
+	desc = parent_type::desc + " Deconstruction will yield less materials due to being deployed via capsule."
+	stack_amount = 4
 
 #undef BARRICADE_PLASTEEL_LOOSE
 #undef BARRICADE_PLASTEEL_ANCHORED


### PR DESCRIPTION

## About The Pull Request

Previously you would get 26 (25.6) points worth of materials from these 18 point capsules if you deconstructed the barricades for a total of 30% extra materials for your points.
With this PR you get 20 points worth. I don't think anyone is going to lose their minds over the small amount of extra metal, we can always just round down if it gets to be a problem (which I doubt).
## Why It's Good For The Game

Should probably not be giving people 30% extra bang for their points at the cost of a tiny bit of extra legwork in prep
## Changelog
:cl:
balance: Capsule barricade deconstruction doesn't yield as many materials
/:cl:
