### PR TITLE
Preweeds Research Outpost + small fixes

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -7,10 +7,17 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 4
 	},
 /area/outpost/hallway/west)
+"ad" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/south_east)
 "ae" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -51,11 +58,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark/blue2,
 /area/outpost/medbay/storage)
-"an" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/outpost/science/research)
 "ap" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -134,6 +136,12 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/dormitories)
+"aI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/yellow2{
+	dir = 1
+	},
+/area/outpost/engineering/hallway)
 "aL" = (
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/tile/dark/red2{
@@ -161,6 +169,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2,
 /area/outpost/medbay/storage)
+"aR" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/outpost/yard/east)
 "aS" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/tile/dark/red2{
@@ -258,6 +271,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/brig/armoury)
+"bt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/dmg3,
+/area/outpost/arrivals)
 "bu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -360,6 +377,11 @@
 "bS" = (
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/east)
+"bT" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/arrivals/securitylz2)
 "bU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -423,7 +445,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig)
 "co" = (
@@ -479,6 +500,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
 "cF" = (
@@ -497,15 +519,11 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/east)
 "cJ" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
 /area/outpost/arrivals)
-"cK" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2,
-/area/outpost/hallway/south_cent)
 "cM" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -521,6 +539,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering/security)
 "cR" = (
@@ -564,17 +583,17 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/surgery)
-"cZ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/decal/cleanable/blood/writing,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/outpost/caves/north_east)
 "da" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 8
 	},
 /area/outpost/hallway/central)
+"db" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/west)
 "dc" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -636,12 +655,6 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/north_east)
-"dq" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 1
-	},
-/area/outpost/hallway/northern)
 "dr" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/lz1)
@@ -657,13 +670,6 @@
 "dw" = (
 /turf/open/floor/plating/dmg2,
 /area/outpost/arrivals)
-"dx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 4
-	},
-/area/outpost/hallway/south_west)
 "dy" = (
 /obj/structure/closet/secure_closet/RD,
 /turf/open/floor/tile/dark/purple2{
@@ -675,12 +681,22 @@
 	dir = 1
 	},
 /area/outpost/yard/east)
+"dB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/yard/east)
 "dD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
 	},
 /area/outpost/cargo/engineering)
+"dE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/cargo)
 "dF" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -757,6 +773,11 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_west)
+"dX" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/central)
 "dY" = (
 /obj/machinery/light{
 	dir = 1
@@ -813,10 +834,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
-"ei" = (
-/obj/machinery/power/geothermal,
-/turf/open/floor/plating,
-/area/outpost/engineering/engine)
+"ej" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/outpost/yard/south)
 "ek" = (
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark/yellow2,
@@ -885,6 +906,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
+"eA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/yard/east)
 "eB" = (
 /obj/machinery/prop/autolathe,
 /obj/machinery/light,
@@ -935,7 +962,6 @@
 /area/outpost/caves/south)
 "eM" = (
 /obj/item/tool/pen,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/south_east)
 "eN" = (
@@ -1021,6 +1047,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south)
+"fg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/south)
 "fi" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -1118,6 +1150,11 @@
 	dir = 10
 	},
 /area/outpost/cargo)
+"fB" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/central)
 "fC" = (
 /obj/machinery/light{
 	dir = 4
@@ -1173,12 +1210,6 @@
 	dir = 4
 	},
 /area/outpost/hallway/central)
-"fP" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 5
-	},
-/area/outpost/caves/north_east)
 "fQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -1238,6 +1269,7 @@
 /area/outpost/caves/east)
 "gb" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -1517,6 +1549,12 @@
 "hs" = (
 /turf/open/floor/plating/dmg1,
 /area/outpost/arrivals)
+"hu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/hallway/south_west)
 "hv" = (
 /obj/machinery/light{
 	dir = 1
@@ -1529,6 +1567,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/outpost/science/hydponics)
+"hD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/outpost/yard/south)
 "hF" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -1591,6 +1633,10 @@
 	dir = 1
 	},
 /area/outpost/medbay/chemistry)
+"hQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north_west)
 "hR" = (
 /obj/machinery/landinglight/lz1{
 	dir = 4
@@ -1610,6 +1656,12 @@
 	dir = 5
 	},
 /area/outpost/arrivals)
+"hX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/outpost/yard/central)
 "hY" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz2)
@@ -1638,6 +1690,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 8
 	},
@@ -1651,6 +1704,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south)
+"if" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/west)
 "ig" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -1682,6 +1739,10 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/caves/north)
+"il" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/arrivals)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/purple2,
@@ -1736,6 +1797,7 @@
 	},
 /area/outpost/yard/central)
 "ix" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 5
 	},
@@ -1760,6 +1822,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science)
 "iC" = (
@@ -1926,6 +1989,12 @@
 	dir = 9
 	},
 /area/outpost/lz1)
+"jn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/caves/north_west)
 "jo" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -2047,11 +2116,6 @@
 	dir = 8
 	},
 /area/outpost/yard/east)
-"jN" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south)
 "jO" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -2079,8 +2143,13 @@
 /area/outpost/medbay)
 "jT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
+"jV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/north_east)
 "jW" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -2157,6 +2226,10 @@
 	dir = 4
 	},
 /area/outpost/dormitories)
+"kj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/west)
 "kk" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -2192,15 +2265,6 @@
 /obj/item/storage/pill_bottle/tramadol,
 /turf/open/floor/tile/dark/blue2,
 /area/outpost/medbay)
-"ks" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 1
-	},
-/area/outpost/hallway/northern)
 "kt" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2259,6 +2323,7 @@
 "kL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science)
 "kN" = (
@@ -2470,6 +2535,10 @@
 "lA" = (
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
+"lB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/east)
 "lC" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -2489,11 +2558,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 1
 	},
 /area/outpost/science/rd_office)
+"lF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/cargo)
 "lG" = (
 /obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 8
@@ -2542,13 +2614,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
+"lQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/brig/armoury)
 "lS" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
 	},
 /area/outpost/cargo)
 "lT" = (
-/obj/effect/landmark/weed_node,
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
@@ -2611,6 +2686,7 @@
 "mh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 8
 	},
@@ -2626,6 +2702,10 @@
 	dir = 4
 	},
 /area/outpost/science)
+"mo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/east)
 "mp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -2637,10 +2717,18 @@
 	dir = 8
 	},
 /area/outpost/hallway/south_west)
+"mu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/south_east)
 "mv" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz2)
+"mw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/damaged/panel,
+/area/outpost/cargo)
 "mx" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 4
@@ -2671,6 +2759,20 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"mD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/hallway/central)
+"mE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/west)
 "mF" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/decal/cleanable/blood/writing{
@@ -2818,12 +2920,6 @@
 	dir = 4
 	},
 /area/outpost/yard/south_east)
-"nr" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
-/area/outpost/yard/north_east)
 "ns" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -2833,6 +2929,10 @@
 	dir = 10
 	},
 /area/outpost/hallway/central)
+"nt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/north)
 "nu" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/decal/cleanable/blood/writing{
@@ -2882,6 +2982,7 @@
 	},
 /area/outpost/cargo/engineering)
 "nB" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/dmg2,
 /area/outpost/hallway/south_east)
 "nC" = (
@@ -2959,6 +3060,10 @@
 /obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science/research)
+"nT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/west)
 "nU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -3071,6 +3176,7 @@
 	},
 /area/outpost/brig/wardens_office)
 "oq" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/asteroidwarning{
 	dir = 10
 	},
@@ -3125,6 +3231,12 @@
 /obj/item/trash/semki,
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
+"oG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/dormitories)
 "oH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/weaponry/ammo/shotgun,
@@ -3291,6 +3403,10 @@
 	},
 /turf/open/liquid/water/river,
 /area/outpost/engineering/engine)
+"pu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/hallway/east)
 "pv" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/north_east)
@@ -3470,6 +3586,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_west)
+"qf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/yard/south)
 "qh" = (
 /obj/machinery/autodoc,
 /turf/open/floor/tile/dark,
@@ -3525,6 +3645,13 @@
 	dir = 5
 	},
 /area/outpost/arrivals)
+"qy" = (
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_east)
 "qz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3562,6 +3689,10 @@
 	dir = 9
 	},
 /area/outpost/hallway/east)
+"qG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/outpost/yard/east)
 "qI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -3630,6 +3761,14 @@
 	dir = 4
 	},
 /area/outpost/engineering/hallway)
+"qU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2,
+/area/outpost/hallway/northern)
 "qV" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -3829,6 +3968,10 @@
 "rM" = (
 /turf/closed/wall/r_wall,
 /area/outpost/science/rd_office)
+"rN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/yard/central)
 "rO" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
@@ -3847,13 +3990,6 @@
 	dir = 6
 	},
 /area/outpost/cargo/engineering)
-"rR" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/decal/cleanable/blood/writing{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_east)
 "rU" = (
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
@@ -3919,12 +4055,25 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
+"sk" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/east)
 "sl" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
 	},
 /area/outpost/yard/south_east)
+"sn" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_east)
 "so" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4023,10 +4172,24 @@
 	dir = 4
 	},
 /area/outpost/caves/north_west)
+"sC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/south)
 "sE" = (
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/yard/south_east)
+"sH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/central)
+"sI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/outpost/caves/north_west)
 "sJ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/tile/dark/brown2{
@@ -4076,9 +4239,21 @@
 	dir = 10
 	},
 /area/outpost/medbay/security)
+"sU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/west)
 "sV" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/lz1)
+"sW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/outpost/caves/south)
 "sX" = (
 /turf/open/floor/tile/dark,
 /area/outpost/science/hydponics)
@@ -4089,6 +4264,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
 "ta" = (
@@ -4104,6 +4280,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -4253,6 +4430,10 @@
 "tK" = (
 /turf/open/floor/tile/dark,
 /area/outpost/dormitories)
+"tL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/outpost/dormitories)
 "tM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4328,10 +4509,21 @@
 /obj/structure/urinal,
 /turf/open/floor/freezer,
 /area/outpost/dormitories)
+"uc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/central)
 "uf" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/caves/south)
+"ug" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "uh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -4350,6 +4542,11 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/arrivals/securitylz2)
+"uo" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "up" = (
 /obj/machinery/landinglight/lz1{
 	dir = 1
@@ -4358,6 +4555,15 @@
 	dir = 1
 	},
 /area/outpost/lz1)
+"uq" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/outpost/brig)
 "ur" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/marking/asteroidwarning{
@@ -4532,6 +4738,12 @@
 	dir = 8
 	},
 /area/outpost/cargo)
+"vi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/outpost/cargo/engineering)
 "vm" = (
 /obj/structure/prop/mainship/research/destructive_analyzer,
 /turf/open/floor/tile/dark/purple2{
@@ -4580,6 +4792,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_east)
 "vy" = (
@@ -4656,6 +4869,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/science/research)
+"vL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/medbay/storage)
 "vO" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -4738,6 +4955,18 @@
 	dir = 4
 	},
 /area/outpost/yard/south_east)
+"wh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/dormitories)
 "wj" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -4747,11 +4976,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north)
-"wl" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/outpost/science/hydponics)
 "wm" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2
@@ -4800,6 +5024,16 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
+"wv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/east)
 "ww" = (
 /turf/closed/wall/r_wall,
 /area/outpost/hallway/central)
@@ -4854,6 +5088,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -4926,6 +5161,10 @@
 	dir = 4
 	},
 /area/outpost/arrivals)
+"wV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/yard/south_east)
 "wW" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot,
@@ -4968,10 +5207,6 @@
 	dir = 1
 	},
 /area/outpost/dormitories)
-"xd" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/asteroidwarning,
-/area/outpost/yard/north)
 "xg" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/rock)
@@ -4996,6 +5231,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/gear_room)
 "xl" = (
@@ -5087,6 +5323,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals/securitylz1)
 "xD" = (
@@ -5349,6 +5586,12 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/arrivals)
+"yM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/dormitories)
 "yO" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5390,6 +5633,12 @@
 "yW" = (
 /turf/closed/mineral/smooth/bigred,
 /area/bigredv2/caves/rock)
+"yX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 8
+	},
+/area/outpost/caves/south)
 "yY" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
@@ -5399,6 +5648,12 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
+/area/outpost/hallway/central)
+"zb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
 /area/outpost/hallway/central)
 "zd" = (
 /obj/effect/landmark/xeno_silo_spawn,
@@ -5496,6 +5751,10 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science/hydponics)
+"zz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/outpost/dormitories)
 "zA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5596,6 +5855,12 @@
 	dir = 10
 	},
 /area/outpost/arrivals)
+"zY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 10
+	},
+/area/outpost/caves/south)
 "zZ" = (
 /turf/closed/wall/r_wall,
 /area/outpost/science/research)
@@ -5684,6 +5949,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/lz2)
+"Av" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/east)
 "Aw" = (
 /obj/machinery/light{
 	dir = 4
@@ -5842,6 +6113,10 @@
 	dir = 8
 	},
 /area/outpost/hallway/central)
+"Bm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random,
+/area/outpost/caves/north_west)
 "Bn" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 4
@@ -5896,12 +6171,6 @@
 	dir = 10
 	},
 /area/outpost/brig)
-"By" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 8
-	},
-/area/outpost/yard/central)
 "Bz" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating,
@@ -5916,11 +6185,6 @@
 	dir = 6
 	},
 /area/outpost/yard/south_east)
-"BD" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2,
-/area/outpost/dormitories)
 "BE" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -5940,8 +6204,13 @@
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/north_east)
+"BI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt,
+/area/outpost/caves/south)
 "BJ" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/south_east)
@@ -5959,6 +6228,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -5983,16 +6253,25 @@
 	dir = 4
 	},
 /area/outpost/yard/central)
+"BV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/medbay)
 "BW" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 5
 	},
 /area/outpost/science/xenobiology)
+"BX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/blue2/corner{
+	dir = 4
+	},
+/area/outpost/medbay)
 "BY" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -6008,6 +6287,12 @@
 	dir = 1
 	},
 /area/outpost/engineering)
+"Ca" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/hallway/south_west)
 "Cb" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -6051,6 +6336,7 @@
 "Cl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "Cm" = (
@@ -6100,6 +6386,7 @@
 /area/outpost/hallway/central)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/blue2/corner,
 /area/outpost/medbay/surgery)
 "Cy" = (
@@ -6162,6 +6449,10 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/south_east)
+"CS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/south)
 "CT" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
@@ -6224,6 +6515,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
 	},
@@ -6394,6 +6686,10 @@
 "DX" = (
 /turf/closed/wall/r_wall,
 /area/outpost/engineering/engine)
+"DY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/brig/gear_room)
 "Ec" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/tile/dark,
@@ -6497,6 +6793,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "Ez" = (
@@ -6637,7 +6934,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
 	},
@@ -6799,11 +7095,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/lz1)
-"FQ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north)
 "FR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/purple2{
@@ -6855,6 +7146,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/research)
 "Gi" = (
@@ -6988,6 +7280,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/central)
 "GN" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/rd_office)
 "GO" = (
@@ -7005,6 +7298,15 @@
 	dir = 9
 	},
 /area/outpost/cargo)
+"GR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/south_west)
 "GT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -7030,6 +7332,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/lz1)
+"Hb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/outpost/cargo)
 "Hc" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/lz1)
@@ -7068,6 +7376,13 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/south)
+"Hl" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/blue2{
+	dir = 4
+	},
+/area/outpost/medbay)
 "Hm" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
@@ -7098,6 +7413,7 @@
 /area/outpost/caves/south_east)
 "Hw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/chemistry)
 "Hx" = (
@@ -7165,6 +7481,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/central)
 "HK" = (
@@ -7186,9 +7503,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/hallway/northern)
+"HO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/central)
 "HP" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south_east)
+"HQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "HR" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/outpost/yard/east)
@@ -7332,6 +7657,10 @@
 	dir = 5
 	},
 /area/outpost/cargo)
+"ID" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/yard/west)
 "IF" = (
 /obj/structure/table,
 /obj/effect/spawner/random/misc/paperbin,
@@ -7468,6 +7797,12 @@
 	},
 /turf/open/floor/plating/asteroidwarning,
 /area/outpost/lz2)
+"Jr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/east)
 "Js" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -7510,10 +7845,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
-"JE" = (
+"JB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/outpost/science)
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "JG" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1
@@ -7603,6 +7941,11 @@
 	dir = 4
 	},
 /area/outpost/cargo)
+"JX" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/outpost/engineering/engine)
 "JY" = (
 /obj/structure/table,
 /obj/item/trash/cigbutt/cigarbutt,
@@ -7709,6 +8052,7 @@
 	},
 /area/outpost/cargo/engineering)
 "Ku" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 8
 	},
@@ -7723,6 +8067,7 @@
 /area/outpost/yard/east)
 "Kx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -7747,11 +8092,6 @@
 	dir = 6
 	},
 /area/outpost/hallway/northern)
-"KC" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_west)
 "KD" = (
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/south_cent)
@@ -7792,6 +8132,12 @@
 	dir = 10
 	},
 /area/outpost/hallway/central)
+"KI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/yard/central)
 "KL" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -7837,6 +8183,11 @@
 	dir = 10
 	},
 /area/outpost/science/hydponics)
+"KU" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_west)
 "KW" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 1
@@ -7875,11 +8226,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
-"Li" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_east)
 "Ll" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
@@ -7887,24 +8233,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig/armoury)
-"Lm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark,
-/area/outpost/medbay)
 "Ln" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/outpost/arrivals/securitylz2)
-"Lo" = (
+"Lp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
 /obj/effect/landmark/weed_node,
-/turf/open/floor/plating/asteroidfloor,
-/area/outpost/yard/east)
+/turf/open/floor/tile/dark,
+/area/outpost/brig/wardens_office)
 "Lq" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 8
@@ -8058,6 +8400,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/central)
 "Me" = (
@@ -8201,6 +8544,10 @@
 	dir = 8
 	},
 /area/outpost/dormitories)
+"ME" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/outpost/cargo)
 "MF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark/yellow2{
@@ -8242,6 +8589,12 @@
 "MM" = (
 /turf/open/floor/plating/dmg1,
 /area/outpost/cargo/security)
+"MP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/south)
 "MR" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -8290,6 +8643,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/gear_room)
 "Na" = (
@@ -8336,6 +8690,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering/engine)
 "Np" = (
@@ -8411,6 +8766,10 @@
 	dir = 10
 	},
 /area/outpost/hallway/east)
+"NC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/west)
 "ND" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
@@ -8481,6 +8840,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/science/security)
 "NV" = (
@@ -8567,6 +8927,12 @@
 	dir = 5
 	},
 /area/outpost/engineering)
+"Ol" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/outpost/yard/central)
 "On" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
@@ -8620,6 +8986,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 8
 	},
@@ -8657,6 +9024,10 @@
 	dir = 8
 	},
 /area/outpost/hallway/south_cent)
+"OF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/caves/south)
 "OH" = (
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/arrivals)
@@ -8702,6 +9073,12 @@
 "OR" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/north)
+"OS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/arrivals)
 "OT" = (
 /turf/closed/mineral/smooth/bigred,
 /area/outpost/yard/east)
@@ -8813,6 +9190,10 @@
 	dir = 1
 	},
 /area/outpost/medbay)
+"Pw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/outpost/engineering/engine)
 "Px" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -8841,8 +9222,15 @@
 /area/outpost/cargo/engineering)
 "PC" = (
 /obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
+"PE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 8
+	},
+/area/outpost/yard/north)
 "PJ" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -8882,6 +9270,13 @@
 	dir = 8
 	},
 /area/outpost/lz1)
+"PS" = (
+/obj/effect/decal/cleanable/blood/writing{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_east)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -8915,6 +9310,12 @@
 	dir = 8
 	},
 /area/outpost/arrivals)
+"PZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/yard/east)
 "Qb" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 6
@@ -9070,6 +9471,14 @@
 	dir = 8
 	},
 /area/outpost/yard/central)
+"QF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/science/hydponics)
 "QG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9118,6 +9527,14 @@
 	dir = 8
 	},
 /area/outpost/lz2)
+"QX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/engineering)
 "QY" = (
 /turf/closed/wall/r_wall,
 /area/outpost/cargo)
@@ -9303,6 +9720,11 @@
 	dir = 8
 	},
 /area/outpost/lz2)
+"RG" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2,
+/area/outpost/brig)
 "RH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -9399,6 +9821,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals)
 "Sh" = (
@@ -9467,6 +9890,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
 	},
@@ -9480,6 +9904,7 @@
 "Ss" = (
 /obj/structure/bed/chair/office/dark,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
 "St" = (
@@ -9496,6 +9921,7 @@
 /area/outpost/caves/north)
 "Sv" = (
 /obj/item/trash/barcaridine,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/outpost/dormitories)
 "Sw" = (
@@ -9504,6 +9930,7 @@
 "Sx" = (
 /obj/structure/bed/chair,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/security)
 "Sy" = (
@@ -9516,11 +9943,22 @@
 "SB" = (
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/west)
+"SD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/science/hydponics)
+"SG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/outpost/cargo)
 "SJ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
 	},
@@ -9542,14 +9980,11 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
 	},
 /area/outpost/science/xenobiology)
-"SQ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/asteroidfloor,
-/area/outpost/yard/central)
 "SR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/asteroidwarning{
@@ -9637,6 +10072,10 @@
 	dir = 6
 	},
 /area/outpost/cargo/office)
+"Th" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/arrivals/securitylz2)
 "Ti" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/tile/dark,
@@ -9655,10 +10094,6 @@
 /obj/item/clothing/shoes/galoshes,
 /turf/open/floor/wood,
 /area/outpost/dormitories)
-"Tm" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2,
-/area/outpost/cargo/engineering)
 "To" = (
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
@@ -9669,16 +10104,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
-"Tq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/green/hidden{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 1
-	},
-/area/outpost/arrivals)
 "Tr" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -9745,6 +10170,25 @@
 	dir = 10
 	},
 /area/outpost/engineering)
+"TH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/purple2{
+	dir = 8
+	},
+/area/outpost/science)
+"TI" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/arrivals)
 "TJ" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 1
@@ -9766,6 +10210,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals)
 "TN" = (
@@ -9980,6 +10425,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner{
 	dir = 4
 	},
@@ -10007,6 +10453,7 @@
 "UP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
 	},
@@ -10078,9 +10525,27 @@
 	dir = 6
 	},
 /area/outpost/caves/north)
+"Vi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/outpost/caves/north)
 "Vj" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/lz1)
+"Vk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/outpost/brig)
 "Vl" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -10241,6 +10706,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/yellow2,
 /area/outpost/engineering/hallway)
+"VX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/outpost/science)
 "VY" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -10268,6 +10741,15 @@
 	dir = 4
 	},
 /area/outpost/science/research)
+"We" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/dormitories)
 "Wf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -10341,6 +10823,12 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/north_east)
+"Wu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/outpost/hallway/west)
 "Ww" = (
 /obj/machinery/prop/computer/rdservercontrol,
 /turf/open/floor/tile/dark/purple2,
@@ -10370,6 +10858,15 @@
 	dir = 10
 	},
 /area/outpost/hallway/central)
+"WC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/outpost/hallway/south_cent)
 "WE" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/cavetodirt{
@@ -10390,6 +10887,7 @@
 	dir = 10
 	},
 /obj/item/trash/raisins,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
 "WL" = (
@@ -10414,6 +10912,10 @@
 	dir = 8
 	},
 /area/outpost/science/hydponics)
+"WP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north)
 "WR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -10546,6 +11048,11 @@
 	dir = 6
 	},
 /area/outpost/hallway/south_west)
+"Xy" = (
+/obj/effect/landmark/excavation_site_spawner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/outpost/cargo)
 "XA" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -10672,6 +11179,16 @@
 "XX" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/west)
+"XY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/outpost/hallway/south_west)
 "XZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
@@ -10710,12 +11227,6 @@
 	dir = 6
 	},
 /area/outpost/cargo)
-"Yk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark/brown2{
-	dir = 1
-	},
-/area/outpost/hallway/south_cent)
 "Yl" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
@@ -10725,6 +11236,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_west)
+"Yo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/north)
 "Yp" = (
 /obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning,
@@ -10836,6 +11351,10 @@
 	dir = 10
 	},
 /area/outpost/dormitories)
+"YK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/yard/north)
 "YL" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/red2{
@@ -10848,14 +11367,6 @@
 	dir = 4
 	},
 /area/outpost/yard/central)
-"YQ" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/decal/cleanable/blood/writing{
-	dir = 9
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_east)
 "YR" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
@@ -10907,6 +11418,10 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
+/area/outpost/yard/south)
+"Zh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/yard/south)
 "Zj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -11034,6 +11549,12 @@
 "ZG" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/outpost/lz2)
+"ZH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
+/area/outpost/caves/north_east)
 "ZI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -14613,17 +15134,17 @@ nO
 AL
 dn
 EB
-EB
+nT
 Nu
 Hg
 jW
 yA
-zh
+if
 su
 nR
 XX
 XX
-XX
+kj
 Cs
 yW
 yW
@@ -14670,7 +15191,7 @@ Cc
 yW
 ho
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -14873,7 +15394,7 @@ yW
 yW
 yW
 cB
-cB
+jn
 cB
 IU
 IU
@@ -15276,7 +15797,7 @@ yP
 yh
 Ef
 Og
-Tq
+gv
 Yz
 NO
 ln
@@ -15284,7 +15805,7 @@ Ii
 wA
 Pt
 zh
-zh
+if
 zh
 yW
 yW
@@ -15330,7 +15851,7 @@ Cc
 yW
 yW
 yW
-ho
+Uu
 ho
 yW
 yW
@@ -15532,7 +16053,7 @@ Cp
 Xc
 FZ
 FZ
-FZ
+hQ
 uw
 Cp
 IU
@@ -15676,7 +16197,7 @@ pH
 cJ
 KG
 hi
-hi
+TI
 oP
 IU
 EB
@@ -15800,7 +16321,7 @@ uK
 Cp
 Cp
 dw
-rJ
+bt
 yh
 NJ
 Ff
@@ -15816,7 +16337,7 @@ Wq
 wB
 EB
 EB
-EB
+nT
 EB
 Ez
 Hc
@@ -15858,7 +16379,7 @@ AW
 wE
 ho
 ho
-ho
+Uu
 ho
 ho
 ja
@@ -15913,13 +16434,13 @@ dW
 Cp
 Zj
 Cp
+KU
+Cp
+Cp
+Cp
+Cp
+ZX
 YH
-Cp
-Cp
-Cp
-Cp
-Cp
-KC
 Cp
 Cp
 Cp
@@ -15945,7 +16466,7 @@ OH
 Vt
 Zl
 Zl
-Zl
+il
 Mp
 Mp
 Mp
@@ -15988,9 +16509,9 @@ Hc
 VS
 AW
 wE
-ho
-ho
 Uu
+ho
+ho
 cz
 ho
 ja
@@ -16042,7 +16563,7 @@ Cp
 Cp
 Cp
 Cp
-Cp
+ZX
 Zj
 Cp
 Cp
@@ -16072,7 +16593,7 @@ VC
 Vt
 Vt
 Vt
-uG
+Vt
 OH
 IU
 yL
@@ -16121,7 +16642,7 @@ VS
 AW
 wE
 ho
-Uu
+ho
 ho
 ux
 ho
@@ -16171,7 +16692,7 @@ yW
 yW
 ja
 Cp
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -16193,7 +16714,7 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 IU
 nm
@@ -16201,10 +16722,10 @@ TM
 NJ
 Ff
 VC
-Vt
+uG
 Tz
 Vt
-Vt
+uG
 OH
 Xw
 Zl
@@ -16212,7 +16733,7 @@ Zl
 Zl
 wU
 wU
-wU
+OS
 wU
 jo
 sQ
@@ -16566,9 +17087,9 @@ yW
 yW
 Cp
 Cp
+ZX
 Cp
 Cp
-Cp
 yW
 yW
 yW
@@ -16578,7 +17099,7 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 Cp
 yW
@@ -16605,7 +17126,7 @@ IU
 IU
 Jb
 Jb
-Jb
+NC
 Jb
 Jb
 yW
@@ -16853,7 +17374,7 @@ yW
 yW
 yW
 yW
-FZ
+hQ
 FZ
 Ev
 Hh
@@ -16915,7 +17436,7 @@ yW
 yW
 ho
 ho
-ho
+Uu
 ho
 yW
 yW
@@ -16961,7 +17482,7 @@ yW
 yW
 Cp
 Cp
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -16969,7 +17490,7 @@ Cp
 yW
 yW
 vW
-FZ
+hQ
 FZ
 FZ
 yW
@@ -16977,27 +17498,27 @@ yW
 yW
 FZ
 FZ
-FZ
+hQ
 FZ
 TK
 sB
 IL
-Cp
+ZX
 Xc
 FZ
 TW
 rn
 Hh
-Hh
+Bm
 Hh
 Hh
 mG
-LI
+mE
 gc
 lf
 cc
 cc
-cc
+db
 cc
 cc
 cc
@@ -17097,7 +17618,7 @@ YH
 Cp
 Cp
 Cp
-Cp
+ZX
 Cp
 Cp
 YH
@@ -17266,7 +17787,7 @@ yW
 yW
 cc
 FK
-KZ
+ID
 KZ
 yW
 yW
@@ -17387,7 +17908,7 @@ kX
 oe
 Ah
 lZ
-lZ
+Wu
 Fh
 SB
 oI
@@ -17573,7 +18094,7 @@ yW
 Cc
 ho
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -17620,20 +18141,20 @@ yW
 yW
 yW
 Cp
-Cp
+ZX
 Cp
 yW
 yW
 yW
 yW
 Bv
-FZ
+hQ
 FZ
 FZ
 yW
 bY
 Ua
-UL
+vL
 AX
 XG
 bq
@@ -17645,7 +18166,7 @@ US
 Iz
 kc
 VE
-To
+BV
 Dt
 nx
 To
@@ -17781,7 +18302,7 @@ Wh
 To
 kq
 oe
-QH
+sU
 kb
 oI
 yW
@@ -17793,7 +18314,7 @@ yW
 yW
 yW
 cc
-cc
+db
 yr
 mx
 yW
@@ -18038,7 +18559,7 @@ Ot
 qh
 UQ
 ON
-To
+BV
 ON
 To
 tE
@@ -18072,11 +18593,11 @@ yW
 yW
 LC
 LC
-gW
+SG
 WV
 WV
 yJ
-tl
+ME
 LC
 LC
 yW
@@ -18087,7 +18608,7 @@ yW
 LC
 LC
 LC
-LC
+dE
 LC
 LC
 yW
@@ -18150,7 +18671,7 @@ yW
 yW
 yW
 YH
-Cp
+ZX
 Cp
 Cp
 Cp
@@ -18192,7 +18713,7 @@ ij
 ij
 ij
 ij
-YR
+Ol
 EA
 EA
 yW
@@ -18217,7 +18738,7 @@ QY
 QY
 QY
 LC
-GE
+mw
 GE
 QY
 QY
@@ -18232,7 +18753,7 @@ yW
 yW
 yW
 ho
-ho
+Uu
 ho
 ho
 yW
@@ -18285,16 +18806,16 @@ Cp
 Cp
 Cp
 Cp
-Cp
+ZX
 Cp
 Xc
-rn
+sI
 AL
 AL
 bY
 Ru
 nv
-UL
+vL
 cV
 bq
 kS
@@ -18320,7 +18841,7 @@ ij
 ij
 YR
 EA
-EA
+HO
 EA
 EA
 UJ
@@ -18434,7 +18955,7 @@ td
 Gv
 Ks
 Zs
-Us
+BX
 LR
 gx
 Yd
@@ -18449,7 +18970,7 @@ SB
 oI
 EA
 EA
-EA
+HO
 EA
 EA
 EA
@@ -18476,7 +18997,7 @@ Jc
 CF
 vB
 tY
-Jc
+HQ
 Oo
 em
 xD
@@ -18586,39 +19107,39 @@ EA
 EA
 EA
 EA
-EA
+HO
 PW
 EA
 EA
 EA
-EA
+HO
 Xl
 yW
 yW
 yW
 QY
 IG
-Tw
+Hb
 hZ
 Jc
-Jc
+HQ
 Jc
 pw
-Jc
+HQ
 pf
 jx
 oV
 Jc
 iU
 Mg
-Jc
+HQ
 zC
 jx
 SU
-Jc
+HQ
 zC
 Yi
-oy
+lF
 QY
 yW
 yW
@@ -18708,12 +19229,12 @@ Uj
 Re
 eX
 Zd
-FA
+qV
 SB
 fz
 QE
 QE
-Ui
+QE
 QE
 QE
 QE
@@ -18831,7 +19352,7 @@ Cl
 Ys
 To
 To
-To
+BV
 nx
 ly
 Oj
@@ -18872,7 +19393,7 @@ Xj
 CF
 rK
 tY
-Jc
+HQ
 jY
 tY
 Jc
@@ -18889,10 +19410,10 @@ yW
 yW
 yW
 ho
+Uu
 ho
 ho
-ho
-ho
+Uu
 ho
 ho
 yW
@@ -18948,13 +19469,13 @@ yW
 yW
 yW
 OR
-OR
+WP
 QZ
 IY
 ZP
 jR
 to
-HW
+Hl
 HW
 Qe
 Iv
@@ -18977,7 +19498,7 @@ aA
 oI
 EA
 EA
-EA
+HO
 EA
 EA
 EA
@@ -19000,14 +19521,14 @@ Jc
 Jc
 yu
 pw
-Xj
+JB
 zC
 jx
 Aa
 Jc
 og
 EP
-Jc
+HQ
 Tw
 jx
 Yi
@@ -19091,7 +19612,7 @@ tr
 YU
 MH
 To
-Lm
+Rf
 TR
 kl
 cO
@@ -19104,7 +19625,7 @@ eX
 Ah
 lb
 Ro
-qV
+FA
 SB
 oI
 yW
@@ -19116,7 +19637,7 @@ EA
 FH
 sY
 EA
-EA
+HO
 EA
 EA
 EA
@@ -19244,7 +19765,7 @@ yW
 ai
 RD
 EA
-EA
+HO
 FH
 bP
 QE
@@ -19253,15 +19774,15 @@ QE
 QE
 QE
 QE
-QE
+Ui
 QE
 QE
 pa
 IG
+HQ
 Jc
 Jc
-Jc
-Mt
+Xy
 Jc
 eb
 Jc
@@ -19275,10 +19796,10 @@ Jc
 Xd
 rK
 bg
-Jc
+HQ
 GQ
 VI
-oy
+lF
 QY
 hK
 hK
@@ -19342,7 +19863,7 @@ ja
 ja
 OR
 PK
-uU
+Su
 uU
 uU
 yW
@@ -19354,7 +19875,7 @@ Hw
 Dq
 tr
 kP
-To
+BV
 Tj
 nx
 oe
@@ -19382,7 +19903,7 @@ Nm
 Nm
 Nm
 Nm
-BU
+Nm
 Nm
 Nm
 bP
@@ -19396,14 +19917,14 @@ Jc
 pw
 pw
 Xs
-Jc
+HQ
 pf
 Qj
 AK
-Jc
+HQ
 Tw
 OL
-Jc
+HQ
 zC
 Qj
 Zk
@@ -19414,7 +19935,7 @@ oy
 QY
 hK
 hK
-hK
+IH
 hK
 hK
 hK
@@ -19474,7 +19995,7 @@ yW
 Az
 iH
 uU
-Su
+uU
 uU
 yW
 yW
@@ -19511,7 +20032,7 @@ EA
 EA
 EA
 EA
-EA
+HO
 EA
 EA
 EA
@@ -19551,7 +20072,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 hK
 yW
@@ -19646,7 +20167,7 @@ EA
 EA
 EA
 EA
-EA
+HO
 EA
 EA
 FH
@@ -19804,10 +20325,10 @@ Cy
 Cy
 my
 Mr
-wM
+MP
 hK
 hK
-hK
+IH
 hK
 hK
 hK
@@ -19891,7 +20412,7 @@ yW
 ww
 ww
 LH
-TY
+zb
 yU
 Ap
 HJ
@@ -19904,7 +20425,7 @@ ww
 yW
 yW
 ai
-ai
+rN
 ai
 yW
 yW
@@ -19913,7 +20434,7 @@ ai
 RD
 EA
 EA
-FH
+uc
 sY
 cU
 ku
@@ -20065,7 +20586,7 @@ yW
 yW
 yW
 tm
-tm
+yX
 Mr
 Mr
 yW
@@ -20074,7 +20595,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 yW
 yW
 yW
@@ -20139,7 +20660,7 @@ uU
 uU
 uU
 Vh
-OR
+WP
 OR
 yW
 yW
@@ -20267,8 +20788,8 @@ ja
 yW
 yW
 uU
-Su
 uU
+Su
 Rp
 OR
 OR
@@ -20278,7 +20799,7 @@ IY
 yW
 yW
 oJ
-dq
+De
 mP
 oJ
 oJ
@@ -20444,7 +20965,7 @@ RS
 RS
 mt
 RS
-RS
+hu
 eo
 RS
 yG
@@ -20459,7 +20980,7 @@ mg
 Mr
 yW
 hK
-lY
+BI
 Mr
 yW
 yW
@@ -20525,7 +21046,7 @@ ja
 yW
 uU
 uU
-Su
+uU
 uU
 ja
 yW
@@ -20535,10 +21056,10 @@ uU
 uU
 yW
 OR
-OR
+WP
 OR
 QZ
-IY
+nt
 IY
 Mv
 Dg
@@ -20550,7 +21071,7 @@ tv
 rf
 PU
 TO
-qs
+fB
 gM
 ww
 yW
@@ -20564,7 +21085,7 @@ Tb
 PU
 Qu
 cy
-cy
+Ca
 Gl
 Jt
 Ke
@@ -20575,19 +21096,19 @@ DA
 iN
 xl
 xl
-dx
+xl
 xl
 MV
 xl
 Pu
 xl
-MV
+XY
 xl
 Xx
 Ke
 yW
 Mr
-Mr
+CS
 mg
 wM
 hK
@@ -20657,7 +21178,7 @@ ja
 yW
 yW
 uU
-uU
+Su
 uU
 wk
 yW
@@ -20703,7 +21224,7 @@ Ke
 Ke
 Ke
 Ke
-aP
+GR
 Yn
 Ke
 pe
@@ -20791,7 +21312,7 @@ yW
 yW
 fV
 uU
-FQ
+wk
 uU
 uU
 fV
@@ -20925,7 +21446,7 @@ yW
 uU
 wk
 uU
-uU
+Su
 uU
 yW
 yW
@@ -20941,7 +21462,7 @@ oJ
 oJ
 oJ
 yq
-mP
+qU
 oJ
 yW
 ww
@@ -20963,7 +21484,7 @@ ai
 pe
 dN
 cy
-cy
+Ca
 Wb
 zD
 zD
@@ -20971,10 +21492,10 @@ zD
 Ki
 pe
 wa
-uJ
+ej
 kn
 jF
-kN
+qf
 Mb
 mN
 BQ
@@ -20987,7 +21508,7 @@ yW
 yW
 yW
 Mr
-wM
+MP
 hK
 yW
 yW
@@ -21084,12 +21605,12 @@ TF
 PU
 PU
 mK
-PU
+mD
 oR
 ZC
 ww
 ww
-ij
+hX
 ij
 ij
 Ke
@@ -21110,7 +21631,7 @@ Np
 rA
 mN
 BQ
-Yk
+wb
 ic
 xm
 Ip
@@ -21129,7 +21650,7 @@ yW
 yW
 yW
 hK
-hK
+IH
 hK
 hK
 hK
@@ -21324,7 +21845,7 @@ yW
 yW
 oc
 OR
-OR
+WP
 fe
 yW
 yW
@@ -21333,8 +21854,8 @@ yW
 yW
 yW
 oJ
-ks
-mP
+ML
+qU
 oJ
 oJ
 oJ
@@ -21365,7 +21886,7 @@ Yn
 On
 jF
 jF
-jF
+fg
 jF
 jF
 kN
@@ -21384,7 +21905,7 @@ yW
 yW
 yW
 hK
-hK
+IH
 hK
 yW
 yW
@@ -21395,7 +21916,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 yW
 yW
@@ -21488,7 +22009,7 @@ oM
 yO
 Of
 XI
-Of
+KI
 Of
 Of
 Bg
@@ -21501,7 +22022,7 @@ Np
 Np
 Np
 Hs
-Mb
+hD
 mN
 ES
 yW
@@ -21641,7 +22162,7 @@ yW
 yW
 Ip
 Ip
-kQ
+WC
 MB
 Ip
 Cy
@@ -21655,7 +22176,7 @@ yW
 yW
 wQ
 hK
-hK
+IH
 hK
 wQ
 yW
@@ -21726,7 +22247,7 @@ uU
 uU
 yW
 OW
-bR
+Vi
 IY
 oJ
 ML
@@ -21748,7 +22269,7 @@ Gy
 Oh
 EA
 EA
-oM
+sH
 CY
 EA
 fG
@@ -21854,7 +22375,7 @@ yW
 yW
 yW
 uU
-uU
+Su
 uU
 Co
 OR
@@ -21906,14 +22427,14 @@ yW
 yW
 Ip
 RB
-cK
+mZ
 KD
 Cy
-Cy
+OF
 Cy
 my
 mg
-Mr
+CS
 Uv
 yW
 ff
@@ -21999,32 +22520,32 @@ tb
 nh
 KB
 wZ
-Ug
+YK
 Ug
 GB
 Uw
 Uw
-Uw
+PE
 Uw
 ew
 uO
 Gy
 ew
 Fc
-By
+Fc
 bP
 iQ
 EA
 fG
 HT
-HT
+tL
 HT
 fG
 dY
 Eu
 fG
 ZK
-ZK
+zz
 ZK
 fG
 mN
@@ -22152,7 +22673,7 @@ QI
 HT
 uu
 fG
-Fu
+We
 aG
 fG
 fs
@@ -22161,7 +22682,7 @@ Iy
 fG
 mN
 wj
-Mb
+hD
 mN
 ES
 yW
@@ -22251,7 +22772,7 @@ yW
 XD
 uU
 uU
-uU
+Su
 uU
 yW
 yW
@@ -22272,7 +22793,7 @@ LJ
 LJ
 aN
 jG
-Gy
+pu
 aN
 EA
 EA
@@ -22311,7 +22832,7 @@ Mr
 Mr
 wM
 hK
-IH
+hK
 hK
 hK
 yW
@@ -22396,10 +22917,10 @@ le
 kL
 vV
 LJ
-LJ
+Yo
 pQ
 Qh
-LJ
+Yo
 LJ
 Ra
 Oh
@@ -22408,7 +22929,7 @@ Gy
 aN
 yW
 EA
-oM
+sH
 IM
 Fc
 jZ
@@ -22439,7 +22960,7 @@ Ip
 yW
 yW
 Mr
-Mr
+CS
 dh
 hK
 wQ
@@ -22512,7 +23033,7 @@ yW
 yW
 uU
 HU
-uU
+Su
 uU
 uU
 uU
@@ -22530,7 +23051,7 @@ vV
 LJ
 LJ
 pQ
-xd
+Qh
 LJ
 Ra
 ED
@@ -22546,12 +23067,12 @@ Of
 tK
 ZD
 ki
-ki
+oG
 ki
 Gf
 bz
 ki
-ki
+oG
 ki
 rP
 tK
@@ -22560,7 +23081,7 @@ Np
 rA
 mN
 ES
-wa
+Zh
 BQ
 FX
 Ep
@@ -22575,19 +23096,19 @@ Mr
 wM
 hK
 hK
+IH
 hK
+hK
+yW
+yW
+yW
+yW
+yW
+yW
+yW
 hK
 IH
-yW
-yW
-yW
-yW
-yW
-yW
-yW
 hK
-hK
-IH
 yW
 yW
 yW
@@ -22667,7 +23188,7 @@ LJ
 Kh
 ED
 Oh
-jG
+wv
 Ia
 aN
 yW
@@ -22795,7 +23316,7 @@ KL
 vV
 pQ
 Qh
-LJ
+Yo
 Kh
 ED
 Oh
@@ -22821,7 +23342,7 @@ xi
 fG
 mN
 mN
-mN
+sC
 ep
 wa
 wa
@@ -22920,8 +23441,8 @@ ua
 iD
 bL
 FI
-JE
-ry
+bD
+VX
 bD
 bC
 vV
@@ -22941,14 +23462,14 @@ yW
 yW
 fG
 HT
-HT
+tL
 HT
 fG
-dY
+wh
 Eu
 fG
 HT
-HT
+tL
 HT
 fG
 ch
@@ -22970,7 +23491,7 @@ yW
 yW
 yW
 hK
-hK
+IH
 hK
 wy
 Sl
@@ -23039,7 +23560,7 @@ iY
 fc
 Je
 Dv
-ng
+Rl
 mA
 aO
 Je
@@ -23209,7 +23730,7 @@ fG
 fG
 fG
 Fu
-BD
+aG
 fG
 fG
 fG
@@ -23222,7 +23743,7 @@ CR
 mJ
 qS
 Zf
-LZ
+mu
 cb
 pV
 yT
@@ -23239,12 +23760,12 @@ cm
 Mr
 mg
 Mr
-Mr
+CS
 Mr
 wM
 hK
 wQ
-hK
+IH
 wQ
 yW
 yW
@@ -23299,7 +23820,7 @@ Rl
 ro
 Dv
 Rl
-Rl
+ng
 id
 Je
 Je
@@ -23364,7 +23885,7 @@ gU
 ND
 Nx
 Cy
-Cy
+OF
 Cy
 Nx
 vy
@@ -23375,7 +23896,7 @@ Mr
 Uv
 hK
 hK
-IH
+hK
 hK
 hK
 yW
@@ -23440,7 +23961,7 @@ LE
 Jn
 VK
 oo
-Rv
+TH
 wc
 wc
 wc
@@ -23463,19 +23984,19 @@ MA
 YY
 bS
 gd
-vC
 yb
+vC
 yb
 iL
 tK
 iS
 ki
-ki
+oG
 ki
 Gf
 sA
 ki
-ki
+oG
 ki
 rP
 tK
@@ -23563,7 +24084,7 @@ Rl
 ro
 Dv
 lO
-ng
+Rl
 uY
 ll
 BW
@@ -23574,8 +24095,8 @@ yn
 Zr
 tu
 Uo
-ra
 Uo
+ra
 Gx
 Oe
 sg
@@ -23618,12 +24139,12 @@ CR
 mJ
 Ex
 UR
-LZ
+mu
 LZ
 Jv
 tQ
 Vd
-Ky
+aI
 VW
 Vd
 Vd
@@ -23695,7 +24216,7 @@ Rl
 ro
 cC
 zT
-Rl
+ng
 nn
 Je
 Je
@@ -23771,7 +24292,7 @@ yW
 yW
 hK
 hK
-hK
+IH
 yW
 yW
 yW
@@ -23865,14 +24386,14 @@ YR
 EA
 fG
 HT
-HT
+tL
 HT
 fG
-dY
+wh
 vn
 fG
 HT
-HT
+tL
 HT
 fG
 NF
@@ -23890,10 +24411,10 @@ Vd
 MF
 pA
 yV
-yK
-yK
-yK
 qT
+yK
+yK
+yK
 yK
 UK
 IK
@@ -23978,21 +24499,21 @@ zZ
 Vx
 qw
 vK
-an
+Ti
 nS
 kH
 Eo
 aM
-pv
+jV
 pv
 wt
 ye
-ZT
+Vk
 yS
 ye
 ij
 lK
-YR
+Ol
 EA
 EA
 fG
@@ -24009,7 +24530,7 @@ Tl
 fG
 NF
 NF
-NF
+qZ
 Xf
 NF
 NF
@@ -24100,11 +24621,11 @@ se
 zB
 Dz
 Mf
-sX
+SD
 Qp
-sX
+SD
 Qp
-bM
+QF
 go
 zZ
 Rk
@@ -24146,7 +24667,7 @@ NF
 NF
 NF
 NF
-oK
+ad
 VN
 BJ
 yW
@@ -24235,7 +24756,7 @@ Pe
 hw
 hw
 hw
-wl
+hw
 Rh
 ft
 zZ
@@ -24262,12 +24783,12 @@ TL
 jZ
 so
 Lx
-Lx
+yM
 Lx
 xc
 eP
 Lx
-Lx
+yM
 Lx
 rC
 jZ
@@ -24356,7 +24877,7 @@ yW
 yW
 NR
 Yx
-Yx
+Lf
 Yx
 Yx
 NR
@@ -24380,7 +24901,7 @@ zZ
 jO
 uM
 uM
-nr
+uM
 uM
 om
 tz
@@ -24389,7 +24910,7 @@ om
 Nm
 Nm
 Nm
-SQ
+bP
 bP
 tK
 ZD
@@ -24419,7 +24940,7 @@ yW
 yW
 yW
 eu
-Wg
+zY
 Mr
 yW
 Sw
@@ -24431,7 +24952,7 @@ Qs
 gY
 XB
 Sw
-EX
+sW
 eK
 eK
 DX
@@ -24486,7 +25007,7 @@ yW
 yW
 yW
 se
-fP
+Wo
 Yx
 Yx
 yW
@@ -24511,16 +25032,16 @@ zZ
 zZ
 Dr
 pv
-pv
+jV
 jg
 pv
 ye
 tz
-tx
+RG
 ye
 EA
 EA
-EA
+HO
 FH
 sY
 fG
@@ -24528,7 +25049,7 @@ fG
 MC
 fG
 fG
-Lv
+Rt
 aG
 fG
 fG
@@ -24559,7 +25080,7 @@ KO
 WK
 rr
 Uh
-rr
+QX
 dZ
 ek
 Sw
@@ -24617,7 +25138,7 @@ yW
 yW
 yW
 WN
-se
+lH
 se
 Wo
 yW
@@ -24636,7 +25157,7 @@ yW
 yW
 yW
 MR
-se
+lH
 XE
 se
 se
@@ -24660,7 +25181,7 @@ vd
 HT
 dc
 fG
-Rt
+Lv
 aG
 fG
 An
@@ -24668,8 +25189,8 @@ HT
 TT
 fG
 yW
-qZ
 NF
+qZ
 NF
 oK
 VN
@@ -24678,7 +25199,7 @@ Nv
 BJ
 BJ
 my
-Mr
+CS
 WE
 hK
 hK
@@ -24770,7 +25291,7 @@ rB
 wu
 jL
 js
-cZ
+dp
 dp
 BH
 Fa
@@ -24789,7 +25310,7 @@ FH
 sY
 fG
 Zy
-HT
+tL
 HT
 fG
 wC
@@ -24806,7 +25327,7 @@ NF
 oK
 VN
 BJ
-BJ
+bv
 JO
 yW
 yW
@@ -24833,17 +25354,17 @@ DX
 DX
 MG
 MG
-wz
+JX
 MG
 AC
 MU
 MG
-MG
+Pw
 wz
 MG
 DX
 MG
-MG
+Pw
 MG
 MG
 DX
@@ -24917,7 +25438,7 @@ ye
 ye
 ye
 ye
-FH
+uc
 sY
 fG
 VJ
@@ -24947,7 +25468,7 @@ hK
 ff
 hK
 hK
-IH
+hK
 hK
 hK
 IV
@@ -25079,7 +25600,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 hK
 Zt
@@ -25105,7 +25626,7 @@ MG
 CU
 RC
 wz
-wz
+JX
 wz
 hf
 CU
@@ -25167,7 +25688,7 @@ yW
 yW
 lp
 Bd
-cp
+lQ
 cp
 oH
 lp
@@ -25175,7 +25696,7 @@ nj
 Ss
 zE
 yY
-uh
+uq
 FF
 re
 BN
@@ -25206,7 +25727,7 @@ BJ
 BJ
 Zp
 LS
-hK
+IH
 hK
 hK
 hK
@@ -25236,7 +25757,7 @@ MU
 MG
 CU
 MG
-ei
+oh
 xx
 Ij
 MG
@@ -25286,7 +25807,7 @@ Yx
 Yx
 Yx
 Yx
-Yx
+Lf
 Yx
 yW
 yW
@@ -25321,7 +25842,7 @@ yW
 yW
 RD
 FH
-Bq
+dX
 EA
 HS
 yW
@@ -25333,7 +25854,7 @@ yW
 yW
 oK
 VN
-BJ
+bv
 BJ
 BJ
 Zp
@@ -25361,17 +25882,17 @@ DX
 DX
 Dh
 MG
-MG
+Pw
 Vl
 MG
 MU
 MG
-MG
+Pw
 MG
 MG
 DX
 MG
-MG
+Pw
 MG
 MG
 DX
@@ -25416,7 +25937,7 @@ Yx
 tF
 Yx
 Yx
-Lf
+Yx
 Yx
 Yx
 Yx
@@ -25557,18 +26078,18 @@ yW
 yW
 yW
 yW
-Lq
-Lf
+PS
+Yx
 yW
 yW
 lp
 iz
-cp
+lQ
 vt
 dJ
 lp
 op
-OK
+Lp
 FG
 yY
 tz
@@ -25721,11 +26242,11 @@ Ar
 Nm
 xB
 YN
-Nm
+BU
 Nm
 np
 np
-HP
+wV
 HP
 wf
 BC
@@ -25739,7 +26260,7 @@ yW
 yW
 hK
 hK
-hK
+IH
 Wg
 Mr
 KM
@@ -25752,7 +26273,7 @@ lA
 kK
 Sw
 JM
-tm
+yX
 tm
 DX
 DX
@@ -25816,7 +26337,7 @@ zJ
 ja
 se
 Ud
-Yx
+Lf
 Yx
 Yx
 yW
@@ -25836,7 +26357,7 @@ hd
 yY
 ee
 QD
-tx
+RG
 XP
 EK
 ck
@@ -25849,7 +26370,7 @@ yW
 yW
 yW
 mH
-Cq
+sk
 sN
 sN
 sN
@@ -25861,10 +26382,10 @@ XV
 ZS
 yW
 yW
-GY
+dB
 GY
 yW
-sN
+mo
 sN
 yW
 py
@@ -25952,7 +26473,7 @@ Yx
 Yx
 Yx
 Yx
-rR
+gE
 dk
 Yx
 Yx
@@ -26019,10 +26540,10 @@ Vc
 eu
 hK
 hK
+uo
+hK
+hK
 wQ
-hK
-hK
-jN
 hK
 yW
 yW
@@ -26083,7 +26604,7 @@ ja
 ja
 Yx
 Yx
-gE
+qy
 dk
 Yx
 Yx
@@ -26107,7 +26628,7 @@ Bx
 ye
 mH
 sK
-sN
+mo
 sN
 Vb
 py
@@ -26132,7 +26653,7 @@ sN
 sN
 dz
 py
-py
+lB
 py
 wM
 hK
@@ -26154,7 +26675,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 yW
 yW
@@ -26213,7 +26734,7 @@ BR
 pJ
 Yx
 ct
-YQ
+rB
 KA
 nw
 Yx
@@ -26244,7 +26765,7 @@ Kw
 Kw
 Kw
 OO
-Pp
+aR
 Xp
 sN
 sN
@@ -26278,7 +26799,7 @@ hK
 eu
 Wy
 hK
-hK
+IH
 iF
 yW
 yW
@@ -26333,7 +26854,7 @@ yW
 yW
 ja
 zJ
-Yx
+Lf
 zJ
 BR
 BR
@@ -26341,7 +26862,7 @@ Hn
 Vy
 xp
 er
-er
+sn
 mF
 KA
 lT
@@ -26380,12 +26901,12 @@ HL
 sN
 sN
 sN
-sN
+mo
 Xp
 sN
 sN
 sN
-XV
+Av
 uV
 sN
 yW
@@ -26394,12 +26915,12 @@ yW
 sN
 sN
 sN
-sN
+mo
 sN
 sN
 dz
 LS
-hK
+IH
 hK
 hK
 hK
@@ -26477,7 +26998,7 @@ Yx
 zJ
 yW
 ct
-Yx
+Lf
 yW
 yW
 yW
@@ -26488,11 +27009,11 @@ yW
 Rs
 TQ
 eO
-UV
+DY
 fv
 Rs
 XO
-UV
+DY
 RJ
 Rs
 gb
@@ -26503,7 +27024,7 @@ ye
 ye
 mH
 sK
-py
+lB
 HR
 sN
 sN
@@ -26605,7 +27126,7 @@ BR
 Fw
 BR
 Yx
-zJ
+Yx
 zJ
 yW
 ct
@@ -26632,8 +27153,8 @@ sc
 we
 Kw
 tZ
-Kw
-Lo
+Jr
+OO
 hq
 py
 HR
@@ -26656,7 +27177,7 @@ sN
 sN
 sN
 sN
-sN
+mo
 sN
 sN
 yW
@@ -26667,13 +27188,13 @@ Aq
 Aq
 ys
 ys
-IH
-hK
 hK
 IH
 hK
 hK
-IH
+hK
+hK
+hK
 hK
 iF
 hK
@@ -26683,7 +27204,7 @@ hK
 hK
 hK
 hK
-hK
+IH
 hK
 yW
 yW
@@ -26738,7 +27259,7 @@ RM
 BR
 Yx
 zJ
-Yx
+zJ
 yW
 ct
 Yx
@@ -26771,7 +27292,7 @@ py
 HR
 sN
 sN
-mH
+PZ
 Pp
 zQ
 Ln
@@ -26784,7 +27305,7 @@ zQ
 XV
 ZS
 sN
-sN
+mo
 sN
 sN
 sN
@@ -26796,7 +27317,7 @@ ys
 Sn
 Cf
 dD
-Lz
+vi
 jp
 ys
 bA
@@ -26873,7 +27394,7 @@ zJ
 yW
 yW
 ct
-Lf
+Yx
 Yx
 yW
 yW
@@ -26907,10 +27428,10 @@ mH
 Pp
 dL
 bx
-Xr
+Th
 KQ
 ea
-If
+bT
 tA
 dL
 XV
@@ -26926,7 +27447,7 @@ yW
 yW
 ys
 iI
-Zm
+rQ
 dD
 nV
 uX
@@ -26935,15 +27456,15 @@ ys
 ZQ
 IZ
 ys
-Pn
-eH
+Hm
+ug
 Hm
 Hm
 ef
 Hm
 Hm
 Hm
-eH
+ug
 Hm
 Hm
 Hm
@@ -27045,19 +27566,19 @@ Qc
 If
 un
 zQ
-XV
+Av
 ZS
 sN
 sN
 sN
 sN
-sN
+mo
 sN
 sN
 sN
 uT
 gf
-gA
+Sy
 gA
 Kt
 Kt
@@ -27127,7 +27648,7 @@ yW
 yW
 ja
 zJ
-Yx
+Lf
 zJ
 BR
 BR
@@ -27137,7 +27658,7 @@ pJ
 Yx
 Yx
 YE
-ZB
+ZH
 Yx
 Yx
 Yx
@@ -27190,17 +27711,17 @@ oq
 uT
 gA
 gA
-Tm
+lg
 HV
-Sy
 gA
+Sy
 wP
 Kt
 ZL
 lg
 ys
 Hm
-Pn
+Hm
 Hm
 yW
 yW
@@ -27312,7 +27833,7 @@ dL
 oX
 Bn
 Bn
-Bn
+eA
 Bn
 Bn
 Bn
@@ -27430,7 +27951,7 @@ yW
 yW
 sN
 sN
-sN
+mo
 mH
 Pp
 sN
@@ -27454,7 +27975,7 @@ ZS
 sN
 ys
 Mw
-rQ
+Zm
 iq
 Ta
 Gi
@@ -27528,7 +28049,7 @@ zJ
 zJ
 zJ
 Yx
-Yx
+Lf
 Yx
 Yx
 Yx
@@ -27565,23 +28086,23 @@ sN
 sN
 mH
 HL
+mo
+sN
+yW
+yW
+yW
+yW
+yW
+yW
+yW
+yW
+yW
+yW
+yW
+yW
 sN
 sN
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-yW
-sN
-sN
-XV
+Av
 ZS
 HD
 ys
@@ -27661,7 +28182,7 @@ ja
 ja
 ct
 ct
-Li
+ct
 ct
 ct
 ct
@@ -27956,7 +28477,7 @@ yW
 yW
 yW
 yW
-HR
+qG
 VY
 hY
 zI
@@ -28125,8 +28646,8 @@ yW
 yW
 yW
 Hm
-Hm
 Pn
+Hm
 Hm
 yW
 yW
@@ -28783,7 +29304,7 @@ yW
 yW
 yW
 Hm
-Hm
+Pn
 Hm
 yW
 yW
@@ -29047,7 +29568,7 @@ yW
 ja
 eH
 Hm
-Pn
+Hm
 eH
 My
 gw
@@ -29312,7 +29833,7 @@ Ht
 eH
 Pn
 Hm
-Pn
+Hm
 My
 gw
 gw
@@ -29439,7 +29960,7 @@ io
 Dk
 TD
 Hm
-Hm
+Pn
 Ht
 Hm
 Hm
@@ -29838,7 +30359,7 @@ yW
 yW
 Hm
 Hm
-Hm
+Pn
 Hm
 Hm
 Eg
@@ -30233,7 +30754,7 @@ Vg
 yW
 Hm
 Hm
-Hm
+Pn
 Hm
 Hm
 Eg


### PR DESCRIPTION
## About The Pull Request
Added more weed node spawners to cover the entirety of Research Outpost. The current preweed is very sparse.
Replaced a missing cable underneath one of the Research Outpost geothermal generators.
Slightly shifted a couple of resin walls in the NE corner of Research Outpost to fill a 1x1 gap.
## Why It's Good For The Game
Less painful xeno prep and small fixes.
## Changelog
:cl:
balance: Research Outpost starts fully covered in weeds.
fix: Replaced a missing cable underneath one of the Research Outpost geothermal generators.
fix: Slightly shifted a couple of resin walls in the NE corner of Research Outpost to fill a 1x1 gap.
/:cl: