### PR TITLE
Shield fix and additions

### DIFF
--- a/code/datums/actions/species_actions/zombie_actions.dm
+++ b/code/datums/actions/species_actions/zombie_actions.dm
@@ -157,6 +157,7 @@
 			var/mob/living/living_owner = owner
 			living_owner.Paralyze(stun_duration)
 			living_owner.set_throwing(FALSE)
+			playsound(get_turf(living_target), 'sound/weapons/alien_knockdown.ogg', 75, TRUE)
 			return
 	trigger_pounce_effect(living_target)
 	pounce_complete()

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -163,8 +163,7 @@
 	var/shield_status_modifier = get_shield_status_modifier()
 
 	switch(attack_type)
-	//BELOW IS INCORRECT, WRONG WAY AROUND UNLESS STONED OUT OF MIND
-		if(COMBAT_TOUCH_ATTACK) //Touch attacks return false if the associated negative effect is blocked
+		if(COMBAT_TOUCH_ATTACK)
 			return touch_block(incoming_damage, damage_type, penetration)
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK) //we return the amount of damage that bypasses the shield
 			var/absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01 * shield_status_modifier  //Determine cover ratio; this is the % of damage we actually intercept.
@@ -188,14 +187,14 @@
 ///Block chance calculation
 /datum/component/shield/proc/item_pure_block_chance(attack_type, incoming_damage, damage_type, silent, penetration)
 	switch(attack_type)
-		if(COMBAT_TOUCH_ATTACK) //Touch attacks return false if the associated negative effect is blocked
+		if(COMBAT_TOUCH_ATTACK)
 			return touch_block(incoming_damage, damage_type, penetration)
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK)
 			if(prob(cover.getRating(damage_type) - penetration))
 				return 0
 			return incoming_damage
 
-//Touch attacks return true if the associated negative effect penetrates the shield
+///Touch attacks return true if the associated negative effect penetrates the shield
 /datum/component/shield/proc/touch_block(incoming_damage, damage_type, penetration)
 	var/obj/item/parent_item = parent
 	incoming_damage = parent_item.modify_by_armor(incoming_damage, damage_type, penetration)

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -163,12 +163,9 @@
 	var/shield_status_modifier = get_shield_status_modifier()
 
 	switch(attack_type)
-		if(COMBAT_TOUCH_ATTACK) //Touch attacks return true if the associated negative effect is blocked
-			if(!prob(cover.getRating(damage_type) * shield_status_modifier))
-				return FALSE
-			var/obj/item/parent_item = parent
-			incoming_damage = parent_item.modify_by_armor(incoming_damage, damage_type, penetration)
-			return prob(50 - round(incoming_damage / 3)) //Two checks for touch attacks to make it less absurdly effective, or something.
+	//BELOW IS INCORRECT, WRONG WAY AROUND UNLESS STONED OUT OF MIND
+		if(COMBAT_TOUCH_ATTACK) //Touch attacks return false if the associated negative effect is blocked
+			return touch_block(incoming_damage, damage_type, penetration)
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK) //we return the amount of damage that bypasses the shield
 			var/absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01 * shield_status_modifier  //Determine cover ratio; this is the % of damage we actually intercept.
 			if(!absorbing_damage)
@@ -191,18 +188,18 @@
 ///Block chance calculation
 /datum/component/shield/proc/item_pure_block_chance(attack_type, incoming_damage, damage_type, silent, penetration)
 	switch(attack_type)
-		if(COMBAT_TOUCH_ATTACK) //Touch attacks return true if the associated negative effect is blocked
-			var/shield_status_modifier = get_shield_status_modifier()
-			if(!prob(cover.getRating(damage_type) * shield_status_modifier))
-				return FALSE
-			var/obj/item/parent_item = parent
-			incoming_damage = parent_item.modify_by_armor(incoming_damage, damage_type, penetration)
-			return prob(50 - round(incoming_damage / 3)) //Two checks for touch attacks to make it less absurdly effective, or something.
+		if(COMBAT_TOUCH_ATTACK) //Touch attacks return false if the associated negative effect is blocked
+			return touch_block(incoming_damage, damage_type, penetration)
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK)
 			if(prob(cover.getRating(damage_type) - penetration))
 				return 0
 			return incoming_damage
 
+//Touch attacks return true if the associated negative effect penetrates the shield
+/datum/component/shield/proc/touch_block(incoming_damage, damage_type, penetration)
+	var/obj/item/parent_item = parent
+	incoming_damage = parent_item.modify_by_armor(incoming_damage, damage_type, penetration)
+	return prob(incoming_damage)
 
 //Dune, Halo and energy shields.
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -124,6 +124,8 @@ Contains most of the procs that are called when a mob is attacked by something
 		damage = check_shields(COMBAT_MELEE_ATTACK, damage, "melee")
 		if(!damage)
 			log_combat(user, src, "attacked", I, "(FAILED: shield blocked) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(I.damtype)])")
+			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE)
+			visible_message(span_danger("[user]'s attack against [src] with [user.p_their()] [I] was blocked!"), null, null, 5)
 			return TRUE
 
 	var/applied_damage = modify_by_armor(damage, MELEE, I.penetration, target_zone)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -366,6 +366,8 @@
 		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
 			xeno_owner.Paralyze(XENO_POUNCE_SHIELD_STUN_DURATION)
 			xeno_owner.set_throwing(FALSE)
+			playsound(get_turf(living_target), 'sound/weapons/alien_knockdown.ogg', 75, TRUE)
+			xeno_owner.visible_message(span_xenowarning("[xeno_owner] is knocked back!"), span_xenowarning("We are knocked back!"))
 			return
 	trigger_pounce_effect(living_target)
 	pounce_complete()

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -268,6 +268,14 @@
 
 /// Do the grab on the target, and clean all previous vars
 /datum/action/ability/activable/xeno/warrior/lunge/proc/lunge_grab(atom/A)
+	if(ishuman(A) && (angle2dir(Get_Angle(xeno_owner.throw_source ? xeno_owner.throw_source : get_turf(xeno_owner), A)) in reverse_nearby_direction(A.dir)))
+		var/mob/living/carbon/human/human_target = A
+		if(!human_target.check_shields(COMBAT_TOUCH_ATTACK, 30, "melee"))
+			xeno_owner.Paralyze(XENO_POUNCE_SHIELD_STUN_DURATION)
+			xeno_owner.set_throwing(FALSE)
+			playsound(get_turf(A), 'sound/weapons/alien_knockdown.ogg', 75, TRUE)
+			xeno_owner.visible_message(span_xenowarning("[xeno_owner] is knocked back!"), span_xenowarning("We are knocked back!"))
+			return
 	clean_lunge_target()
 	xeno_owner.swap_hand()
 	if(xeno_owner.start_pulling(A) && isliving(A) && !xeno_owner.issamexenohive(A))


### PR DESCRIPTION

## About The Pull Request
Fixed how shield block chance is calculated and used.
Every instance of shield touch block (stuff like xeno pounces) was actually checking for the wrong return value.
Combined with the weird formula for touch block chance, this resulted in firstly very low chances to bypass a shield, but also shields with worse stats being more likely to block.

The proc now returns results the expected way around since that made more sense anyway, and reworked the formula to actually be sane, with a simple modify by armour prob check.

Ironically this does mean, based on the values in actual use, that the block chance seen in game in most cases are pretty close to how they are, but now at least they're probably adjustable and the deployable shield isn't magically better than the big shield.

Also made warrior lunge get blocked in the same way that hunter/runner lunge is. Note that this is one of the few directional interactions in the game - shields only block from the front.

And added some more feedback to some of these related abilities if they are blocked.
## Why It's Good For The Game
Bug fix.

Shield (currently only available as the deployable cade or certain map spawns) provides some protection from warrior depredation, as a minor little alt feature.
## Changelog
:cl:
qol: Added some missing feedback for certain abilities that can be blocked by shields
balance: Warrior lunge can be blocked by shields similarly to runners or hunters.
fix: fixed shield code working the wrong way for certain interactions
code: Shield code works sensibly for touch interactions
/:cl:
