### PR TITLE
Chair spin fixes

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -21,6 +21,8 @@
 	max_integrity = 20
 	layer = BELOW_TABLE_LAYER
 	var/propelled = 0 //Check for fire-extinguisher-driven chairs
+	///Whether this chair can be rotated via verb
+	var/can_rotate = TRUE //this only exists because spriters don't add directional sprites to all chair types, which allows for exploits.
 
 //directional variants mostly used for random spawners
 /obj/structure/bed/chair/east
@@ -74,6 +76,8 @@
 	set category = "IC.Object"
 	set src in view(0)
 
+	if(!can_rotate)
+		return FALSE
 	var/mob/living/carbon/user = usr
 
 	if(!istype(user) || !isturf(user.loc) || user.incapacitated())
@@ -167,6 +171,8 @@
 	desc = "It looks comfy."
 	icon_state = "sofamiddle"
 	resistance_flags = XENO_DAMAGEABLE
+	can_rotate = FALSE
+
 /obj/structure/bed/chair/sofa/left
 	icon_state = "sofaend_left"
 
@@ -283,16 +289,15 @@
 
 /obj/structure/bed/chair/office/light
 	icon_state = "officechair_white"
-	anchored = FALSE
 
 /obj/structure/bed/chair/office/dark
 	icon_state = "officechair_dark"
-	anchored = FALSE
 
 /obj/structure/bed/chair/dropship
 	name = "dropship chair"
 	desc = "Holds you in place during high altitude drops."
 	icon_state = "shuttle_chair"
+	can_rotate = FALSE
 	/// Handles the chair buckle bars overlay
 	var/image/chairbar = null
 	buildstacktype = 0
@@ -560,3 +565,4 @@
 	buildstacktype = null
 	resistance_flags = UNACIDABLE
 	dir = WEST
+	can_rotate = FALSE

--- a/code/modules/vehicles/armored/interiors/chairs.dm
+++ b/code/modules/vehicles/armored/interiors/chairs.dm
@@ -5,6 +5,7 @@
 	icon_state = "vehicle_chair"
 	resistance_flags = RESIST_ALL
 	dir = EAST
+	can_rotate = FALSE
 
 /obj/structure/bed/chair/loader_seat/update_overlays()
 	. = ..()
@@ -32,6 +33,7 @@
 	dir = EAST
 	buckling_x = -2
 	buckling_y = 0
+	can_rotate = FALSE
 	///owner of this object, assigned during interior linkage
 	var/obj/vehicle/sealed/armored/owner
 	///The skill required to man this chair


### PR DESCRIPTION

## About The Pull Request
Fixes #16790 
A variety of chairs that shouldn't be rotatable by the player (either due to be bolted to the floor or lacking sprites) can no longer do so.
## Why It's Good For The Game
Chair of +2 invisibility is bad.
## Changelog
:cl:
fix: fixed being able to rotate certain chairs you shouldn't be able to, allowing you to hide your sprite entirely
/:cl:
