### PR TITLE
Minimap layer improvements

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -317,6 +317,10 @@
 #define MINIMAP_BLIPS_LAYER 11
 #define MINIMAP_LOCATOR_LAYER 12
 #define MINIMAP_LABELS_LAYER 13
+///Layer for important things like objectives
+#define MINIMAP_PRIORITY_LAYER 16
+///Layer for the nuke itself, generally nothing is more important
+#define MINIMAP_NUKE_LAYER 19
 #define INTRO_LAYER 20
 
 #define FOV_EFFECT_LAYER 100

--- a/code/game/objects/machinery/computer/code_generator.dm
+++ b/code/game/objects/machinery/computer/code_generator.dm
@@ -137,4 +137,4 @@
 ///Change minimap icon if its on or off
 /obj/machinery/computer/code_generator/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
-	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips_large.dmi', null, "[key_color]_disk[current_timer ? "_on" : "_off"]", MINIMAP_LABELS_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips_large.dmi', null, "[key_color]_disk[current_timer ? "_on" : "_off"]", MINIMAP_PRIORITY_LAYER))

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -368,7 +368,7 @@
 ///Change minimap icon if its on or off
 /obj/machinery/nuclearbomb/proc/update_minimap_icon()
 	SSminimaps.remove_marker(src)
-	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips_large.dmi', null, "nuke[timer_enabled ? "_on" : "_off"]", MINIMAP_LOCATOR_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips_large.dmi', null, "nuke[timer_enabled ? "_on" : "_off"]", MINIMAP_NUKE_LAYER))
 
 #undef NUKE_STAGE_NONE
 #undef NUKE_STAGE_COVER_REMOVED

--- a/code/game/objects/structures/campaign_structures/campaign_structure.dm
+++ b/code/game/objects/structures/campaign_structures/campaign_structure.dm
@@ -70,7 +70,7 @@
 	var/new_icon_state = "campaign_objective"
 	if(objective_flags & CAMPAIGN_OBJECTIVE_DISABLED)
 		new_icon_state += "_disabled"
-	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, new_icon_state, MINIMAP_LABELS_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, new_icon_state, MINIMAP_PRIORITY_LAYER))
 
 ///Remaining time for overhead countdown if applicable
 /obj/structure/campaign_objective/proc/get_time_left()

--- a/code/game/objects/structures/campaign_structures/capture_objectives.dm
+++ b/code/game/objects/structures/campaign_structures/capture_objectives.dm
@@ -45,7 +45,7 @@
 			else
 				new_icon_state = capturing_faction ? "campaign_objective_decap_som" : "campaign_objective_som"
 
-	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, new_icon_state, MINIMAP_LABELS_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, new_icon_state, MINIMAP_PRIORITY_LAYER))
 
 /obj/structure/campaign_objective/capture_objective/attack_hand(mob/living/user)
 	if(!ishuman(user))

--- a/code/game/objects/structures/sensor_tower.dm
+++ b/code/game/objects/structures/sensor_tower.dm
@@ -171,6 +171,6 @@
 /obj/structure/sensor_tower/proc/update_control_minimap_icon()
 	SSminimaps.remove_marker(src)
 	if(activated)
-		SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "relay_[towerid]_on_full", MINIMAP_LABELS_LAYER))
+		SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "relay_[towerid]_on_full", MINIMAP_PRIORITY_LAYER))
 	else
-		SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "relay_[towerid][current_timer ? "_on" : "_off"]", MINIMAP_LABELS_LAYER))
+		SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "relay_[towerid][current_timer ? "_on" : "_off"]", MINIMAP_PRIORITY_LAYER))

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -98,7 +98,7 @@
 
 /obj/structure/xeno/silo/update_minimap_icon()
 	SSminimaps.remove_marker(src)
-	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "silo[threat_warning ? "_warn" : "_passive"]", MINIMAP_LABELS_LAYER))
+	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "silo[threat_warning ? "_warn" : "_passive"]", MINIMAP_PRIORITY_LAYER))
 
 /obj/structure/xeno/silo/process()
 	//Regenerate if we're at less than max integrity


### PR DESCRIPTION

## About The Pull Request
Added some new minimap layers.

Important things layer over normal stuff (silo, disk gen, campaign objectives etc).
Nuke layers over everything.
## Why It's Good For The Game
Having important stuff hidden under other minimap icons/text is bad.
## Changelog
:cl:
qol: Important stuff such as objectives and the nuke layers higher on the minimap
/:cl:
