### PR TITLE
NPC ammo storage fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals.dm
+++ b/code/__DEFINES/dcs/signals/signals.dm
@@ -487,6 +487,9 @@
 
 #define COMSIG_OBJ_GET_FUELTYPE "obj_get_fueltype"				//called in /obj/get_fueltype()
 
+/// from /datum/storage/proc/handle_item_insertion when an item is stored in src
+#define COMSIG_ITEM_STORED "item_stored"
+
 // /obj/item signals
 #define COMSIG_ITEM_APPLY_CUSTOM_OVERLAY "item_apply_custom_overlay" //from base of obj/item/apply_custom(): (/image/standing)
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)

--- a/code/datums/managed_inventory.dm
+++ b/code/datums/managed_inventory.dm
@@ -108,6 +108,7 @@
 		return
 	equipped_list += equipped_item
 	RegisterSignal(equipped_item, COMSIG_ITEM_REMOVED_INVENTORY, PROC_REF(item_unequipped))
+	RegisterSignal(equipped_item, COMSIG_ITEM_STORED, PROC_REF(on_storage_insert))
 
 	var/list/sort_list = list(equipped_item)
 	sort_list += get_stored(equipped_item) //NOTE TO SELF:internal storage stuff isnt populated if the mob has ai BEFORE the outfit
@@ -127,7 +128,7 @@
 ///Handles the removal of an item
 /datum/managed_inventory/proc/item_unequipped(obj/item/unequipped_item, mob/user)
 	SIGNAL_HANDLER
-	UnregisterSignal(unequipped_item, COMSIG_ITEM_REMOVED_INVENTORY)
+	UnregisterSignal(unequipped_item, list(COMSIG_ITEM_REMOVED_INVENTORY, COMSIG_ITEM_STORED))
 	equipped_list -= unequipped_item
 	if(owner in get_nested_locs(unequipped_item))
 		return //still equipped
@@ -138,6 +139,11 @@
 
 	for(var/obj/item/thing AS in sort_list)
 		SEND_SIGNAL(thing, COMSIG_INVENTORY_STORED_REMOVAL)
+
+///Handles items being directly added to storage
+/datum/managed_inventory/proc/on_storage_insert(obj/source, obj/item/stored)
+	SIGNAL_HANDLER
+	sort_item(stored)
 
 ///Wrapper for sorting a newly stored item
 /datum/managed_inventory/proc/item_stored(mob/store_mob, obj/item/new_item, slot)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -766,6 +766,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			return FALSE
 	else
 		item.forceMove(parent)
+	SEND_SIGNAL(parent, COMSIG_ITEM_STORED, item)
 	RegisterSignal(item, COMSIG_MOVABLE_MOVED, PROC_REF(item_removed_from_storage))
 	item.on_enter_storage(parent)
 	if(length(holsterable_allowed))

--- a/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/helper_procs.dm
@@ -208,7 +208,7 @@
 		if(!(magazine.type in valid_ammo))
 			continue
 		if(!behavior_datum.try_store_item(magazine))
-			return
+			break
 		ammo_count ++
 	if(!ammo_count)
 		behavior_datum.try_speak("No ammo for me here!")


### PR DESCRIPTION

## About The Pull Request
Fixes #18772 

NPC will now properly update their managed inventory when directly adding things to storage, such as ammo box interactions.
## Why It's Good For The Game
Bug fix.
## Changelog
:cl:
fix: NPC's will properly take ammo from ammo boxes
/:cl:
