### PR TITLE
Heal foam nade buff

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_INIT(medic_gear_listed_products, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus = list(CAT_MEDSUP, "Injector (Peridaxon Plus)", 1, "corps-meds"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "corps-meds"),
 		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 14, "corps-meds"),
-		/obj/item/explosive/grenade/chem_grenade/healing_foam = list(CAT_MEDSUP, "EMS-02 Healing Foam Grenade", 8, "corps-meds"),
+		/obj/item/explosive/grenade/chem_grenade/healing_foam = list(CAT_MEDSUP, "EMS-02 Healing Foam Grenade", 3, "corps-meds"),
 		/obj/effect/vendor_bundle/stretcher = list(CAT_MEDSUP, "Medivac Stretcher", 45, "corps-tools"),
 		/obj/item/reagent_containers/hypospray/advanced/big = list(CAT_MEDSUP, "Big hypospray", 10, "corps-tools"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Hypospray", 2, "corps-tools"),

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -1515,19 +1515,21 @@
 /datum/reagent/medicine/experimental_medical_salve/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier += PAIN_REDUCTION_HEAVY
 	switch(current_cycle)
-		if(1 to 5) // big burst of healing + stamina initially
+		if(1 to 8) // big burst of healing + stamina initially
 			if(!particle_holder)
 				particle_holder = new(L, /particles/healing_cross)
 			L.heal_overall_damage(4*effect_str, 4*effect_str)
 			L.adjustStaminaLoss(-4*effect_str)
-		if(6 to 25) // smaller gradual healing
+		if(9 to 25) // smaller gradual healing
 			L.heal_overall_damage(1.5*effect_str, 1.5*effect_str)
-		if(26 to INFINITY) // purges itself quickly
-			if(particle_holder)
-				qdel(particle_holder)
-				particle_holder = null
-			holder.remove_reagent(/datum/reagent/medicine/experimental_medical_salve, 10)
-	return ..()
+	. = ..()
+	if(current_cycle < 26)
+		return
+	if(particle_holder)
+		qdel(particle_holder)
+		particle_holder = null
+	if(holder) // purges itself quickly
+		holder.remove_reagent(/datum/reagent/medicine/experimental_medical_salve, 10)
 
 /datum/reagent/medicine/experimental_medical_salve/on_mob_delete(mob/living/L, metabolism)
 	if(particle_holder)


### PR DESCRIPTION

## About The Pull Request
Makes the EMS-02 heal foam nades significantly cheaper, at 3 points instead of 8.
Slightly buffs its healing, by making the initial stronger heal last for 3 more ticks.

Fixes the foam runtiming when it gets purged.
## Why It's Good For The Game
Most people have a funny tendency to shy away from using single use consumables (people do the classic 'hold onto them just in case' for an entire game and never use them), and these nades are not omega strong to begin with.

By making them a lot cheaper, it should encourage people to pick them more often, especially if you just have a small number of points left over and you're not sure what to use them on.
## Changelog
:cl:
balance: EMS-02 heal foam grenades cost 3 points instead of 8 in the medic vendor
balance: EMS-02 heal foam grenades have their stronger heal last for 3 more ticks, total duration unchanged
fix: Fixed EMS-02 heal foam grenades from runtiming whenever they get purged
/:cl:
