### PR TITLE
zombie giga nerf

### DIFF
--- a/code/datums/outfits/survivor.dm
+++ b/code/datums/outfits/survivor.dm
@@ -253,14 +253,12 @@
 	jobtype = /datum/job/survivor/miner
 
 	w_uniform = /obj/item/clothing/under/rank/miner
-	head = /obj/item/clothing/head/helmet/space/rig/mining
 	glasses = /obj/item/clothing/glasses/meson
 	shoes = /obj/item/clothing/shoes/black
 	gloves = /obj/item/clothing/gloves/ruggedgloves
 	back = /obj/item/storage/backpack/satchel/som
 	l_hand = /obj/item/weapon/twohanded/sledgehammer
 	r_pocket = /obj/item/reagent_containers/cup/glass/flask
-	wear_suit = /obj/item/clothing/suit/space/rig/mining
 	ears = /obj/item/radio/survivor
 
 	backpack_contents = list(

--- a/code/modules/ai/presets/zombie_presets.dm
+++ b/code/modules/ai/presets/zombie_presets.dm
@@ -15,7 +15,7 @@
 	ai_type = /datum/ai_behavior/xeno/zombie/patrolling
 
 /mob/living/carbon/human/species/zombie/ai/fast
-	race = "Fast zombie"
+	race = "Runner zombie"
 
 /mob/living/carbon/human/species/zombie/ai/fast/stay
 	ai_type = /datum/ai_behavior/xeno/zombie/idle

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -86,6 +86,17 @@
 	if(prob(2))
 		playsound(get_turf(H), pick(sounds), 50)
 
+	for(var/datum/limb/limb AS in H.limbs) //Regrow some limbs
+		if(limb.limb_status & LIMB_DESTROYED && !(limb.parent?.limb_status & LIMB_DESTROYED) && prob(2))
+			limb.remove_limb_flags(LIMB_DESTROYED)
+			if(istype(limb, /datum/limb/hand/l_hand))
+				H.equip_to_slot_or_del(new claw_type, SLOT_L_HAND)
+			else if (istype(limb, /datum/limb/hand/r_hand))
+				H.equip_to_slot_or_del(new claw_type, SLOT_R_HAND)
+			H.update_body()
+		else if(limb.limb_status & LIMB_BROKEN && prob(5))
+			limb.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
+
 	if(H.health != total_health)
 		H.heal_limbs(heal_rate)
 

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -169,7 +169,7 @@
 /datum/species/zombie/psi_zombie
 	name = "Psi zombie" //reanimated by psionic ability
 	slowdown = -0.5
-	heal_rate = 20 // Sectoids are incredibly rare so i dont want to nerf them
+	heal_rate = 20
 	total_health = 200
 	faction = FACTION_SECTOIDS
 	claw_type = /obj/item/weapon/zombie_claw/no_zombium

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -2,7 +2,7 @@
 	name = "Zombie"
 	icobase = 'icons/mob/human_races/r_husk.dmi'
 	total_health = 100
-	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|PARALYSE_RESISTANT|SPECIES_NO_HUG
+	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|SPECIES_NO_HUG
 	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	blood_color = "#110a0a"
 	hair_color = "#000000"
@@ -23,7 +23,7 @@
 	///Time before resurrecting if dead
 	var/revive_time = 1 MINUTES
 	///How much burn and burn damage can you heal every Life tick (half a sec)
-	var/heal_rate = 7
+	var/heal_rate = 0.5 // i would remove this entirely but otherwise it's functionally better to just leave them in crit so they don't revive at all. This whole thing is a design mess.
 	var/faction = FACTION_ZOMBIE
 	var/claw_type = /obj/item/weapon/zombie_claw
 	///Whether this zombie type can jump
@@ -33,11 +33,6 @@
 
 /datum/species/zombie/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
-	for(var/datum/limb/limb AS in H.limbs)
-		if(!istype(limb, /datum/limb/head))
-			continue
-		limb.vital = FALSE
-		break
 
 	H.set_undefibbable()
 	H.faction = faction
@@ -60,10 +55,6 @@
 	H.job = new /datum/job/zombie //Prevent from skewing the respawn timer if you take a zombie, it's a ghost role after all
 	for(var/datum/action/action AS in H.actions)
 		action.remove_action(H)
-	var/datum/action/rally_zombie/rally_zombie = new
-	rally_zombie.give_action(H)
-	var/datum/action/set_agressivity/set_zombie_behaviour = new
-	set_zombie_behaviour.give_action(H)
 	if(can_jump)
 		H.set_jump_component(cost = 0)
 
@@ -92,18 +83,8 @@
 		H.set_jump_component()
 
 /datum/species/zombie/handle_unique_behavior(mob/living/carbon/human/H)
-	if(prob(10))
+	if(prob(2))
 		playsound(get_turf(H), pick(sounds), 50)
-	for(var/datum/limb/limb AS in H.limbs) //Regrow some limbs
-		if(limb.limb_status & LIMB_DESTROYED && !(limb.parent?.limb_status & LIMB_DESTROYED) && prob(4))
-			limb.remove_limb_flags(LIMB_DESTROYED)
-			if(istype(limb, /datum/limb/hand/l_hand))
-				H.equip_to_slot_or_del(new claw_type, SLOT_L_HAND)
-			else if (istype(limb, /datum/limb/hand/r_hand))
-				H.equip_to_slot_or_del(new claw_type, SLOT_R_HAND)
-			H.update_body()
-		else if(limb.limb_status & LIMB_BROKEN && prob(20))
-			limb.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
 
 	if(H.health != total_health)
 		H.heal_limbs(heal_rate)
@@ -137,23 +118,25 @@
 	QDEL_IN(H, time)
 
 /datum/species/zombie/fast
-	name = "Fast zombie"
-	slowdown = 0
+	name = "Runner zombie"
+	total_health = 50 // dies to a gentle breeze
+	slowdown = -0.5
 	can_jump = TRUE
 
 /datum/species/zombie/fast/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
-	H.transform = matrix().Scale(0.8, 0.8)
+	H.transform = matrix().Scale(0.9, 0.9)
+	H.add_atom_colour(COLOR_RED, FIXED_COLOR_PRIORITY)
 
 /datum/species/zombie/fast/post_species_loss(mob/living/carbon/human/H)
 	. = ..()
-	H.transform = matrix().Scale(1/(0.8), 1/(0.8))
+	H.transform = matrix().Scale(1/(0.9), 1/(0.9))
+	H.remove_atom_colour(COLOR_RED, FIXED_COLOR_PRIORITY)
 
 /datum/species/zombie/tank
 	name = "Tank zombie"
 	slowdown = 1
-	heal_rate = 30
-	total_health = 350
+	total_health = 300
 	claw_type = /obj/item/weapon/zombie_claw/tank
 
 /datum/species/zombie/tank/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
@@ -171,8 +154,7 @@
 
 /datum/species/zombie/strong
 	name = "Strong zombie" //These are zombies created from marines, they are stronger, but of course rarer
-	slowdown = -0.5
-	heal_rate = 20
+	slowdown = 0.2
 	total_health = 200
 	claw_type = /obj/item/weapon/zombie_claw/strong
 
@@ -187,7 +169,7 @@
 /datum/species/zombie/psi_zombie
 	name = "Psi zombie" //reanimated by psionic ability
 	slowdown = -0.5
-	heal_rate = 20
+	heal_rate = 20 // Sectoids are incredibly rare so i dont want to nerf them
 	total_health = 200
 	faction = FACTION_SECTOIDS
 	claw_type = /obj/item/weapon/zombie_claw/no_zombium
@@ -217,7 +199,7 @@
 /datum/species/zombie/hunter
 	name = "Hunter zombie"
 	total_health = 175
-	slowdown = 0
+	slowdown = 0.2
 	can_jump = TRUE
 	claw_type = /obj/item/weapon/zombie_claw/strong
 	action_list = list(/datum/action/ability/activable/pounce)
@@ -232,8 +214,8 @@
 
 /datum/species/zombie/boomer
 	name = "Boomer zombie"
-	heal_rate = 20
 	total_health = 250
+	claw_type = /obj/item/weapon/zombie_claw/boomer
 	action_list = list(
 		/datum/action/ability/activable/bile_spit,
 		/datum/action/ability/boomer_explode,

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -1,18 +1,9 @@
+/mob/living/carbon/human/species/zombie
+	gib_chance = 10
+
 ///Rallies nearby zombies
 /proc/global_rally_zombies(atom/rally_point, global_rally = FALSE)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_AI_ZOMBIE_RALLY, rally_point, global_rally)
-
-/datum/action/rally_zombie
-	name = "Rally Zombies"
-	action_icon_state = "rally_minions"
-	action_icon = 'icons/Xeno/actions/leader.dmi'
-
-/datum/action/rally_zombie/action_activate()
-	owner.balloon_alert(owner, "Zombies Rallied!")
-	global_rally_zombies(owner)
-	var/datum/action/set_agressivity/set_agressivity = owner.actions_by_path[/datum/action/set_agressivity]
-	if(set_agressivity)
-		SEND_SIGNAL(owner, COMSIG_ESCORTING_ATOM_BEHAVIOUR_CHANGED, set_agressivity.zombies_agressive) //New escorting ais should have the same behaviour as old one
 
 /datum/action/set_agressivity
 	name = "Set other zombie behavior"
@@ -35,7 +26,7 @@
 	hitsound = 'sound/weapons/slice.ogg'
 	icon_state = "zombie_claw_left"
 	base_icon_state = "zombie_claw"
-	force = 25
+	force = 15
 	sharp = IS_SHARP_ITEM_BIG
 	edge = TRUE
 	attack_verb = list("claws", "slashes", "tears", "rips", "dices", "cuts", "bites")
@@ -43,7 +34,7 @@
 	attack_speed = 8 //Same as unarmed delay
 	pry_capable = IS_PRY_CAPABLE_FORCE
 	///How much zombium is transferred per hit. Set to zero to remove transmission
-	var/zombium_per_hit = 7
+	var/zombium_per_hit = 2
 
 /obj/item/weapon/zombie_claw/Initialize(mapload)
 	. = ..()
@@ -56,11 +47,16 @@
 	target.attack_zombie(user, src, params, rightclick)
 
 /obj/item/weapon/zombie_claw/strong
-	force = 35
+	force = 20
+	zombium_per_hit = 4
+
+/obj/item/weapon/zombie_claw/boomer
+	zombium_per_hit = 8
 
 /obj/item/weapon/zombie_claw/tank
 	attack_speed = 12
-	force = 40
+	force = 25
+	zombium_per_hit = 4
 
 /obj/item/weapon/zombie_claw/no_zombium
 	zombium_per_hit = 0

--- a/code/modules/projectiles/ammo_types/zombie_ammo.dm
+++ b/code/modules/projectiles/ammo_types/zombie_ammo.dm
@@ -13,12 +13,8 @@
 
 /datum/ammo/bile_spit/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/mob/living/living_target = target_mob
-	shake_camera(target_mob, 1, 1)
 	living_target.add_slowdown(3)
 	living_target.adjust_stagger(3 SECONDS)
-	living_target.AdjustConfused(3 SECONDS)
-	living_target.blind_eyes(2)
-	living_target.adjust_blurriness(4)
 
 	drop_nade(get_turf(target_mob))
 

--- a/code/modules/reagents/chemistry/reagents/medical.dm
+++ b/code/modules/reagents/chemistry/reagents/medical.dm
@@ -385,7 +385,7 @@
 	name = "Dylovene"
 	description = "Dylovene is a broad-spectrum antitoxin."
 	color = COLOR_REAGENT_DYLOVENE
-	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/research/stimulon, /datum/reagent/consumable/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
+	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/research/stimulon, /datum/reagent/consumable/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway, /datum/reagent/zombium)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL

--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -652,7 +652,7 @@
 
 /datum/reagent/zombium/on_mob_life(mob/living/L, metabolism)
 	. = ..()
-	if(prob(10))
+	if(prob(1))
 		L.emote("cough")
 
 /datum/reagent/zombium/on_overdose_start(mob/living/L, metabolism)
@@ -663,13 +663,13 @@
 
 /datum/reagent/zombium/overdose_process(mob/living/L, metabolism)
 	if(prob(5))
-		L.emote("gasp")
+		L.emote("pain")
 	L.adjustOxyLoss(1.5)
 	L.adjustToxLoss(1.5)
 
 /datum/reagent/zombium/overdose_crit_process(mob/living/L, metabolism)
-	if(prob(50))
-		L.emote("gasp")
+	if(prob(5))
+		L.emote("scream")
 	L.adjustOxyLoss(5)
 	L.adjustToxLoss(5)
 


### PR DESCRIPTION

## About The Pull Request
This pr takes zombies as they are now out back behind the barn and shoots them in the head. see changelog or changed files for the specific nerfs.
They are overall weaker and easier to kill, and don't kill or frac as fast as before. Zombies can once again be perma killed by removing their heads while they are still alive. 
The zombie rally ability is completely removed but you can still control nearby zombie AI as it's frustrating to watch your entire AI team run down mid onto a turret.
## Why It's Good For The Game
Zombies are in a state right now where zombie crash mode is just utterly unfun unless you are running an insanely meta loadout. You should be able to take a loadout from the mack vendor and go blast zombies with little knowledge of the game. In it's current state zombie crash devolves into turtling canter because nobody can push out to do objectives; which is seriously not ideal for a super low pop mode.

Zombie heads being in a state of limbo as to whether they are vestigial or not is unfun and not communicated very well to players.

One player zombie being able to end the whole round; forcing marines to prep again and usually just killing server pop, is really bad. The most consistent complaint about zombie crash is player zombies, and it's derived from their ability to gather massive hordes and throw them at marines who have left the canter.
## Changelog
:cl:
balance: dylovene purges zombium
balance: zombies do less brute damage, inject less zombium on hit, regen significantly slower, respect that they have no head and die, and regrow limbs and heal fractures about half as fast as before.
add: Fast zombies are now Runner zombies, they are also red and slightly bigger than before.
add: zombies have a chance to explode into gibs when overkilled.
removal: removes zombie rallying to player zombies and paralyze resistance.
balance: any zombie except for Runner zombies that were faster than a player is now not faster than a player.
balance: boomer bile no longer shakes your screen, confuses and blinds you on hit. boomer claws now inject extra zombium.
qol: zombies make noise alot less, zombium makes you cough alot less. Zombium overdose now makes you painscream or regular scream instead of spam gasping.
/:cl:
