### PR TITLE
Fixes an infinite recursion with buckled bodybags

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -190,7 +190,7 @@
 
 
 /obj/structure/closet/bodybag/forceMove(atom/destination)
-	if(roller_buckled)
+	if(roller_buckled && (destination != roller_buckled.loc))
 		roller_buckled.unbuckle_bodybag()
 	return ..()
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -124,8 +124,8 @@
 	. = ..()
 	if(!buckled_bodybag || buckled_bodybag.Move(loc, movement_dir, glide_size))
 		return TRUE
-	forceMove(buckled_bodybag.loc)
-	return FALSE
+	buckled_bodybag.forceMove(loc) //this should generally only happen in the bed itself is forcemoved, such as a shuttle
+	return TRUE
 
 /obj/structure/bed/roller/CanAllowThrough(atom/movable/mover, turf/target)
 	if(mover == buckled_bodybag)


### PR DESCRIPTION

## About The Pull Request
Fixed an infinite recursion with forcemoving a bed with a bodybag/stasis bag buckled to it.
This caused many bad things, up to and including permanently breaking the shuttle it happened to be on at the time.

Fixes #13838
## Why It's Good For The Game
Bad bug is bad.
## Changelog
:cl:
fix: fixed an issue with forcemoving beds with bodybags buckled to them
/:cl:
