### PR TITLE
NPC healing fixes

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -111,14 +111,16 @@ GLOBAL_LIST_EMPTY(nodes_with_construction)
 ///Looking for weapons
 #define HUMAN_AI_NEED_WEAPONS (1<<1)
 ///Healing or being healed
-#define HUMAN_AI_HEALING (1<<2)
+#define HUMAN_AI_BEING_HEALED (1<<2)
 ///Healing self
 #define HUMAN_AI_SELF_HEALING (1<<3)
 ///Building something
 #define HUMAN_AI_BUILDING (1<<4)
+///Healing someone else
+#define HUMAN_AI_HEALING_OTHER (1<<5)
 
 ///Any action that we generally don't want to interrupt
-#define HUMAN_AI_BUSY_ACTION (HUMAN_AI_HEALING|HUMAN_AI_SELF_HEALING|HUMAN_AI_BUILDING)
+#define HUMAN_AI_BUSY_ACTION (HUMAN_AI_SELF_HEALING|HUMAN_AI_BUILDING|HUMAN_AI_HEALING_OTHER|HUMAN_AI_BEING_HEALED)
 
 ///We're good to shoot
 #define AI_FIRE_CAN_HIT (1<<0)

--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(nodes_with_construction)
 #define HUMAN_AI_FIRING (1<<0)
 ///Looking for weapons
 #define HUMAN_AI_NEED_WEAPONS (1<<1)
-///Healing or being healed
+///Being healed by another NPC
 #define HUMAN_AI_BEING_HEALED (1<<2)
 ///Healing self
 #define HUMAN_AI_SELF_HEALING (1<<3)

--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -95,6 +95,8 @@ GLOBAL_LIST_EMPTY(nodes_with_construction)
 ///Obstacle can be ignored
 #define AI_OBSTACLE_IGNORED "ai_obstacle_ignored"
 
+//human_ai_behavior_flags
+
 ///If the mob parent can heal itself and so should flee
 #define HUMAN_AI_SELF_HEAL (1<<0)
 ///Uses weapons
@@ -105,6 +107,8 @@ GLOBAL_LIST_EMPTY(nodes_with_construction)
 #define HUMAN_AI_NO_FF (1<<3)
 ///Will try avoid hazards when possible
 #define HUMAN_AI_AVOID_HAZARDS (1<<4)
+
+//human_ai_state_flags
 
 ///Currently shooting
 #define HUMAN_AI_FIRING (1<<0)

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -52,14 +52,16 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 	var/is_offered_on_creation = FALSE
 	///Are we waiting for advanced pathfinding
 	var/registered_for_node_pathfinding = FALSE
-	///Are we already registered for normal pathfinding
-	var/registered_for_move = FALSE
 	///Should we lose the escorted atom if we change action
 	var/weak_escort = FALSE
 	///List of abilities to consider doing every Process()
 	var/list/ability_list = list()
 	///Count of how many times we've failed to form a path to our goal node
 	var/fail_goal_path_count = 0
+	///timer for movement
+	var/next_move_timer
+	///the time when we can next move
+	var/next_move_time = 0
 
 /datum/ai_behavior/New(loc, mob/parent_to_assign, atom/escorted_atom)
 	..()
@@ -109,8 +111,8 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 			change_action(ESCORTING_ATOM, escorted_atom)
 		if(IDLE)
 			change_action(IDLE)
-	if(!registered_for_move)
-		scheduled_move()
+	if(!next_move_timer)
+		prepare_move()
 
 ///Refresh abilities-to-consider list
 /datum/ai_behavior/proc/refresh_abilities()
@@ -461,17 +463,22 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 
 /// Move the ai and schedule the next move
 /datum/ai_behavior/proc/scheduled_move()
+	next_move_timer = null
 	if(QDELETED(mob_parent))
 		return
 	if(!atom_to_walk_to)
-		registered_for_move = FALSE
 		return
 	ai_do_move()
-	var/next_move = mob_parent.cached_multiplicative_slowdown + mob_parent.next_move_slowdown
+	prepare_move()
+
+///Prepares the NPC to move
+/datum/ai_behavior/proc/prepare_move()
+	if(next_move_timer)
+		return
+	var/next_move = min(next_move_time - world.time, mob_parent.cached_multiplicative_slowdown + mob_parent.next_move_slowdown)
 	if(next_move <= 0)
 		next_move = 1
-	addtimer(CALLBACK(src, PROC_REF(scheduled_move)), next_move, NONE, SSpathfinder)
-	registered_for_move = TRUE
+	next_move_timer = addtimer(CALLBACK(src, PROC_REF(scheduled_move)), next_move, TIMER_STOPPABLE, SSpathfinder)
 
 ///Returns true if the mob should not move for some reason
 /datum/ai_behavior/proc/should_hold()
@@ -488,6 +495,8 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	if(!mob_parent?.canmove)
 		return
 	if(should_hold())
+		return
+	if(world.time < next_move_time)
 		return
 	mob_parent.next_move_slowdown = 0
 	var/list/dir_options = find_next_dirs()
@@ -542,6 +551,7 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 	if(ISDIAGONALDIR(move_dir))
 		mob_parent.next_move_slowdown += (DIAG_MOVEMENT_ADDED_DELAY_MULTIPLIER - 1) * mob_parent.cached_multiplicative_slowdown
 	mob_parent.set_glide_size(DELAY_TO_GLIDE_SIZE(mob_parent.cached_multiplicative_slowdown + mob_parent.next_move_slowdown * ( ISDIAGONALDIR(move_dir) ? DIAG_MOVEMENT_ADDED_DELAY_MULTIPLIER : 1 ) )) //todo: probs dont even need this
+	next_move_time = world.time + mob_parent.cached_multiplicative_slowdown + mob_parent.next_move_slowdown
 
 ///Finds and sets the most suitable escort candidate, if possible
 /datum/ai_behavior/proc/set_escort()
@@ -614,8 +624,8 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		do_unset_target(atom_to_walk_to, FALSE)
 	atom_to_walk_to = new_target
 	RegisterSignals(atom_to_walk_to, list(COMSIG_QDELETING, COMSIG_MOB_DEATH, COMSIG_OBJ_DECONSTRUCT, COMSIG_MOVABLE_Z_CHANGED, COMSIG_FACE_HUGGER_DEATH), PROC_REF(unset_target), TRUE)
-	if(!registered_for_move)
-		INVOKE_ASYNC(src, PROC_REF(scheduled_move))
+	if(!next_move_timer)
+		INVOKE_ASYNC(src, PROC_REF(prepare_move))
 	return TRUE
 
 ///Sets our active combat target

--- a/code/modules/ai/ai_behaviors/human_mobs/heal_procs.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/heal_procs.dm
@@ -22,18 +22,21 @@
 	for(var/dam_type in dam_list)
 		if(dam_list[dam_type] <= 10)
 			if(dam_type == TOX)
-				address_toxins(patient)
+				. = address_toxins(patient)
 			continue
 		if(heal_by_type(patient, dam_type))
 			. = TRUE
 			continue
 
-///Deals with toxins in the patient if required
+/**
+ * Specifically deals with toxins in the patient
+ * If any toxin is above the threshold, we treat
+ */
 /datum/ai_behavior/human/proc/address_toxins(mob/living/carbon/human/patient)
 	for(var/datum/reagent/toxin/tox in patient.reagents.reagent_list)
 		if(tox.volume < 10) //arbitrary magic number, but there's no simple way to determine an appropriate threshold
 			continue
-		heal_by_type(patient, TOX)
+		. = heal_by_type(patient, TOX)
 		return
 
 ///Heal other ailments

--- a/code/modules/ai/ai_behaviors/human_mobs/healing.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/healing.dm
@@ -48,14 +48,20 @@
 ///Someone is healing us
 /datum/ai_behavior/human/proc/parent_being_healed(mob/living/source, mob/living/carbon/human/healer) //add player healing sig? only AI healing currently
 	SIGNAL_HANDLER
-	human_ai_state_flags |= HUMAN_AI_HEALING
-	RegisterSignals(healer, list(COMSIG_MOB_STAT_CHANGED, COMSIG_MOVABLE_MOVED, COMSIG_AI_HEALING_FINISHED), PROC_REF(on_heal_end)) //DOC IS NOT SET AS A TARGET, SO THIS MAY FAIL IF THEY JUST GET GIBBED OR SOMETHING
+	human_ai_state_flags |= HUMAN_AI_BEING_HEALED
+	RegisterSignals(healer, list(COMSIG_MOB_STAT_CHANGED, COMSIG_MOVABLE_MOVED, COMSIG_AI_HEALING_FINISHED, COMSIG_QDELETING), PROC_REF(on_heal_end))
 
-///Our healing ended, successfully or otherwise
+///We finish healing ourselves, or being healed by another
 /datum/ai_behavior/human/proc/on_heal_end(mob/living/carbon/human/healer)
 	SIGNAL_HANDLER
-	UnregisterSignal(healer, list(COMSIG_MOB_STAT_CHANGED, COMSIG_MOVABLE_MOVED, COMSIG_AI_HEALING_FINISHED))
-	human_ai_state_flags &= ~HUMAN_AI_HEALING
+	UnregisterSignal(healer, list(COMSIG_MOB_STAT_CHANGED, COMSIG_MOVABLE_MOVED, COMSIG_AI_HEALING_FINISHED, COMSIG_QDELETING))
+	human_ai_state_flags &= ~HUMAN_AI_BEING_HEALED
+	late_initialize()
+
+/datum/ai_behavior/human/proc/on_heal_other_end(mob/living/carbon/human/patient)
+	SIGNAL_HANDLER
+	SEND_SIGNAL(mob_parent, COMSIG_AI_HEALING_FINISHED)
+	human_ai_state_flags &= ~HUMAN_AI_HEALING_OTHER
 	late_initialize()
 
 ///Decides if we should do something when another mob goes crit
@@ -145,6 +151,8 @@
 
 ///Tries to heal another mob
 /datum/ai_behavior/human/proc/try_heal_other(mob/living/carbon/human/patient)
+	if(human_ai_state_flags & HUMAN_AI_BUSY_ACTION)
+		return
 	if(patient.InCritical()) //crit heal is always priority
 		heal_by_type(patient, OXY)
 
@@ -161,11 +169,11 @@
 		return
 
 	try_speak(pick(healing_chat))
-	human_ai_state_flags |= HUMAN_AI_HEALING
+	human_ai_state_flags |= HUMAN_AI_HEALING_OTHER
 
 	if(patient.stat == DEAD) //we specifically don't want the sig sent out if we fail to defib
 		if(!attempt_revive(patient))
-			on_heal_end(mob_parent)
+			on_heal_other_end(patient)
 			return
 
 	SEND_SIGNAL(patient, COMSIG_AI_HEALING_MOB, mob_parent)
@@ -176,5 +184,4 @@
 	if(!did_heal || prob(30)) //heal interupted or nothing left to heal, or to stop overload
 		do_unset_target(patient)
 	UnregisterSignal(patient, COMSIG_MOVABLE_MOVED)
-	on_heal_end(mob_parent)
-	SEND_SIGNAL(mob_parent, COMSIG_AI_HEALING_FINISHED)
+	on_heal_other_end(patient)

--- a/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
+++ b/code/modules/ai/ai_behaviors/human_mobs/human_mob.dm
@@ -169,7 +169,8 @@
 
 /datum/ai_behavior/human/scheduled_move()
 	if(human_ai_state_flags & HUMAN_AI_BUSY_ACTION)
-		registered_for_move = FALSE
+		deltimer(next_move_timer)
+		next_move_timer = null
 		return
 	return ..()
 
@@ -239,8 +240,8 @@
 	remove_atom_of_interest(old_target)
 
 	if(QDELETED(old_target)) //if they're deleted we need to ensure engineering and medical stuff is cleaned up properly
-		if(human_ai_state_flags & HUMAN_AI_HEALING)
-			on_heal_end(old_target)
+		if(human_ai_state_flags & HUMAN_AI_HEALING_OTHER)
+			on_heal_other_end(old_target)
 		else
 			remove_from_heal_list(old_target)
 		if(human_ai_state_flags & HUMAN_AI_BUILDING)
@@ -258,8 +259,8 @@
 			remove_from_heal_list(old_target)
 	else
 		remove_from_heal_list(old_target)
-	if((human_ai_state_flags & HUMAN_AI_HEALING) && !revive_target)
-		on_heal_end(old_target)
+	if((human_ai_state_flags & HUMAN_AI_HEALING_OTHER) && !revive_target)
+		on_heal_other_end(old_target)
 	return ..()
 
 ///Sets run move intent if able


### PR DESCRIPTION

## About The Pull Request
Fixes NPC's sometimes moving when healing.

Reworked some healing related code to be a bit clearer and more robust, by splitting out the generic healing flag into 'healing self, healing other, and being healed'.

Also improved npc movement code to avoid certain issues with occasional double stacked movement due to how the timer is set.
## Why It's Good For The Game
More stable NPC's.
## Changelog
:cl:
fix: fixed NPC's not holding still when healing in some cases
/:cl:
