### PR TITLE
Reduce zombie health

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -1,7 +1,7 @@
 /datum/species/zombie
 	name = "Zombie"
 	icobase = 'icons/mob/human_races/r_husk.dmi'
-	total_health = 100
+	total_health = 80
 	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|PARALYSE_RESISTANT|SPECIES_NO_HUG
 	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	blood_color = "#110a0a"
@@ -23,7 +23,7 @@
 	///Time before resurrecting if dead
 	var/revive_time = 1 MINUTES
 	///How much burn and burn damage can you heal every Life tick (half a sec)
-	var/heal_rate = 7
+	var/heal_rate = 5
 	var/faction = FACTION_ZOMBIE
 	var/claw_type = /obj/item/weapon/zombie_claw
 	///Whether this zombie type can jump

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -1,7 +1,7 @@
 /datum/species/zombie
 	name = "Zombie"
 	icobase = 'icons/mob/human_races/r_husk.dmi'
-	total_health = 80
+	total_health = 60
 	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_PAIN|NO_CHEM_METABOLIZATION|NO_STAMINA|HAS_UNDERWEAR|HEALTH_HUD_ALWAYS_DEAD|PARALYSE_RESISTANT|SPECIES_NO_HUG
 	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	blood_color = "#110a0a"
@@ -23,7 +23,7 @@
 	///Time before resurrecting if dead
 	var/revive_time = 1 MINUTES
 	///How much burn and burn damage can you heal every Life tick (half a sec)
-	var/heal_rate = 5
+	var/heal_rate = 4
 	var/faction = FACTION_ZOMBIE
 	var/claw_type = /obj/item/weapon/zombie_claw
 	///Whether this zombie type can jump


### PR DESCRIPTION

## About The Pull Request

Reduce zombie health and heal rate

## Why It's Good For The Game

It's more fun having lower health zombies, mowing down hordes is fun, zombie crash is a bit too hard right now

## Changelog
:cl:
balance: Reduce zombie health and heal rate
/:cl:
