### PR TITLE
Small anti fire buffs

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -142,6 +142,9 @@
 ///ammo count shown on mag sprite
 #define MAGAZINE_SHOW_AMMO (1<<5)
 
+///Standard flamer burn duration in 2 second ticks
+#define FLAMER_STANDARD_BURN_DURATION 17
+
 //Slowdown from various armors.
 #define SHOES_SLOWDOWN -1.0			// How much shoes slow you down by default. Negative values speed you up
 

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -7,10 +7,10 @@
 	dir = NORTHEAST //Spawns with a diagonal direction, for spread optimization.
 	var/amount = 1 //Basically moles.
 	var/spread_fail_chance = 75 //percent
-	///Used for the fire_lvl of the resulting fire
-	var/fire_lvl = 15
-	///Used for the burn_lvl of the resulting fire
-	var/burn_lvl = 15
+	///Used for the burn_time of the resulting fire
+	var/burn_time = 15
+	///Used for the burn_level of the resulting fire
+	var/burn_level = 15
 	var/f_color = "red"
 
 
@@ -21,8 +21,8 @@
 	)
 	AddElement(/datum/element/connect_loc, connections)
 	amount = amt
-	burn_lvl += rand(-15, 15)
-	fire_lvl += rand(-10, 20)
+	burn_level += rand(-15, 15)
+	burn_time += rand(-10, 20)
 	if(newDir)
 		setDir(newDir)
 	return INITIALIZE_HINT_LATELOAD
@@ -94,7 +94,7 @@
 	if(igniter)
 		visible_message(span_warning("[igniter] ignites the spilled fuel!"))
 	var/turf/S = get_turf(src)
-	S.ignite(fire_lvl, burn_lvl, f_color)
+	S.ignite(burn_time, burn_level, f_color)
 	for(var/D in CARDINAL_DIRS)
 		var/turf/T = get_step(S, D)
 		for(var/obj/effect/decal/cleanable/liquid_fuel/other in T)
@@ -125,6 +125,6 @@
 	spread_fail_chance = 0 //percent
 
 /obj/effect/decal/cleanable/liquid_fuel/xfuel
-	fire_lvl = 25
-	burn_lvl = 25
+	burn_time = 25
+	burn_level = 25
 	f_color = "blue"

--- a/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/dragon/abilities_dragon.dm
@@ -634,7 +634,7 @@
 				continue
 			if(isfire(impacted_atom))
 				var/obj/fire/fire = impacted_atom
-				fire.reduce_fire(20)
+				fire.reduce_fire(20, 10)
 				continue
 			if(!(impacted_atom.resistance_flags & XENO_DAMAGEABLE))
 				continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -324,7 +324,7 @@
 			continue
 		if(isfire(victim))
 			var/obj/fire/fire = victim
-			fire.reduce_fire(10)
+			fire.reduce_fire(FLAMER_STANDARD_BURN_DURATION, 10)
 
 ///cleans up when the charge up is finished or interrupted
 /datum/action/ability/activable/xeno/shattering_roar/proc/finish_charging()

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -253,7 +253,7 @@
 		for(var/atom/movable/affected AS in affected_tile)
 			if(isfire(affected))
 				var/obj/fire/fire = affected
-				fire.reduce_fire(10)
+				fire.reduce_fire(10, 10)
 				continue
 			if(projectile_cooldown_mulitplier && istype(affected, /atom/movable/projectile))
 				things_to_deflect += affected

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -468,7 +468,7 @@
 				continue
 			if(isfire(victim))
 				var/obj/fire/fire = victim
-				fire.reduce_fire(5 * current_iterations)
+				fire.reduce_fire(5 * current_iterations, 2 * current_iterations)
 				continue
 	pre_stop_crush()
 

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -783,7 +783,7 @@
 	bullet_color = LIGHT_COLOR_ELECTRIC_GREEN
 
 	///Fire burn time
-	var/heat = 12
+	var/burn_time = 12
 	///Fire damage
 	var/burn_damage = 9
 	///Fire color
@@ -794,7 +794,7 @@
 	var/burn_mod = 1
 	if(istype(target_turf, /turf/closed/wall))
 		burn_mod = 3
-	target_turf.ignite(heat, burn_damage * burn_mod, fire_color)
+	target_turf.ignite(burn_time, burn_damage * burn_mod, fire_color)
 
 	for(var/mob/living/mob_caught in target_turf)
 		if(mob_caught.stat == DEAD || mob_caught == target)

--- a/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
+++ b/code/modules/projectiles/ammo_types/miscellaneous_ammo.dm
@@ -100,13 +100,15 @@
 	incendiary_strength = 30 //Firestacks cap at 20, but that's after armor.
 	bullet_color = LIGHT_COLOR_FIRE
 	var/fire_color = "red"
-	var/burntime = 17
-	var/burnlevel = 31
+	///Duration of the flame in 2 second ticks
+	var/burn_time = FLAMER_STANDARD_BURN_DURATION
+	///Intensity of the flame
+	var/burn_level = 31
 
 /datum/ammo/flamethrower/drop_flame(turf/T)
 	if(!istype(T))
 		return
-	T.ignite(burntime, burnlevel, fire_color)
+	T.ignite(burn_time, burn_level, fire_color)
 
 /datum/ammo/flamethrower/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	drop_flame(get_turf(target_mob))
@@ -138,8 +140,8 @@
 	hud_state = "flame_blue"
 	max_range = 7
 	fire_color = "blue"
-	burntime = 40
-	burnlevel = 46
+	burn_time = 40
+	burn_level = 46
 	bullet_color = COLOR_NAVY
 
 /datum/ammo/flamethrower/armored_spray // armored vehicle flamer that sprays a visual continual flame
@@ -148,7 +150,7 @@
 	max_range = 7
 	shell_speed = 0.3
 	damage = 6
-	burntime = 0.3 SECONDS
+	burn_time = 0.3 SECONDS
 
 /datum/ammo/flamethrower/sentry // is also a spray
 	name = "spraying flames"
@@ -156,7 +158,7 @@
 	max_range = 7
 	shell_speed = 0.3
 	damage = 6
-	burntime = 0.3 SECONDS
+	burn_time = 0.3 SECONDS
 
 /datum/ammo/water
 	name = "water"

--- a/code/modules/projectiles/guns/_shared_ammo_objects.dm
+++ b/code/modules/projectiles/guns/_shared_ammo_objects.dm
@@ -154,12 +154,13 @@
 /obj/fire/proc/affect_atom(atom/affected)
 	return
 
-///Reduces duration of fire
-/obj/fire/proc/reduce_fire(amount = 1)
-	if(amount <= 0)
+///Reduces fire duration or level
+/obj/fire/proc/reduce_fire(duration = 1, level = 0)
+	if(duration <= 0 && level <= 0)
 		return
-	burn_ticks -= amount
-	if(burn_ticks > 0)
+	burn_ticks -= duration
+	burn_level -= level
+	if(burn_ticks > 0 && burn_level > 0)
 		update_appearance(UPDATE_ICON)
 	else
 		qdel(src)

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -235,8 +235,8 @@
 		return FALSE
 
 	var/datum/ammo/flamethrower/loaded_ammo = CHECK_BITFIELD(flamer_features_flags, FLAMER_USES_GUN_FLAMES) ? ammo_datum_type : get_magazine_default_ammo(chamber_items[current_chamber_position])
-	var/burn_level = initial(loaded_ammo.burnlevel) * burn_level_mod
-	var/burn_time = initial(loaded_ammo.burntime) * burn_time_mod
+	var/burn_level = initial(loaded_ammo.burn_level) * burn_level_mod
+	var/burn_time = initial(loaded_ammo.burn_time) * burn_time_mod
 	var/fire_color = initial(loaded_ammo.fire_color)
 
 	for(var/turf/turf_to_ignite AS in turfs_to_burn)
@@ -454,20 +454,20 @@
 		/obj/item/attachable/magnetic_harness,
 	)
 
-/turf/proc/ignite(fire_lvl, burn_lvl, f_color, fire_stacks = 0, fire_damage = 0, fire_type = /obj/fire/flamer)
+/turf/proc/ignite(burn_time, burn_level, f_color, fire_stacks = 0, fire_damage = 0, fire_type = /obj/fire/flamer)
 	//extinguish any flame present
 	var/obj/fire/flamer/old_fire = locate(/obj/fire/flamer) in src
 	if(old_fire)
-		var/new_fire_level = min(fire_lvl + old_fire.burn_ticks, fire_lvl * 2)
-		var/new_burn_level = min(burn_lvl + old_fire.burn_level, burn_lvl * 1.5)
+		var/new_fire_level = min(burn_time + old_fire.burn_ticks, burn_time * 2)
+		var/new_burn_level = min(burn_level + old_fire.burn_level, burn_level * 1.5)
 		old_fire.set_fire(new_fire_level, new_burn_level, f_color, fire_stacks, fire_damage)
 		return
 
-	new fire_type(src, fire_lvl, burn_lvl, f_color, fire_stacks, fire_damage)
+	new fire_type(src, burn_time, burn_level, f_color, fire_stacks, fire_damage)
 	for(var/obj/structure/flora/jungle/vines/vines in src)
 		QDEL_NULL(vines)
 
-/turf/open/floor/plating/ground/snow/ignite(fire_lvl, burn_lvl, f_color, fire_stacks = 0, fire_damage = 0)
+/turf/open/floor/plating/ground/snow/ignite(burn_time, burn_level, f_color, fire_stacks = 0, fire_damage = 0)
 	if(slayer > 0)
 		slayer -= 1
 		update_appearance()


### PR DESCRIPTION

## About The Pull Request
King roar now extinguishes fire enough to instantly extinguish a standard flamer flame.
All xeno abilities that weaken fire duration now also weaken burn level as well.

Fixed up a bunch of var/arg names that were super fucking confusing for no reason. No more trying to remember what the hell fire lvl means vs burn lvl etc.
## Why It's Good For The Game
Clearer code.
A bit more counterplay against fire, especially at higher pop.
## Changelog
:cl:
balance: King roar and some other xeno abilities are more effective at extinguishing or weakening fire
code: Cleaned up a bunch of fire related arg/var names for clarity
/:cl:
