### PR TITLE
Fixes Tadpole landing designator not expanding the user's view range

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -136,8 +136,9 @@
 	if(!see_hidden)
 		to_add += SSshuttle.hidden_shuttle_turf_images
 	user.client.images += to_add
-	user.client.view_size.unsupress() //The parent proc suppresses the view size, so we need to unsuppress it here to allow the view size to be set to view_range.
+	user.client.view_size.supress_changes = FALSE //The parent proc suppresses the viewport, so we need to unsuppress it here to allow the view size to be set to view_range.
 	user.client.view_size.set_view_radius_to(view_range)
+	user.client.view_size.supress_changes = TRUE //Resuppress the viewport to prevent the user from changing it while using the console.
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/remove_eye_control(mob/living/user)
 	. = ..()

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -136,6 +136,7 @@
 	if(!see_hidden)
 		to_add += SSshuttle.hidden_shuttle_turf_images
 	user.client.images += to_add
+	user.client.view_size.unsupress() //The parent proc suppresses the view size, so we need to unsuppress it here to allow the view size to be set to view_range.
 	user.client.view_size.set_view_radius_to(view_range)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/remove_eye_control(mob/living/user)


### PR DESCRIPTION

## About The Pull Request
Discovered that the Tadpole landing designator is supposed to give the user a "view_range" of "26x26" as per mini_dropship.dm; however in-game, your view range doesn't actually change.
The parent proc "give_eye_control" in camera_advanced.dm suppresses the user's viewport, preventing any changes.
I added a line of code to the child proc in navigation_computer.dm to un-suppress the viewport, allowing "set_view_radius" to set the intended "view_range".

Before
<img width="608" height="480" alt="Before view fix" src="https://github.com/user-attachments/assets/6954a2e3-186e-425a-b0ab-ea40f3fb5e39" />
After
<img width="1440" height="1312" alt="After view fix" src="https://github.com/user-attachments/assets/b57ac70b-49ef-4a05-8a75-e149baeac91d" />
## Why It's Good For The Game
Fixes a bug and makes it much easier to find a landing spot for the Tadpole, especially the larger models.
## Changelog
:cl:
fix: The Tadpole landing designator now expands your view range as intended.
/:cl: