### PR TITLE
Better explosion logging

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -158,7 +158,7 @@ SUBSYSTEM_DEF(explosions)
 
 	if(adminlog)
 		log_attack("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Apparent cause: [explosion_cause]. Mob responsible: [key_name(blame_mob)].")
-		if(blame_mob)
+		if(blame_mob && !is_centcom_level(epicenter.z))
 			msg_admin_ff("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)], Apparent cause: [ADMIN_LOOKUPFLW(explosion_cause)]. Mob responsible: [ADMIN_LOOKUPFLW(blame_mob)]")
 
 	if(max_range >= 6 || heavy_impact_range)

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -157,7 +157,7 @@ SUBSYSTEM_DEF(explosions)
 	var/started_at = REALTIMEOFDAY
 
 	if(adminlog)
-		log_attack("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Apparent cause: [explosion_cause]. Mob responsible: [blame_mob].")
+		log_attack("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Apparent cause: [explosion_cause]. Mob responsible: [key_name(blame_mob)].")
 		if(blame_mob)
 			msg_admin_ff("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)], Apparent cause: [ADMIN_LOOKUPFLW(explosion_cause)]. Mob responsible: [ADMIN_LOOKUPFLW(blame_mob)]")
 

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -114,7 +114,7 @@ SUBSYSTEM_DEF(explosions)
  * - explosion_direction: The angle in which the explosion is pointed (for directional explosions.)
  * - explosion_arc: The angle of the arc covered by a directional explosion (if 360 the explosion is non-directional.)
  */
-/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360)
+/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360, mob/blame_mob = null)
 	return SSexplosions.explode(arglist(args))
 
 /**
@@ -138,8 +138,9 @@ SUBSYSTEM_DEF(explosions)
  * - explosion_cause: [Optional] The atom that caused the explosion, when different to the origin. Used for logging.
  * - explosion_direction: The angle in which the explosion is pointed (for directional explosions.)
  * - explosion_arc: The angle of the arc covered by a directional explosion (if 360 the explosion is non-directional.)
+ * - blame_mob: The actual mob that caused this explosion, if available
  */
-/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360)
+/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flash_range, flame_range = 0, throw_range, adminlog = TRUE, silent = FALSE, smoke = FALSE, color = LIGHT_COLOR_LAVA, tiny = FALSE, protect_epicenter = FALSE, atom/explosion_cause = null, explosion_direction = 0, explosion_arc = 360, mob/blame_mob = null)
 	explosion_cause = explosion_cause ? explosion_cause : epicenter
 
 	epicenter = get_turf(epicenter)
@@ -155,30 +156,10 @@ SUBSYSTEM_DEF(explosions)
 	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, weak_impact_range, flame_range, throw_range)
 	var/started_at = REALTIMEOFDAY
 
-	// Now begins a bit of a logic train to find out whodunnit.
-	var/who_did_it = "N/A"
-	var/who_did_it_game_log = "N/A"
-
-	// Projectiles have special handling. They rely on a firer var and not fingerprints. Check special cases for firer being
-	// mecha, mob or an object such as the gun itself. Handle each uniquely.
-	if(istype(explosion_cause, /atom/movable/projectile)) // todo we mostly pass ammo datums cus drop explosion doesnt pass the projectiles-pls fix
-		var/atom/movable/projectile/fired_projectile = explosion_cause
-		if(ismob(fired_projectile.firer))
-			who_did_it = "\[Projectile firer: [ADMIN_LOOKUPFLW(fired_projectile.firer)]\]"
-			who_did_it_game_log = "\[Projectile firer: [key_name(fired_projectile.firer)]\]"
-		else // no fuckin idea?? better just send the obj that did it
-			who_did_it = "\[Projectile firer: [fired_projectile.firer], ref:[text_ref(fired_projectile.firer)]\]"
-			who_did_it_game_log = "\[Projectile firer: [fired_projectile.firer], ref:[text_ref(fired_projectile.firer)]]\]"
-	// Otherwise if the explosion cause is an atom, try get the ref. could be fingerprints but alas our logging sucks
-	else if(istype(explosion_cause))
-		who_did_it = "\[Exploder: [explosion_cause], ref:[text_ref(explosion_cause)]\]"
-		who_did_it_game_log = "\[Exploder: [explosion_cause], ref:[text_ref(explosion_cause)]]\]"
-
 	if(adminlog)
-		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Possible cause: [explosion_cause]. Last fingerprints: [who_did_it].")
-		var/datum/game_mode/infestation/xenomode = SSticker.mode
-		if(istype(xenomode) && (xenomode.round_stage != INFESTATION_MARINE_CRASHING) && is_mainship_level(epicenter.z))
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)], Possible cause: [explosion_cause]. Last fingerprints: [who_did_it_game_log]")
+		log_attack("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [loc_name(epicenter)], Apparent cause: [explosion_cause]. Mob responsible: [blame_mob].")
+		if(blame_mob)
+			msg_admin_ff("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [weak_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)], Apparent cause: [ADMIN_LOOKUPFLW(explosion_cause)]. Mob responsible: [ADMIN_LOOKUPFLW(blame_mob)]")
 
 	if(max_range >= 6 || heavy_impact_range)
 		new /obj/effect/temp_visual/shockwave(epicenter, max_range)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -92,12 +92,12 @@
 		GLOB.round_statistics.grenades_thrown++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "grenades_thrown")
 		update_icon()
-	det_timer = addtimer(CALLBACK(src, PROC_REF(prime)), det_time, TIMER_STOPPABLE)
+	det_timer = addtimer(CALLBACK(src, PROC_REF(prime), user), det_time, TIMER_STOPPABLE)
 	notify_ai_hazard()
 	return TRUE
 
 ///Detonation effects TODO MAKE THIS PASS THE USER TO EXPLOSION FOR LOGGING
-/obj/item/explosive/grenade/proc/prime()
+/obj/item/explosive/grenade/proc/prime(mob/user)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/idiot = loc
 		var/in_hand = FALSE
@@ -114,7 +114,7 @@
 			if(idiot.ckey)
 				var/datum/personal_statistics/personal_statistics = GLOB.personal_statistics_list[idiot.ckey]
 				personal_statistics.grenade_hand_delimbs ++
-	explosion(loc, light_impact_range = src.light_impact_range, weak_impact_range = src.weak_impact_range, explosion_cause=src)
+	explosion(loc, light_impact_range = src.light_impact_range, weak_impact_range = src.weak_impact_range, explosion_cause = src, blame_mob = user)
 	qdel(src)
 
 ///Adjusts det time, used for grenade launchers

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -96,7 +96,7 @@
 	notify_ai_hazard()
 	return TRUE
 
-///Detonation effects TODO MAKE THIS PASS THE USER TO EXPLOSION FOR LOGGING
+///Detonation effects
 /obj/item/explosive/grenade/proc/prime(mob/user)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/idiot = loc

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -199,7 +199,7 @@
 	var/turf/location = get_turf(src)
 	. = ..()
 	if(QDELETED(src))
-		log_attack("[key_name(src)] was gibbed with C4 by [ADMIN_LOOKUP(plastique_user)] at [AREACOORD(location)]")
+		log_attack("[key_name(src)] was gibbed with C4 by [key_name(plastique_user)] at [AREACOORD(location)]")
 		msg_admin_ff("[ADMIN_LOOKUPFLW(src)] was gibbed with C4 by [ADMIN_LOOKUPFLW(plastique_user)] at [ADMIN_VERBOSEJMP(location)]")
 
 ///Allows the c4 timer to be tweaked on certain atoms as required

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -198,7 +198,7 @@
 /mob/living/carbon/human/plastique_act(mob/living/plastique_user)
 	var/turf/location = get_turf(src)
 	. = ..()
-	if(QDELETED(src))
+	if(QDELETED(src) && !is_centcom_level(location.z))
 		log_attack("[key_name(src)] was gibbed with C4 by [key_name(plastique_user)] at [AREACOORD(location)]")
 		msg_admin_ff("[ADMIN_LOOKUPFLW(src)] was gibbed with C4 by [ADMIN_LOOKUPFLW(plastique_user)] at [ADMIN_VERBOSEJMP(location)]")
 

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -195,6 +195,13 @@
 /atom/proc/plastique_act(mob/living/plastique_user)
 	ex_act(EXPLODE_DEVASTATE)
 
+/mob/living/carbon/human/plastique_act(mob/living/plastique_user)
+	var/turf/location = get_turf(src)
+	. = ..()
+	if(QDELETED(src))
+		log_attack("[key_name(src)] was gibbed with C4 by [ADMIN_LOOKUP(plastique_user)] at [AREACOORD(location)]")
+		msg_admin_ff("[ADMIN_LOOKUPFLW(src)] was gibbed with C4 by [ADMIN_LOOKUPFLW(plastique_user)] at [ADMIN_VERBOSEJMP(location)]")
+
 ///Allows the c4 timer to be tweaked on certain atoms as required
 /atom/proc/plastique_time_mod(time)
 	return time

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -94,7 +94,7 @@
 /obj/structure/ship_ammo/proc/show_loaded_desc(mob/user)
 	return "It's loaded with \a [src]."
 
-/obj/structure/ship_ammo/proc/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/proc/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	return
 
 //CAS impact prediction.
@@ -262,7 +262,7 @@
 
 	return strafelist
 
-/obj/structure/ship_ammo/cas/heavygun/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/heavygun/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	playsound(impact, 'sound/effects/casplane_flyby.ogg', 40)
 	strafe_turfs(get_turfs_to_impact(impact, attackdir))
 
@@ -314,9 +314,9 @@
 	light_explosion_range = 4
 	prediction_type = CAS_AMMO_EXPLOSIVE
 
-/obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, color = COLOR_CYAN, explosion_cause="railgun")//no messaging admin, that'd spam them.
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, color = COLOR_CYAN, explosion_cause = "railgun", blame_mob = firer)//no messaging admin, that'd spam them.
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last railgun has fired and impacted the ground.
 
@@ -366,7 +366,7 @@
 		end = get_step(end, attackdir)
 	return get_traversal_line(beginning, end)
 
-/obj/structure/ship_ammo/cas/laser_battery/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/laser_battery/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	var/list/turf/lazertargets = get_turfs_to_impact(impact, attackdir)
 	process_lazer(lazertargets)
 	if(!ammo_count)
@@ -407,9 +407,9 @@
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
-/obj/structure/ship_ammo/cas/rocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer)
 	qdel(src)
 
 //ATGMs, defined by 3 second travel time and tight explosion sizes.
@@ -456,9 +456,9 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/napalm
 	crosshair = 'icons/UI_Icons/cas_crosshairs/napalm.dmi'
 
-/obj/structure/ship_ammo/cas/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer)
 	flame_radius(fire_range, impact, 30, 60) //cooking for a long time
 	var/datum/effect_system/smoke_spread/phosphorus/warcrime = new
 	warcrime.set_up(fire_range + 1, impact, 7)
@@ -484,9 +484,9 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/banshee
 	crosshair = 'icons/UI_Icons/cas_crosshairs/banshee.dmi'
 
-/obj/structure/ship_ammo/cas/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(3)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range, explosion_cause=src) //more spread out, with flames
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, flame_range = fire_range, explosion_cause = src, blame_mob = firer) //more spread out, with flames
 	qdel(src)
 
 //The fatty is well.. Fat.
@@ -504,10 +504,10 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/fatty
 	crosshair = 'icons/UI_Icons/cas_crosshairs/fatty.dmi'
 
-/obj/structure/ship_ammo/cas/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src) //first explosion is small to trick xenos into thinking its a minirocket.
-	addtimer(CALLBACK(src, PROC_REF(delayed_detonation), impact), 3 SECONDS)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer) //first explosion is small to trick xenos into thinking its a minirocket.
+	addtimer(CALLBACK(src, PROC_REF(delayed_detonation), impact, firer), 3 SECONDS)
 
 /**
  * proc/delayed_detonation(turf/impact)
@@ -516,13 +516,13 @@
  * * (turf/impact): targets impacted turf from first explosion
  */
 
-/obj/structure/ship_ammo/cas/rocket/fatty/proc/delayed_detonation(turf/impact)
+/obj/structure/ship_ammo/cas/rocket/fatty/proc/delayed_detonation(turf/impact, mob/firer)
 	var/list/impact_coords = list(list(-3,3),list(0,4),list(3,3),list(-4,0),list(4,0),list(-3,-3),list(0,-4), list(3,-3))
 	for(var/i=1 to 8)
 		var/list/coords = impact_coords[i]
 		var/turf/detonation_target = locate(impact.x+coords[1],impact.y+coords[2],impact.z)
 		detonation_target.ceiling_debris_check(2)
-		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, explosion_cause=src)
+		explosion(detonation_target, devastating_explosion_range, heavy_explosion_range, light_explosion_range, adminlog = FALSE, explosion_cause = src, blame_mob = firer)
 	qdel(src)
 
 // This is the "Default" heavy rocket.
@@ -578,9 +578,9 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/minirocket
 	crosshair = 'icons/UI_Icons/cas_crosshairs/rocket.dmi'
 
-/obj/structure/ship_ammo/cas/minirocket/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer)
 	if(!ammo_count)
 		QDEL_IN(src, travelling_time) //deleted after last minirocket has fired and impacted the ground.
 
@@ -604,7 +604,7 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/incendiary
 	crosshair = 'icons/UI_Icons/cas_crosshairs/rocket_incend.dmi'
 
-/obj/structure/ship_ammo/cas/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/incendiary/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	. = ..()
 	flame_radius(fire_range, impact)
 
@@ -620,7 +620,7 @@
 	light_explosion_range = 2
 	crosshair = 'icons/UI_Icons/cas_crosshairs/rocket_smoke.dmi'
 
-/obj/structure/ship_ammo/cas/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/smoke/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
 	var/datum/effect_system/smoke_spread/tactical/S = new
 	S.set_up(7, impact)// Large radius, but dissipates quickly
@@ -638,9 +638,9 @@
 	cas_effect = /obj/effect/overlay/blinking_laser/tfoot
 	crosshair = 'icons/UI_Icons/cas_crosshairs/rocket_tangle.dmi'
 
-/obj/structure/ship_ammo/cas/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/tangle/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0, explosion_cause=src)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, throw_range = 0, explosion_cause = src, blame_mob = firer)
 	var/datum/effect_system/smoke_spread/plasmaloss/S = new
 	S.set_up(9, impact, 9)// Between grenade and mortar
 	S.start()
@@ -659,7 +659,7 @@
 	prediction_type = CAS_AMMO_HARMLESS
 	crosshair = 'icons/UI_Icons/cas_crosshairs/rocket_flare.dmi'
 
-/obj/structure/ship_ammo/cas/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
 	addtimer(CALLBACK(src, PROC_REF(drop_cas_flare), impact), 1.5 SECONDS)
 	if(!ammo_count)
@@ -691,9 +691,9 @@
 	crosshair = 'icons/UI_Icons/cas_crosshairs/tiny.dmi'
 
 
-/obj/structure/ship_ammo/cas/bomb/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/bomb/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause=src)
+	explosion(impact, devastating_explosion_range, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer)
 
 // Four hundos have no real gimmick beyond being a bigger payload.
 /obj/structure/ship_ammo/cas/bomb/fourhundred
@@ -749,9 +749,9 @@
 	crosshair = 'icons/UI_Icons/cas_crosshairs/dandelion.dmi'
 
 
-/obj/structure/ship_ammo/cas/bomblet/detonate_on(turf/impact, attackdir = NORTH)
+/obj/structure/ship_ammo/cas/bomblet/detonate_on(turf/impact, attackdir = NORTH, mob/firer)
 	impact.ceiling_debris_check(2)
-	explosion(impact, heavy_explosion_range, light_explosion_range, explosion_cause=src)
+	explosion(impact, heavy_explosion_range, light_explosion_range, explosion_cause = src, blame_mob = firer)
 
 /obj/structure/ship_ammo/cas/bomblet/medium
 	name = "\improper AOE-75lb 'Poppies' stack"

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -834,7 +834,7 @@
 		ammo_equipped.ammo_count = max(ammo_equipped.ammo_count-ammo_equipped.ammo_used_per_firing, 0)
 	update_icon()
 
-/obj/structure/dropship_equipment/cas/weapon/proc/open_fire(obj/selected_target, attackdir)
+/obj/structure/dropship_equipment/cas/weapon/proc/open_fire(obj/selected_target, attackdir, mob/firer)
 	var/turf/target_turf = get_turf(selected_target)
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, TRUE)
@@ -862,7 +862,7 @@
 	for(var/turf/impact in predicted_dangerous_turfs)
 		effects_to_delete += new /obj/effect/overlay/blinking_laser/marine/lines(impact)
 
-	addtimer(CALLBACK(SA, TYPE_PROC_REF(/obj/structure/ship_ammo, detonate_on), target_turf, attackdir), ammo_travelling_time)
+	addtimer(CALLBACK(SA, TYPE_PROC_REF(/obj/structure/ship_ammo, detonate_on), target_turf, attackdir, firer), ammo_travelling_time)
 	QDEL_LIST_IN(effects_to_delete, ammo_travelling_time)
 
 /obj/structure/dropship_equipment/cas/weapon/heavygun

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -225,7 +225,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	var/impact_time = 10 SECONDS + (WARHEAD_FLY_TIME * (GLOB.current_orbit/3))
 
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/orbital_cannon, handle_ob_firing_effects), target), impact_time - (0.5 SECONDS))
-	var/impact_timerid = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/orbital_cannon, impact_callback), target, inaccurate_fuel), impact_time, TIMER_STOPPABLE)
+	var/impact_timerid = addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/orbital_cannon, impact_callback), target, inaccurate_fuel, user), impact_time, TIMER_STOPPABLE)
 
 	var/canceltext = "Warhead: [tray.warhead.warhead_kind]. Impact at [ADMIN_VERBOSEJMP(target)] <a href='byond://?_src_=holder;[HrefToken(TRUE)];cancelob=[impact_timerid]'>\[CANCEL OB\]</a>"
 	message_admins("[span_prefix("OB FIRED:")] <span class='message linkify'> [canceltext]</span>")
@@ -233,8 +233,8 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	notify_ghosts("<b>[user]</b> has just fired \the <b>[src]</b> !", source = T, action = NOTIFY_JUMP)
 
 
-/obj/structure/orbital_cannon/proc/impact_callback(target,inaccurate_fuel)
-	tray.warhead.warhead_impact(target, inaccurate_fuel)
+/obj/structure/orbital_cannon/proc/impact_callback(target, inaccurate_fuel, mob/firer)
+	tray.warhead.warhead_impact(target, inaccurate_fuel, firer)
 
 	ob_cannon_busy = FALSE
 	chambered_tray = FALSE
@@ -358,7 +358,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	var/warhead_kind
 
 ///Explode the warhead
-/obj/structure/ob_ammo/warhead/proc/warhead_impact()
+/obj/structure/ob_ammo/warhead/proc/warhead_impact(turf/target, inaccuracy_amt = 0, mob/firer)
 	return
 
 /obj/structure/ob_ammo/warhead/explosive
@@ -366,9 +366,9 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	warhead_kind = "explosive"
 	icon_state = "ob_warhead_1"
 
-/obj/structure/ob_ammo/warhead/explosive/warhead_impact(turf/target, inaccuracy_amt = 0)
+/obj/structure/ob_ammo/warhead/explosive/warhead_impact(turf/target, inaccuracy_amt = 0, mob/firer)
 	. = ..()
-	explosion(target, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 0, 15 - inaccuracy_amt, explosion_cause=src)
+	explosion(target, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 15 - inaccuracy_amt, 0, 15 - inaccuracy_amt, explosion_cause = src, blame_mob = firer)
 
 
 
@@ -378,7 +378,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	icon_state = "ob_warhead_2"
 
 
-/obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
+/obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0, mob/firer)
 	. = ..()
 	var/range_num = max(15 - inaccuracy_amt, 12)
 	flame_radius(range_num, target,	burn_intensity = 46, burn_duration = 40, colour = "blue")
@@ -391,7 +391,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	warhead_kind = "cluster"
 	icon_state = "ob_warhead_3"
 
-/obj/structure/ob_ammo/warhead/cluster/warhead_impact(turf/target, inaccuracy_amt = 0)
+/obj/structure/ob_ammo/warhead/cluster/warhead_impact(turf/target, inaccuracy_amt = 0, mob/firer)
 	set waitfor = FALSE
 	. = ..()
 	var/range_num = max(9 - inaccuracy_amt, 6)
@@ -399,7 +399,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	var/total_amt = max(25 - inaccuracy_amt, 20)
 	for(var/i = 1 to total_amt)
 		var/turf/U = pick_n_take(turf_list)
-		explosion(U, 2, 4, 6, 0, 6, throw_range = 0, explosion_cause=src)
+		explosion(U, 2, 4, 6, 0, 6, throw_range = 0, explosion_cause = src, blame_mob = firer)
 		sleep(0.1 SECONDS)
 
 /obj/structure/ob_ammo/warhead/plasmaloss
@@ -408,7 +408,7 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	icon_state = "ob_warhead_4"
 
 
-/obj/structure/ob_ammo/warhead/plasmaloss/warhead_impact(turf/target, inaccuracy_amt = 0)
+/obj/structure/ob_ammo/warhead/plasmaloss/warhead_impact(turf/target, inaccuracy_amt = 0, mob/firer)
 	. = ..()
 	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
 	smoke.set_up(25, target, 30 - (inaccuracy_amt * 2))//Vape nation
@@ -576,8 +576,8 @@ GLOBAL_DATUM(rail_gun, /obj/structure/ship_rail_gun)
 	for(var/mob/living/silicon/ai/AI AS in GLOB.ai_list)
 		to_chat(AI, span_notice("NOTICE - \The [src] has fired."))
 	rail_gun_ammo.ammo_count = max(0, rail_gun_ammo.ammo_count - rail_gun_ammo.ammo_used_per_firing)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/ship_rail_gun, impact_rail_gun), target), 1 SECONDS + (RG_FLY_TIME * (GLOB.current_orbit/3)))
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/ship_rail_gun, impact_rail_gun), target, user), 1 SECONDS + (RG_FLY_TIME * (GLOB.current_orbit/3)))
 
-/obj/structure/ship_rail_gun/proc/impact_rail_gun(turf/T)
-	rail_gun_ammo.detonate_on(T)
+/obj/structure/ship_rail_gun/proc/impact_rail_gun(turf/target_turf, mob/firer)
+	rail_gun_ammo.detonate_on(target_turf, firer)
 	cannon_busy = FALSE

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -184,12 +184,12 @@
 	if(exploding)
 		return
 	exploding = TRUE
-	if (reagents.total_volume > 500)
-		explosion(loc, light_impact_range = 4, flame_range = 4, explosion_cause = src, blame_mob = blame_mob)
-	else if (reagents.total_volume > 100)
-		explosion(loc, light_impact_range = 3, flame_range = 3, explosion_cause = src, blame_mob = blame_mob)
-	else
-		explosion(loc, light_impact_range = 2, flame_range = 2, explosion_cause = src, blame_mob = blame_mob)
+	var/explosion_strength = 2
+	if(reagents.total_volume > 500)
+		explosion_strength = 4
+	else if(reagents.total_volume > 100)
+		explosion_strength = 3
+	explosion(loc, light_impact_range = explosion_strength, flame_range = explosion_strength, explosion_cause = src, blame_mob = blame_mob)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(burn_level)
@@ -232,17 +232,13 @@
 	if(exploding)
 		return
 	exploding = TRUE
-
+	var/explosion_strength = 3
 	if(reagents.total_volume > 500)
-		flame_radius(5, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 5, explosion_cause = src, blame_mob = blame_mob)
+		explosion_strength = 5
 	else if(reagents.total_volume > 100)
-		flame_radius(4, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 4, explosion_cause = src, blame_mob = blame_mob)
-	else
-		flame_radius(3, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 3, explosion_cause = src, blame_mob = blame_mob)
-
+		explosion_strength = 4
+	flame_radius(explosion_strength, loc, 40, 46, 31, 30, colour = "blue")
+	explosion(loc, light_impact_range = explosion_strength, explosion_cause = src, blame_mob = blame_mob)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/spacefuel

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -174,22 +174,22 @@
 		return
 	if(proj.damage > 10 && prob(60) && (proj.ammo.damage_type in list(BRUTE, BURN)))
 		log_attack("[key_name(proj.firer)] detonated a fuel tank with a projectile at [AREACOORD(src)].")
-		explode()
+		explode(proj.firer)
 
 /obj/structure/reagent_dispensers/fueltank/ex_act()
 	explode()
 
 ///Does what it says on the tin, blows up the fueltank with radius depending on fuel left
-/obj/structure/reagent_dispensers/fueltank/proc/explode()
+/obj/structure/reagent_dispensers/fueltank/proc/explode(mob/blame_mob)
 	if(exploding)
 		return
 	exploding = TRUE
 	if (reagents.total_volume > 500)
-		explosion(loc, light_impact_range = 4, flame_range = 4, explosion_cause="fueltank explosion")
+		explosion(loc, light_impact_range = 4, flame_range = 4, explosion_cause = src, blame_mob = blame_mob)
 	else if (reagents.total_volume > 100)
-		explosion(loc, light_impact_range = 3, flame_range = 3, explosion_cause="fueltank explosion")
+		explosion(loc, light_impact_range = 3, flame_range = 3, explosion_cause = src, blame_mob = blame_mob)
 	else
-		explosion(loc, light_impact_range = 2, flame_range = 2, explosion_cause="fueltank explosion")
+		explosion(loc, light_impact_range = 2, flame_range = 2, explosion_cause = src, blame_mob = blame_mob)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(burn_level)
@@ -227,7 +227,7 @@
 	icon_state = "xweldtank"
 	list_reagents = list(/datum/reagent/fuel/xfuel = 1000)
 
-/obj/structure/reagent_dispensers/fueltank/xfuel/explode()
+/obj/structure/reagent_dispensers/fueltank/xfuel/explode(mob/blame_mob)
 	log_bomber(usr, "triggered a fueltank explosion with", src)
 	if(exploding)
 		return
@@ -235,13 +235,13 @@
 
 	if(reagents.total_volume > 500)
 		flame_radius(5, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 5, explosion_cause="xfueltank explosion")
+		explosion(loc, light_impact_range = 5, explosion_cause = src, blame_mob = blame_mob)
 	else if(reagents.total_volume > 100)
 		flame_radius(4, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 4, explosion_cause="xfueltank explosion")
+		explosion(loc, light_impact_range = 4, explosion_cause = src, blame_mob = blame_mob)
 	else
 		flame_radius(3, loc, 40, 46, 31, 30, colour = "blue")
-		explosion(loc, light_impact_range = 3, explosion_cause="xfueltank explosion")
+		explosion(loc, light_impact_range = 3, explosion_cause = src, blame_mob = blame_mob)
 
 	qdel(src)
 

--- a/code/modules/ai/spawners/zombie.dm
+++ b/code/modules/ai/spawners/zombie.dm
@@ -39,7 +39,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_ZOMBIE_TUNNEL_DESTROYED)
 	QDEL_NULL(proximity_monitor)
 
-/obj/effect/ai_node/spawner/zombie/plastique_act()
+/obj/effect/ai_node/spawner/zombie/plastique_act(mob/living/plastique_user)
 	spawn_defenders()
 
 	playsound(loc, 'sound/effects/meteorimpact.ogg', 35, 1)

--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -249,6 +249,7 @@
 
 ///Handles clicking on a target while in CAS mode
 /obj/docking_port/mobile/marine_dropship/casplane/proc/fire_weapons_at(datum/source, atom/target, turf/location, control, params)
+	SIGNAL_HANDLER
 	if(state != PLANE_STATE_FLYING || is_mainship_level(z))
 		end_cas_mission(source)
 		return
@@ -270,7 +271,7 @@
 	if(!COOLDOWN_FINISHED(active_weapon, last_fired))
 		to_chat(source, span_warning("[active_weapon] just fired, wait for it to cool down."))
 		return
-	active_weapon.open_fire(target, attackdir)
+	active_weapon.open_fire(target, attackdir, source)
 	record_cas_activity(active_weapon)
 
 /obj/docking_port/mobile/marine_dropship/casplane/ui_data(mob/user)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -89,7 +89,7 @@
 	var/turf/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
 		if(!(target_mob.status_flags & GODMODE))
-			log_attack("[key_name(src)] has been gibbed by [src], fired by [key_name(proj.firer)].")
+			log_attack("[key_name(target_mob)] has been gibbed by [src], fired by [key_name(proj.firer)].")
 			msg_admin_ff("[ADMIN_LOOKUPFLW(target_mob)] was gibbed by a tank shell fired by [ADMIN_LOOKUPFLW(proj.firer)] at [ADMIN_VERBOSEJMP(target_turf)]")
 			target_mob.gib()
 	else

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -89,8 +89,9 @@
 	var/turf/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
 		if(!(target_mob.status_flags & GODMODE))
-			log_attack("[key_name(target_mob)] has been gibbed by [src], fired by [key_name(proj.firer)].")
-			msg_admin_ff("[ADMIN_LOOKUPFLW(target_mob)] was gibbed by a tank shell fired by [ADMIN_LOOKUPFLW(proj.firer)] at [ADMIN_VERBOSEJMP(target_turf)]")
+			if(!is_centcom_level(epicenter.z))
+				log_attack("[key_name(target_mob)] has been gibbed by [src], fired by [key_name(proj.firer)].")
+				msg_admin_ff("[ADMIN_LOOKUPFLW(target_mob)] was gibbed by a tank shell fired by [ADMIN_LOOKUPFLW(proj.firer)] at [ADMIN_VERBOSEJMP(target_turf)]")
 			target_mob.gib()
 	else
 		staggerstun(target_mob, proj, max_range, knockback = 1, hard_size_threshold = 3)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -25,7 +25,7 @@
 	barricade_clear_distance = 2
 
 /datum/ammo/rocket/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 4, 6, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 4, 6, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -56,7 +56,7 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG // We want this one to specifically go over onscreen range.
 
 /datum/ammo/rocket/he/unguided/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 7, 0, 0, 2, throw_range = 4, explosion_cause = proj)
+	explosion(target_turf, 0, 7, 0, 0, 2, throw_range = 4, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/ap
 	name = "kinetic penetrator"
@@ -68,7 +68,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/ap/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/ltb
 	name = "cannon round"
@@ -83,19 +83,21 @@
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/ltb/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 5, 0, 3, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 5, 0, 3, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	var/target_turf = get_turf(target_mob)
+	var/turf/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
 		if(!(target_mob.status_flags & GODMODE))
+			log_attack("[key_name(src)] has been gibbed by [src], fired by [key_name(proj.firer)].")
+			msg_admin_ff("[ADMIN_LOOKUPFLW(target_mob)] was gibbed by a tank shell fired by [ADMIN_LOOKUPFLW(proj.firer)] at [ADMIN_VERBOSEJMP(target_turf)]")
 			target_mob.gib()
 	else
 		staggerstun(target_mob, proj, max_range, knockback = 1, hard_size_threshold = 3)
 	drop_nade(target_turf, proj)
 
 /datum/ammo/rocket/ltb/heavy/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 1, 4, 6, 0, 3, explosion_cause = proj)
+	explosion(target_turf, 1, 4, 6, 0, 3, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/heavy_isg
 	name = "8.8cm round"
@@ -111,7 +113,7 @@
 	handful_amount = 1
 
 /datum/ammo/rocket/heavy_isg/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 7, 8, 12, explosion_cause = proj)
+	explosion(target_turf, 0, 7, 8, 12, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/heavy_isg/unguided
 	hud_state = "bigshell_he_unguided"
@@ -222,7 +224,7 @@
 	sundering = 50
 
 /datum/ammo/rocket/recoilless/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 3, 4, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 3, 4, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/recoilless/heat
 	name = "HEAT shell"
@@ -234,7 +236,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/recoilless/heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/recoilless/heat/mech //for anti mech use in HvH
 	name = "HEAM shell"
@@ -248,7 +250,7 @@
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
 /datum/ammo/rocket/recoilless/heat/mech/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/recoilless/light
 	name = "light explosive shell"
@@ -262,7 +264,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/recoilless/light/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 1, 8, 0, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 1, 8, 0, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/recoilless/chemical
 	name = "low velocity chemical shell"
@@ -284,7 +286,7 @@
 	playsound(target_turf, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(smokeradius, target_turf, rand(5,9))
 	smoke.start()
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/recoilless/chemical/cloak
 	name = "low velocity chemical shell"
@@ -316,7 +318,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/recoilless/low_impact/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 1, 8, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 1, 8, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/oneuse
 	name = "explosive rocket"
@@ -337,7 +339,7 @@
 	sundering = 20
 
 /datum/ammo/rocket/som/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 3, 6, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 3, 6, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/som/light
 	name = "low impact RPG"
@@ -349,7 +351,7 @@
 	penetration = 10
 
 /datum/ammo/rocket/som/light/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 7, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 7, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/som/thermobaric
 	name = "thermobaric RPG"
@@ -358,7 +360,7 @@
 	damage = 30
 
 /datum/ammo/rocket/som/thermobaric/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj)
+	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/som/heat //Anti tank, or mech
 	name = "HEAT RPG"
@@ -377,7 +379,7 @@
 		proj.damage *= 3 //this is specifically designed to hurt vehicles
 
 /datum/ammo/rocket/som/heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 1, 0, 0, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/som/rad
 	name = "irrad RPG"
@@ -412,7 +414,7 @@
 		strength = victim.modify_by_armor(strength, BIO, 25)
 		victim.apply_radiation(strength, sound_level)
 
-	explosion(target_turf, weak_impact_range = 4, explosion_cause = proj)
+	explosion(target_turf, weak_impact_range = 4, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/atgun_shell
 	name = "high explosive ballistic cap shell"
@@ -428,7 +430,7 @@
 	handful_amount = 1
 
 /datum/ammo/rocket/atgun_shell/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/atgun_shell/on_hit_turf(turf/target_turf, atom/movable/projectile/proj) //no explosion every time it hits a turf
 	proj.proj_max_range -= 10
@@ -443,7 +445,7 @@
 	sundering = 25
 
 /datum/ammo/rocket/atgun_shell/apcr/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/atgun_shell/apcr/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/target_turf = get_turf(target_mob)
@@ -467,7 +469,7 @@
 	sundering = 35
 
 /datum/ammo/rocket/atgun_shell/he/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 3, 5, explosion_cause = proj)
+	explosion(target_turf, 0, 3, 5, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/atgun_shell/he/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	drop_nade(target_turf.density ? get_step(target_turf, proj) : target_turf)
@@ -485,7 +487,7 @@
 	var/bonus_projectile_quantity = 10
 
 /datum/ammo/rocket/atgun_shell/beehive/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/atgun_shell/beehive/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/turf/det_turf = get_step_towards(target_mob, proj)
@@ -560,7 +562,7 @@
 	var/turn_rate = 5
 
 /datum/ammo/rocket/homing/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 3, 4, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 3, 4, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/homing/ammo_process(atom/movable/projectile/proj, damage)
 	if(QDELETED(proj.original_target))
@@ -584,7 +586,7 @@
 	turn_rate = 10
 
 /datum/ammo/rocket/homing/microrocket/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 0, 0, 4, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 0, 0, 4, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/homing/microrocket/mech
 	name = "homing mech HE microrocket"
@@ -595,7 +597,7 @@
 	turn_rate = 10
 
 /datum/ammo/rocket/homing/microrocket/mech/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 0, 0, 2, 1, explosion_cause = proj)
+	explosion(target_turf, 0, 0, 0, 2, 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/homing/tow
 	name = "TOW-III missile"
@@ -609,7 +611,7 @@
 	max_range = 30
 
 /datum/ammo/rocket/homing/tow/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 0, 4, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 0, 4, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/coilgun
 	name = "kinetic penetrator"
@@ -630,7 +632,7 @@
 	barricade_clear_distance = 4
 
 /datum/ammo/rocket/coilgun/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 3, 5, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 3, 5, 0, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/coilgun/holder //only used for tankside effect checks
 	ammo_behavior_flags = AMMO_ENERGY
@@ -642,7 +644,7 @@
 	sundering = 5
 
 /datum/ammo/rocket/coilgun/low/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 3, 4, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 3, 4, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/coilgun/high
 	damage_falloff = 0
@@ -653,7 +655,7 @@
 	ammo_behavior_flags = AMMO_BETTER_COVER_RNG|AMMO_PASS_THROUGH_MOB
 
 /datum/ammo/rocket/coilgun/high/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 1, 4, 5, 6, 2, explosion_cause = proj)
+	explosion(target_turf, 1, 4, 5, 6, 2, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/coilgun/high/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	if(ishuman(target_mob) && prob(50)) //it only has AMMO_PASS_THROUGH_MOB so it can keep going if it gibs a mob
@@ -675,7 +677,7 @@
 	sundering = 0
 
 /datum/ammo/rocket/icc_lowvel_heat/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, flash_range = 1, explosion_cause = proj)
+	explosion(target_turf, flash_range = 1, explosion_cause = proj, blame_mob = proj.firer)
 
 /datum/ammo/rocket/icc_lowvel_high_explosive
 	name = "Low Velocity HE shell"
@@ -686,4 +688,4 @@
 	shell_speed = 1
 
 /datum/ammo/rocket/icc_lowvel_high_explosive/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj)
+	explosion(target_turf, 0, 2, 3, 0, 2, explosion_cause = proj, blame_mob = proj.firer)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -89,7 +89,7 @@
 	var/turf/target_turf = get_turf(target_mob)
 	if(!isxeno(target_mob))
 		if(!(target_mob.status_flags & GODMODE))
-			if(!is_centcom_level(epicenter.z))
+			if(!is_centcom_level(target_mob.z))
 				log_attack("[key_name(target_mob)] has been gibbed by [src], fired by [key_name(proj.firer)].")
 				msg_admin_ff("[ADMIN_LOOKUPFLW(target_mob)] was gibbed by a tank shell fired by [ADMIN_LOOKUPFLW(proj.firer)] at [ADMIN_VERBOSEJMP(target_turf)]")
 			target_mob.gib()


### PR DESCRIPTION

## About The Pull Request
Explosion logging is now actually useful.
It now tracks the source of the explosion (i.e. what actually blew up) and the mob that caused it.

This display in the attack logs, including the actual chat attack logs, so admins can see what's going on if needed.
<img width="761" height="72" alt="image" src="https://github.com/user-attachments/assets/04d861f6-deda-4881-b74e-4887a8324b2b" />

Not all explosions will have the mob be trackable due to a variety of reasons, but most common causes are, namely:
- Grenades
- Projectiles
- Shooting fuel tanks
- CAS
- OB
- Railgun
- C4 (if it actually gibs someone)
- LTB rounds (if it actually gibs someone)
## Why It's Good For The Game
Currently this is fucking awful for admins to try trace down, this should make it super easy to do so in the majority of cases.
## Changelog
:cl:
admin: Greatly improved explosion logging
/:cl:
