### PR TITLE
Prevents zombies from being able to damage dead bodies + heart removal QOL

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -398,11 +398,8 @@ Contains most of the procs that are called when a mob is attacked by something
 	//Perception distorting effects of the psychic scream*
 
 /mob/living/carbon/human/attackby(obj/item/I, mob/living/user, params)
-	if(stat != DEAD || I.sharp < IS_SHARP_ITEM_ACCURATE || user.a_intent != INTENT_HARM)
+	if(stat != DEAD || I.sharp < IS_SHARP_ITEM_ACCURATE || (user.a_intent != INTENT_HARM && !iszombie(src)))
 		return ..()
-	if(iszombie(user))
-		to_chat(user, span_warning("You shouldn't rip out another zombie's heart."))
-		return
 	if(!get_organ_slot(ORGAN_SLOT_HEART))
 		to_chat(user, span_notice("[src] no longer has a heart."))
 		return
@@ -420,7 +417,7 @@ Contains most of the procs that are called when a mob is attacked by something
 	remove_organ_slot(ORGAN_SLOT_HEART)
 	var/obj/item/organ/heart/heart = new
 	heart.die()
-	user.put_in_hands(heart)
+	user.dropItemToGround(heart)
 	if(iszombie(src))
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(fade_out), heart), 9.5 SECONDS)
 		QDEL_IN(heart, 10 SECONDS)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -49,6 +49,14 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
+/obj/item/weapon/zombie_claw/preattack(atom/target, mob/user, params)
+	if(ishuman(target))
+		var/mob/living/carbon/human/human_target = target
+		if(human_target.stat == DEAD)
+			to_chat(user, span_warning("[human_target] is already dead!"))
+			return TRUE
+	return ..()
+
 /obj/item/weapon/zombie_claw/melee_attack_chain(mob/user, atom/target, params, rightclick)
 	. = ..()
 	if(!.)


### PR DESCRIPTION

## About The Pull Request
Adds a check at the pre-attack level to prevent zombie claws from being used to damage a dead human mob. The check to prevent a zombie from removing a heart is no longer needed since it can't use its zombie claws on dead bodies now.

Also lets zombie hearts be removed regardless of intent and will drop on the floor instead of trying to go in the empty hand.
## Why It's Good For The Game
Sentient zombies can keep attacking dead humans to cause massive amounts of damage+limb loss, which makes the body practically unrevivable. See pic related. This does not seem intended.
<img width="918" height="676" alt="oof" src="https://github.com/user-attachments/assets/996d697f-1568-4ee3-8ded-f580d0baa7b7" />

The QOL changes seek to simplify zombie heart removal by eliminating unneeded steps. There should be no need to cycle to harm intent just to remove a zombie's heart. There is no reason to give the player the removed heart because it serves no purpose to them.
## Changelog
:cl:
qol: Zombie hearts can be removed regardless of intent and will drop on the floor instead of going in your empty hand.
fix: Zombies can no longer damage dead bodies.
/:cl:
