### PR TITLE
Dense jungle wall name

### DIFF
--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -277,6 +277,7 @@
 
 //Ground map dense jungle
 /turf/closed/gm
+	name = "thick jungle wall"
 	icon = 'icons/turf/walls/jungle.dmi'
 	icon_state = "junglewall-0"
 	desc = "Some thick jungle."
@@ -291,7 +292,6 @@
 /turf/closed/gm/add_debris_element()
 	AddElement(/datum/element/debris, DEBRIS_LEAF, -40, 5)
 
-	//Not yet
 /turf/closed/gm/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)


### PR DESCRIPTION

## About The Pull Request
Fixed a type of dense jungle wall not having a proper name.
## Why It's Good For The Game
GM.
## Changelog
:cl:
fix: fixed certain jungle walls being called 'GM'
/:cl:
