### PR TITLE
Strip menu fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -553,12 +553,12 @@
 	if(H.species.hud?.equip_slots)
 		mob_equip = H.species.hud.equip_slots
 
-	if(!H.has_limb_for_slot(slot))
-		return FALSE
-
 	if(bitslot)
 		var/old_slot = slot
 		slot = slotbit2slotdefine(old_slot)
+
+	if(!H.has_limb_for_slot(slot))
+		return FALSE
 
 	if(H.species && !(slot in mob_equip))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
Fixes strip menu (and likely other stuff) not working properly when equipping items to someone else in most cases.

A funny PR a year ago added a check to mob_can_equip() without actually testing it, and it just broke the entire proc in like half of the ways it gets used, since it assumes the slot is a normal define instead of a bitslot, before the check/change for that purpose.
## Why It's Good For The Game
Working code is good.
## Changelog
:cl:
fix: fixed strip menu failing when equipping items to certain slots
/:cl:
