### PR TITLE
Fix stack storage exploit

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -968,17 +968,18 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, PROC_REF(remove_from_storage), item, item.loc, null, FALSE, TRUE, FALSE)
 
-///signal sent from /atom/proc/max_stack_merging()
-/datum/storage/proc/max_stack_merging(datum/source, obj/item/stack/stacks)
+///Returns the max amount that be put into a stack in src without exceeding the weight limit
+/datum/storage/proc/max_stack_merging(datum/source, obj/item/stack/stacks, list/max_list)
+	SIGNAL_HANDLER
 	if(is_type_in_typecache(stacks, typecacheof(storage_type_limits)))
 		return FALSE //No need for limits if we can bypass it.
 	var/weight_diff = initial(stacks.w_class) - max_w_class
 	if(weight_diff <= 0)
 		return FALSE //Nor if the limit is not higher than what we have.
-	var/max_amt = round((stacks.max_amount / STACK_WEIGHT_STEPS) * (STACK_WEIGHT_STEPS - weight_diff)) //How much we can fill per weight step times the valid steps.
+	var/max_amt = floor((stacks.max_amount / STACK_WEIGHT_STEPS) * (STACK_WEIGHT_STEPS - weight_diff)) //How much we can fill per weight step times the valid steps.
 	if(max_amt <= 0 || max_amt > stacks.max_amount)
 		stack_trace("[parent.name] tried to max_stack_merging([stacks]) with [max_w_class] max_w_class and [weight_diff] weight_diff, resulting in [max_amt] max_amt.")
-	return max_amt
+	max_list += max_amt
 
 ///Called from signal in order to update the color of our storage, it's "fullness" basically
 /datum/storage/proc/recalculate_storage_space(datum/source)

--- a/code/game/atoms/_atom.dm
+++ b/code/game/atoms/_atom.dm
@@ -715,8 +715,11 @@ directive is properly returned.
 
 /atom/proc/max_stack_merging(obj/item/stack/S)
 	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(src, ATOM_MAX_STACK_MERGING, S)
-	return FALSE //But if they do, limit is not an issue.
+	var/list/max_list = list() //yes this is dumb, please do a better solution
+	SEND_SIGNAL(src, ATOM_MAX_STACK_MERGING, S, max_list)
+	if(length(max_list))
+		return max_list[1]
+	return 0
 
 /atom/proc/recalculate_storage_space()
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION

## About The Pull Request
Fixes #16226
Note that stack code is still pretty cursed so there are other related bugs that this doesn't fix.
## Why It's Good For The Game
Chipping away at the mountain.
## Changelog
:cl:
fix: fixed a bug with merging stacks in storage
/:cl:
