### PR TITLE
Campaign overview menu can be operated when dead

### DIFF
--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -496,12 +496,12 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 		CRASH("campaign_mission loaded without campaign game mode")
 
 	var/mob/user = usr //the actual user
-	var/mob/living/user_body //the user's body, different if they're dead
+	var/mob/living/user_body = usr //the user's body, different if they're dead
 	if(!isliving(user))
 		var/mob/dead/observer/observer_user = user
 		user_body = observer_user.can_reenter_corpse.resolve()
-	if(!user_body)
-		user_body = user
+		if(!user_body) //if you have no body, you can't do anything
+			return
 
 	switch(action)
 		if("set_attrition_points")

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -588,11 +588,11 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 ///Returns a list of people in the faction, both living and dead
 /datum/faction_stats/proc/get_notification_list()
-	//Historically we've continued to have issues with null entries getting into these glob lists, so we avoid AS is when interacting with this proc
+	//Historically we've continued to have issues with null entries getting into these glob lists, so we avoid AS is when interacting with the result of this proc
 	var/list/mob_list = list()
 	mob_list += GLOB.alive_human_list_faction[faction]
 	for(var/mob/ghost AS in GLOB.observer_list)
-		if(ghost.faction != faction)
+		if(ghost?.faction != faction)
 			continue
 		mob_list += ghost
 	return mob_list

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -218,16 +218,17 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	faction_leader = new_leader
 	RegisterSignals(faction_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE), PROC_REF(unset_faction_leader))
 
+	var/list/notification_list = get_notification_list()
 	if(old_leader && old_leader != faction_leader)
 		UnregisterSignal(old_leader, list(COMSIG_QDELETING, COMSIG_HUMAN_SET_UNDEFIBBABLE))
-		for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list_faction[faction])
-			human.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[old_leader] has been demoted from the role of faction commander", LEFT_ALIGN_TEXT), faction_portrait)
+		for(var/mob/faction_member in notification_list)
+			faction_member.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[old_leader] has been demoted from the role of faction commander", LEFT_ALIGN_TEXT), faction_portrait)
 	if(!faction_leader)
 		return
 
-	for(var/mob/living/carbon/human/human AS in GLOB.alive_human_list_faction[faction])
-		human.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
-		human.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[faction_leader] has been promoted to the role of faction commander", LEFT_ALIGN_TEXT), faction_portrait)
+	for(var/mob/faction_member in notification_list)
+		faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
+		faction_member.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[faction_leader] has been promoted to the role of faction commander", LEFT_ALIGN_TEXT), faction_portrait)
 	to_chat(faction_leader, span_userdanger("You have been promoted to the role of commander for your faction. It is your responsibility to determine your side's course of action, and how to best utilise the resources at your disposal. \
 	Attrition must be set BEFORE a mission starts ensure you team has access to respawns. Check this in the Faction UI screen. \
 	You are the only one that can choose the next mission for your faction. If your faction wins a mission, select the next one in the Faction UI screen, in the Missions tab."))
@@ -264,7 +265,7 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	active_attrition_points = amount
 	stats_flags |= CAMPAIGN_TEAM_HAS_SET_ATTRITION
 
-	for(var/mob/living/carbon/human/faction_member in GLOB.alive_human_list_faction[faction])
+	for(var/mob/faction_member in get_notification_list())
 		faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
 		to_chat(faction_member, span_warning("[user ? user : "Auto selection"] has assigned [amount] attrition points for the next mission."))
 	update_static_data_for_all_viewers()
@@ -494,13 +495,20 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 	if(!istype(current_mode))
 		CRASH("campaign_mission loaded without campaign game mode")
 
-	var/mob/living/user = usr
+	var/mob/user = usr //the actual user
+	var/mob/living/user_body //the user's body, different if they're dead
+	if(isliving(usr))
+		user_body = usr
+	else
+		var/mob/dead/observer/observer_user = usr
+		user_body = observer_user.can_reenter_corpse.resolve()
+
 	if(!istype(user))
 		return
 
 	switch(action)
 		if("set_attrition_points")
-			if(!is_leadership_role(user))
+			if(!is_leadership_role(user_body))
 				to_chat(user, span_warning("Only leadership roles can do this."))
 				return
 			if((current_mode.current_mission?.mission_state != MISSION_STATE_NEW) && (current_mode.current_mission?.mission_state != MISSION_STATE_LOADED))
@@ -545,24 +553,24 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 			if(!faction_assets[selected_asset])
 				return
 			var/datum/campaign_asset/choice = faction_assets[selected_asset]
-			if(!is_leadership_role(user))
+			if(!is_leadership_role(user_body))
 				if(!(choice.asset_flags & ASSET_SL_AVAILABLE))
 					to_chat(user, span_warning("Only leadership roles can do this."))
 					return
-				if(!(ismarineleaderjob(user.job) || issommarineleaderjob(user.job)))
+				if(!(ismarineleaderjob(user_body.job) || issommarineleaderjob(user_body.job)))
 					to_chat(user, span_warning("Only squad leaders and above can do this."))
 					return
 			if(!choice.attempt_activatation(user))
 				return
-			for(var/mob/living/carbon/human/faction_member in GLOB.alive_human_list_faction[faction])
+			for(var/mob/faction_member in get_notification_list())
 				faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
 				var/portrait = choice.asset_portrait ? choice.asset_portrait : faction_portrait
 				faction_member.play_screen_text(HUD_ANNOUNCEMENT_FORMATTING("OVERWATCH", "[choice.name] asset activated", LEFT_ALIGN_TEXT), portrait)
-				to_chat(faction_member, span_warning("[user] has activated the [choice.name] campaign asset."))
+				to_chat(faction_member, span_warning("[user_body] has activated the [choice.name] campaign asset."))
 			return TRUE
 
 		if("purchase_reward")
-			if(!is_leadership_role(user))
+			if(!is_leadership_role(user_body))
 				to_chat(user, span_warning("Only leadership roles can do this."))
 				return
 			var/datum/campaign_asset/selected_asset = text2path(params["selected_reward"])
@@ -575,11 +583,22 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 				return
 			add_asset(selected_asset)
 			total_attrition_points -= initial(selected_asset.cost)
-			for(var/mob/living/carbon/human/faction_member in GLOB.alive_human_list_faction[faction])
+			for(var/mob/faction_member in get_notification_list())
 				faction_member.playsound_local(null, 'sound/effects/CIC_order.ogg', 30, 1)
-				to_chat(faction_member, span_warning("[user] has purchased the [initial(selected_asset.name)] campaign asset."))
+				to_chat(faction_member, span_warning("[user_body] has purchased the [initial(selected_asset.name)] campaign asset."))
 			update_static_data_for_all_viewers()
 			return TRUE
+
+///Returns a list of people in the faction, both living and dead
+/datum/faction_stats/proc/get_notification_list()
+	//Historically we've continued to have issues with null entries getting into these glob lists, so we avoid AS is when interacting with this proc
+	var/list/mob_list = list()
+	mob_list += GLOB.alive_human_list_faction[faction]
+	for(var/mob/ghost AS in GLOB.observer_list)
+		if(ghost.faction != faction)
+			continue
+		mob_list += ghost
+	return mob_list
 
 //overview for campaign gamemode
 /datum/action/campaign_overview

--- a/code/datums/gamemodes/campaign/faction_stats.dm
+++ b/code/datums/gamemodes/campaign/faction_stats.dm
@@ -497,14 +497,11 @@ GLOBAL_LIST_INIT(campaign_mission_pool, list(
 
 	var/mob/user = usr //the actual user
 	var/mob/living/user_body //the user's body, different if they're dead
-	if(isliving(usr))
-		user_body = usr
-	else
-		var/mob/dead/observer/observer_user = usr
+	if(!isliving(user))
+		var/mob/dead/observer/observer_user = user
 		user_body = observer_user.can_reenter_corpse.resolve()
-
-	if(!istype(user))
-		return
+	if(!user_body)
+		user_body = user
 
 	switch(action)
 		if("set_attrition_points")


### PR DESCRIPTION

## About The Pull Request
What it says on the tin.
Faction leaders/leadership roles can now properly use the faction overview even when dead.
This means they can purchase and/or activate assets while dead, particularly useful for rapid reserves.
## Why It's Good For The Game
Big QOL improvement and helps teams use their stuff when they need it most.
## Changelog
:cl:
add: Campaign: Buying and using assets can be done even when dead
/:cl:
