### PR TITLE
Fix attack speed bug

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -20,7 +20,7 @@
 	///Byond tick delay between left click attacks
 	var/attack_speed = CLICK_CD_MELEE_WEAPON_DEFAULT
 	///Byond tick delay between right click alternate attacks
-	var/attack_speed_alternate = CLICK_CD_MELEE_WEAPON_DEFAULT
+	var/attack_speed_alternate = null
 	///Used in attackby() to say how something was attacked "[x] [z.attack_verb] [y] with their [z]!" Should be in simple present tense!
 	var/list/attack_verb
 
@@ -191,6 +191,9 @@
 
 	if(autobalance_monitor_value)
 		AddComponent(/datum/component/autobalance_monitor, autobalance_monitor_value)
+
+	if(!isnum(attack_speed_alternate))
+		attack_speed_alternate = attack_speed
 
 /obj/item/Destroy()
 	if(ismob(loc))


### PR DESCRIPTION

## About The Pull Request
Fixed an oversight that let you ignore higher attack delays on weapons... such as claymore/axe etc.

Right click attack does nothing for any item in the game currently, but this is just simply applying normal attack delay to right click attacks, unless specifically overridden.
## Why It's Good For The Game
Exploit bad.
## Changelog
:cl:
fix: fixed right click attacks ignoring the proper weapon attack delay
/:cl:
