### PR TITLE
spotting rifle skill fix

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1417,6 +1417,7 @@
 	fire_sound =  'sound/weapons/guns/fire/spottingrifle.ogg'
 	caliber = CALIBER_12x7
 	slot = ATTACHMENT_SLOT_UNDER
+	gun_skill_category = SKILL_SMARTGUN
 	max_shells = 5
 	default_ammo_type =/obj/item/ammo_magazine/rifle/standard_spottingrifle
 	allowed_ammo_types = list(


### PR DESCRIPTION

## About The Pull Request
The spotting rifle (as in the attachment) now actually uses the smartgun skill instead of the rifle skill.
## Why It's Good For The Game
SG skill perk in HvH will actually boost it now.
## Changelog
:cl:
fix: The spotting rifle checks the SG skill instead of the rifle skill
/:cl:
