### PR TITLE
Add sentry and ammo to zombie crash vendor

### DIFF
--- a/code/game/objects/machinery/vending/zombie_crash_vendor.dm
+++ b/code/game/objects/machinery/vending/zombie_crash_vendor.dm
@@ -90,7 +90,7 @@
 
 		// Emplacements
 		/obj/item/storage/box/crate/sentry = list(CAT_EMPLACEMENTS, "\"ST-571\" Sentry crate", 50, "sentry"),
-		/obj/item/ammo_magazine/sentry = list(CAT_EMPLACEMENTS, "\"ST-571\" Ammo", 10, "emplacement-laser"),
+		/obj/item/ammo_magazine/sentry = list(CAT_EMPLACEMENTS, "\"ST-571\" Ammo", 10, "sentry-ammo"),
 		/obj/item/weapon/gun/energy/lasgun/lasrifle/heavy_laser/deployable = list(CAT_EMPLACEMENTS, "\"TE-9001\" Emplacement", 10, "emplacement-laser"),
 		/obj/item/cell/lasgun/heavy_laser = list(CAT_EMPLACEMENTS, "\"TE-9001\" Laser Ammo", 6, "emplacement-laser"), // Cheap due to low ammo capacity.
 		/obj/item/weapon/gun/hsg_102 = list(CAT_EMPLACEMENTS, "\"HSG-102\" Emplacement", 14, "emplacement-heavysmartgun"),

--- a/code/game/objects/machinery/vending/zombie_crash_vendor.dm
+++ b/code/game/objects/machinery/vending/zombie_crash_vendor.dm
@@ -89,6 +89,8 @@
 		/obj/item/mecha_parts/mecha_equipment/laser_sword = list(CAT_MECH, "Laser sword", 10, "mech-weapon"),
 
 		// Emplacements
+		/obj/item/storage/box/crate/sentry = list(CAT_EMPLACEMENTS, "\"ST-571\" Sentry crate", 50, "sentry"),
+		/obj/item/ammo_magazine/sentry = list(CAT_EMPLACEMENTS, "\"ST-571\" Ammo", 10, "emplacement-laser"),
 		/obj/item/weapon/gun/energy/lasgun/lasrifle/heavy_laser/deployable = list(CAT_EMPLACEMENTS, "\"TE-9001\" Emplacement", 10, "emplacement-laser"),
 		/obj/item/cell/lasgun/heavy_laser = list(CAT_EMPLACEMENTS, "\"TE-9001\" Laser Ammo", 6, "emplacement-laser"), // Cheap due to low ammo capacity.
 		/obj/item/weapon/gun/hsg_102 = list(CAT_EMPLACEMENTS, "\"HSG-102\" Emplacement", 14, "emplacement-heavysmartgun"),

--- a/tgui/packages/tgui/interfaces/ZombieCrashSelector.jsx
+++ b/tgui/packages/tgui/interfaces/ZombieCrashSelector.jsx
@@ -237,6 +237,16 @@ const ItemLine = (props) => {
         Mech Equipment
       </Box>
     ),
+    sentry: (
+      <Box inline mr="6px" ml="6px" color="#fff385ff">
+        Laser
+      </Box>
+    ),
+    'sentry-ammo': (
+      <Box inline mr="6px" ml="6px" color="#fff385ff">
+        Laser
+      </Box>
+    ),
     'emplacement-laser': (
       <Box inline mr="6px" ml="6px" color="#fff385ff">
         Laser

--- a/tgui/packages/tgui/interfaces/ZombieCrashSelector.jsx
+++ b/tgui/packages/tgui/interfaces/ZombieCrashSelector.jsx
@@ -239,12 +239,7 @@ const ItemLine = (props) => {
     ),
     sentry: (
       <Box inline mr="6px" ml="6px" color="#fff385ff">
-        Laser
-      </Box>
-    ),
-    'sentry-ammo': (
-      <Box inline mr="6px" ml="6px" color="#fff385ff">
-        Laser
+        Sentry
       </Box>
     ),
     'emplacement-laser': (


### PR DESCRIPTION

## About The Pull Request

Add sentry and ammo to zombie crash vendor

## Why It's Good For The Game

If the round goes on too long, despite having plenty of points, the sentries will all run dry, and the alternative is to replace them with BAS which run out of ammo fast and FF, so there should be an option to replenish the ST-571. I also added a ST-571 crate which is expensive because they are very good, and can replace a destroyed sentry

## Changelog
:cl:
add: Add sentry and ammo to zombie crash vendor
/:cl:
