### PR TITLE
Banish select buildtype and place hologram to different keys

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -223,11 +223,11 @@
 	full_name = "Place Hologram"
 	description = "Place a holographic template of a structure"
 	keybind_signal = COMSIG_ABILITY_PLACE_HOLOGRAM
-	hotkey_keys = list("E")
+	hotkey_keys = list("U")
 
 /datum/keybinding/human/select_buildtype
 	name = "select_buildtype"
 	full_name = "Select Buildtype"
 	description = "Select the structure to use when using Place Hologram"
 	keybind_signal = COMSIG_ABILITY_SELECT_BUILDTYPE
-	hotkey_keys = list("Q")
+	hotkey_keys = list("I")


### PR DESCRIPTION

## About The Pull Request
They are now on I and U respectively

Just realised #18579 exists but it seems to be abandoned so
## Why It's Good For The Game
These overlap big time with some of the most important marine binds
## Changelog
:cl:
qol: Moved the default keybinds for select buildtype and place hologram
/:cl:
