### PR TITLE
Remove flaregun from civil war uniform

### DIFF
--- a/code/datums/outfits/quick_load_civil_war.dm
+++ b/code/datums/outfits/quick_load_civil_war.dm
@@ -14,7 +14,7 @@
 	belt = /obj/item/storage/belt/shotgun/martini/full
 	back = /obj/item/weapon/gun/shotgun/double/martini
 	r_pocket = /obj/item/storage/pouch/firstaid
-	l_pocket = /obj/item/storage/holster/flarepouch/full
+	l_pocket = /obj/item/storage/holster/flarepouch/full/nogun
 
 	r_pocket_contents = list(
 		/obj/item/storage/pill_bottle/tramadol = 1,

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -409,6 +409,12 @@
 	for(var/i in 1 to (storage_datum.storage_slots - flare_gun.w_class))
 		new /obj/item/explosive/grenade/flare(src)
 
+/obj/item/storage/holster/flarepouch/full/nogun
+	name = "flare pouch"
+
+/obj/item/storage/holster/flarepouch/full/nogun/PopulateContents()
+	for(var/i in 1 to (storage_datum.storage_slots))
+		new /obj/item/explosive/grenade/flare(src)
 
 /obj/item/storage/holster/icc_mg
 	name = "\improper ML-41 scabbard (10x26mm)"


### PR DESCRIPTION

## About The Pull Request

Remove flaregun from civil war uniform

## Why It's Good For The Game

They shouldn't have them incredibly important

## Changelog
:cl:
del: Remove flaregun from civil war uniform
/:cl:
